### PR TITLE
Filter objects by target type #176 #315 #318

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Fixed missing `Markdown` input format in options schema. [#315](https://github.com/Microsoft/PSRule/issues/315)
+- Added `-TargetType` parameter to filter input objects by target type. [#176](https://github.com/Microsoft/PSRule/issues/176)
+  - This parameter applies to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget`.
+- **Breaking change**: Unprocessed object results are not returned from `Test-PSRuleTarget` by default. [#318](https://github.com/Microsoft/PSRule/issues/318)
+  - Previously unprocessed objects returned `$True`, now unprocessed objects return no result.
+  - Use `-Outcome All` to return `$True` for unprocessed objects the same as <= v0.10.0.
+
 ## v0.10.0
 
 What's changed since v0.9.0:

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionnotprocessedwarning)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)
+  - [Input.TargetType](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputtargettype)
   - [Logging.LimitDebug](docs/concepts/PSRule/en-US/about_PSRule_Options.md#logginglimitdebug)
   - [Logging.LimitVerbose](docs/concepts/PSRule/en-US/about_PSRule_Options.md#logginglimitverbose)
   - [Logging.RuleFail](docs/concepts/PSRule/en-US/about_PSRule_Options.md#loggingrulefail)

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -18,8 +18,8 @@ Evaluate objects against matching rules and assert any failures.
 ```text
 Assert-PSRule [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>] [-Style <OutputStyle>]
  [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-OutputPath <String>]
- [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-Culture <String[]>]
- -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
+ [-Culture <String[]>] -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputPath
@@ -27,8 +27,8 @@ Assert-PSRule [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineO
 ```text
 Assert-PSRule -InputPath <String[]> [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>]
  [-Style <OutputStyle>] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-OutputPath <String>]
- [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-Culture <String[]>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
+ [-Culture <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -64,7 +64,7 @@ $items | Assert-PSRule -Path .\docs\scenarios\fruit\
 ```
 
 ```text
- -> Fridge : System.Management.Automation.PSCustomObject
+-> Fridge : System.Management.Automation.PSCustomObject
 
     [FAIL] isFruit
 
@@ -237,6 +237,33 @@ If the property specified by `ObjectPath` is a collection or an array, then each
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetType
+
+Filters input objects by TargetType.
+
+If specified, only objects with the specified TargetType are processed.
+Objects that do not match TargetType are ignored.
+If multiple values are specified, only one TargetType must match. This parameter is not case-sensitive.
+
+By default, all objects are processed.
+
+This parameter if set, overrides the `Input.TargetType` option.
+
+To change the field TargetType is bound to set the `Binding.TargetType` option.
+For details see the about_PSRule_Options help topic.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -18,8 +18,8 @@ Evaluate objects against matching rules and output the results.
 ```text
 Invoke-PSRule [-Module <String[]>] [-Outcome <RuleOutcome>] [-As <ResultFormat>] [-Format <InputFormat>]
  [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Baseline <BaselineOption>] [[-Path] <String[]>]
- [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-Culture <String[]>]
- -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
+ [-Culture <String[]>] -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### InputPath
@@ -28,7 +28,7 @@ Invoke-PSRule [-Module <String[]>] [-Outcome <RuleOutcome>] [-As <ResultFormat>]
 Invoke-PSRule -InputPath <String[]> [-Module <String[]>] [-Outcome <RuleOutcome>] [-As <ResultFormat>]
  [-Format <InputFormat>] [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Baseline <BaselineOption>]
  [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>]
- [-Culture <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TargetType <String[]>] [-Culture <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 
 ### -Outcome
 
-Filter output to only show rules with a specific outcome.
+Filter output to only show rule results with a specific outcome.
 
 ```yaml
 Type: RuleOutcome
@@ -292,6 +292,33 @@ If the property specified by `ObjectPath` is a collection or an array, then each
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetType
+
+Filters input objects by TargetType.
+
+If specified, only objects with the specified TargetType are processed.
+Objects that do not match TargetType are ignored.
+If multiple values are specified, only one TargetType must match. This parameter is not case-sensitive.
+
+By default, all objects are processed.
+
+This parameter if set, overrides the `Input.TargetType` option.
+
+To change the field TargetType is bound to set the `Binding.TargetType` option.
+For details see the about_PSRule_Options help topic.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -18,7 +18,7 @@ New-PSRuleOption [[-Path] <String>] [[-Option] <PSRuleOption>] [-Configuration <
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-LoggingLimitDebug <String[]>]
+ [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
  [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
  [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
  [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
@@ -297,6 +297,22 @@ Sets the `Input.ObjectPath` option to use an object path to use instead of the p
 Type: String
 Parameter Sets: (All)
 Aliases: InputObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputTargetType
+
+Sets the `Input.TargetType` option to only process objects with the specified TargetType.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -17,10 +17,10 @@ Sets options that configure PSRule execution.
 Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-AllowClobber]
  [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-ObjectPath <String>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputPath <String>]
- [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -245,6 +245,22 @@ Sets the `Input.ObjectPath` option to use an object path to use instead of the p
 Type: String
 Parameter Sets: (All)
 Aliases: InputObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputTargetType
+
+Sets the `Input.TargetType` option to only process objects with the specified TargetType.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -16,17 +16,17 @@ Pass or fail objects against matching rules.
 ### Input (Default)
 
 ```text
-Test-PSRuleTarget [-Module <String[]>] [-Format <InputFormat>] [[-Path] <String[]>] [-Name <String[]>]
- [-Tag <Hashtable>] -InputObject <PSObject> [-Option <PSRuleOption>] [-ObjectPath <String>] [-Culture <String>]
- [<CommonParameters>]
+Test-PSRuleTarget [-Module <String[]>] [-Outcome <RuleOutcome>] [-Format <InputFormat>] [[-Path] <String[]>]
+ [-Name <String[]>] [-Tag <Hashtable>] -InputObject <PSObject> [-Option <PSRuleOption>] [-ObjectPath <String>]
+ [-TargetType <String[]>] [-Culture <String>] [<CommonParameters>]
 ```
 
 ### InputPath
 
 ```text
-Test-PSRuleTarget -InputPath <String[]> [-Module <String[]>] [-Format <InputFormat>] [[-Path] <String[]>]
- [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-Culture <String>]
- [<CommonParameters>]
+Test-PSRuleTarget -InputPath <String[]> [-Module <String[]>] [-Outcome <RuleOutcome>] [-Format <InputFormat>]
+ [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>]
+ [-TargetType <String[]>] [-Culture <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,8 +39,11 @@ PSRule uses the following logic to determine overall pass or fail for an object:
   - Any rules fail or error.
   - Any rules are inconclusive.
 - The object passes if:
-  - No rules were found that match preconditions, name and tag filters.
+  - No matching rules were found.
   - All rules pass.
+
+By default, objects that do match any rules are not returned in results.
+To return `$True` for these objects, use `-Outcome All`.
 
 ## EXAMPLES
 
@@ -87,6 +90,23 @@ Aliases: n
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Outcome
+
+Filter output to only show pipeline objects with a specific outcome.
+
+```yaml
+Type: RuleOutcome
+Parameter Sets: (All)
+Aliases:
+Accepted values: Pass, Fail, Error, None, Processed, All
+
+Required: False
+Position: Named
+Default value: Pass, Fail, Error
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -182,6 +202,33 @@ If the property specified by `ObjectPath` is a collection or an array, then each
 
 ```yaml
 Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TargetType
+
+Filters input objects by TargetType.
+
+If specified, only objects with the specified TargetType are processed.
+Objects that do not match TargetType are ignored.
+If multiple values are specified, only one TargetType must match. This parameter is not case-sensitive.
+
+By default, all objects are processed.
+
+This parameter if set, overrides the `Input.TargetType` option.
+
+To change the field TargetType is bound to set the `Binding.TargetType` option.
+For details see the about_PSRule_Options help topic.
+
+```yaml
+Type: String[]
 Parameter Sets: (All)
 Aliases:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -18,6 +18,7 @@ The following workspace options are available for use:
 - [Execution.NotProcessedWarning](#executionnotprocessedwarning)
 - [Input.Format](#inputformat)
 - [Input.ObjectPath](#inputobjectpath)
+- [Input.TargetType](#inputtargettype)
 - [Logging.LimitDebug](#logginglimitdebug)
 - [Logging.LimitVerbose](#logginglimitverbose)
 - [Logging.RuleFail](#loggingrulefail)
@@ -448,7 +449,7 @@ If the property specified by `ObjectPath` is a collection/ array, then each item
 
 If the property specified by `ObjectPath` does not exist, PSRule skips the object.
 
-When using `Invoke-PSRule` and `Test-PSRuleTarget` the `-ObjectPath` parameter will override any value set in configuration.
+When using `Invoke-PSRule`, `Test-PSRuleTarget` and `Assert-PSRule` the `-ObjectPath` parameter will override any value set in configuration.
 
 This option can be specified using:
 
@@ -471,6 +472,44 @@ Set-PSRuleOption -ObjectPath 'items';
 # YAML: Using the input/objectPath property
 input:
   objectPath: items
+```
+
+### Input.TargetType
+
+Filters input objects by TargetType.
+
+If specified, only objects with the specified TargetType are processed.
+Objects that do not match TargetType are ignored.
+If multiple values are specified, only one TargetType must match. This option is not case-sensitive.
+
+By default, all objects are processed.
+
+To change the field TargetType is bound to set the `Binding.TargetType` option.
+
+When using `Invoke-PSRule`, `Test-PSRuleTarget` and `Assert-PSRule` the `-TargetType` parameter will override any value set in configuration.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the InputTargetType parameter
+$option = New-PSRuleOption -InputTargetType 'virtualMachine';
+```
+
+```powershell
+# PowerShell: Using the Input.TargetType hashtable key
+$option = New-PSRuleOption -Option @{ 'Input.TargetType' = 'virtualMachine' };
+```
+
+```powershell
+# PowerShell: Using the InputTargetType parameter to set YAML
+Set-PSRuleOption -InputTargetType 'virtualMachine';
+```
+
+```yaml
+# YAML: Using the input/targetType property
+input:
+  targetType:
+  - virtualMachine
 ```
 
 ### Logging.LimitDebug
@@ -962,6 +1001,9 @@ execution:
 input:
   format: Yaml
   objectPath: items
+  targetType:
+  - Microsoft.Compute/virtualMachines
+  - Microsoft.Network/virtualNetworks
 
 # Configures outcome logging options
 logging:
@@ -1030,6 +1072,7 @@ execution:
 input:
   format: Detect
   objectPath: null
+  targetType: [ ]
 
 # Configures outcome logging options
 logging:

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -4,7 +4,7 @@
     "description": "A schema for PSRule YAML options files.",
     "oneOf": [
         {
-            "$ref": "#/definitions/options-v0.8.0"
+            "$ref": "#/definitions/options"
         }
     ],
     "definitions": {
@@ -75,7 +75,7 @@
             },
             "additionalProperties": false
         },
-        "input-v0.4.0": {
+        "input-option": {
             "type": "object",
             "title": "Input options",
             "description": "Options that affect how input types are processed.",
@@ -88,6 +88,7 @@
                         "None",
                         "Yaml",
                         "Json",
+                        "Markdown",
                         "Detect"
                     ],
                     "default": "Detect"
@@ -96,6 +97,15 @@
                     "type": "string",
                     "title": "Object path",
                     "description": "The object path to a property to use instead of the pipeline object."
+                },
+                "targetType": {
+                    "type": "array",
+                    "title": "Target type",
+                    "description": "Only process objects that match one of the included types.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
                 }
             },
             "additionalProperties": false
@@ -254,7 +264,7 @@
             },
             "additionalProperties": false
         },
-        "options-v0.8.0": {
+        "options": {
             "properties": {
                 "binding": {
                     "type": "object",
@@ -284,7 +294,7 @@
                     "type": "object",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/input-v0.4.0"
+                            "$ref": "#/definitions/input-option"
                         }
                     ]
                 },

--- a/src/PSRule/Configuration/BindingOption.cs
+++ b/src/PSRule/Configuration/BindingOption.cs
@@ -13,7 +13,7 @@ namespace PSRule.Configuration
     {
         private const bool DEFAULT_IGNORECASE = true;
 
-        public static readonly BindingOption Default = new BindingOption
+        internal static readonly BindingOption Default = new BindingOption
         {
             IgnoreCase = DEFAULT_IGNORECASE
         };

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -11,7 +11,7 @@ namespace PSRule.Configuration
         private const bool DEFAULT_INCONCLUSIVEWARNING = true;
         private const bool DEFAULT_NOTPROCESSEDWARNING = true;
 
-        public static readonly ExecutionOption Default = new ExecutionOption
+        internal static readonly ExecutionOption Default = new ExecutionOption
         {
             LanguageMode = DEFAULT_LANGUAGEMODE,
             InconclusiveWarning = DEFAULT_INCONCLUSIVEWARNING,

--- a/src/PSRule/Configuration/InputOption.cs
+++ b/src/PSRule/Configuration/InputOption.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.ComponentModel;
 
 namespace PSRule.Configuration
@@ -8,27 +9,56 @@ namespace PSRule.Configuration
     /// <summary>
     /// Options that affect how input types are processed.
     /// </summary>
-    public sealed class InputOption
+    public sealed class InputOption : IEquatable<InputOption>
     {
         private const InputFormat DEFAULT_FORMAT = PSRule.Configuration.InputFormat.Detect;
         private const string DEFAULT_OBJECTPATH = null;
+        private const string[] DEFAULT_TARGETTYPE = null;
 
-        public static readonly InputOption Default = new InputOption
+        internal static readonly InputOption Default = new InputOption
         {
             Format = DEFAULT_FORMAT,
-            ObjectPath = DEFAULT_OBJECTPATH
+            ObjectPath = DEFAULT_OBJECTPATH,
+            TargetType = DEFAULT_TARGETTYPE,
         };
 
         public InputOption()
         {
             Format = null;
             ObjectPath = null;
+            TargetType = null;
         }
 
         public InputOption(InputOption option)
         {
             Format = option.Format;
             ObjectPath = option.ObjectPath;
+            TargetType = option.TargetType;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is InputOption option && Equals(option);
+        }
+
+        public bool Equals(InputOption other)
+        {
+            return other != null &&
+                Format == other.Format &&
+                ObjectPath == other.ObjectPath &&
+                TargetType == other.TargetType;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine
+            {
+                int hash = 17;
+                hash = hash * 23 + (Format.HasValue ? Format.Value.GetHashCode() : 0);
+                hash = hash * 23 + (ObjectPath != null ? ObjectPath.GetHashCode() : 0);
+                hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
+                return hash;
+            }
         }
 
         /// <summary>
@@ -42,5 +72,11 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public string ObjectPath { get; set; }
+
+        /// <summary>
+        /// Only process objects that match one of the included types.
+        /// </summary>
+        [DefaultValue(null)]
+        public string[] TargetType { get; set; }
     }
 }

--- a/src/PSRule/Configuration/LoggingOption.cs
+++ b/src/PSRule/Configuration/LoggingOption.cs
@@ -13,7 +13,7 @@ namespace PSRule.Configuration
         private const OutcomeLogStream DEFAULT_RULEFAIL = OutcomeLogStream.None;
         private const OutcomeLogStream DEFAULT_RULEPASS = OutcomeLogStream.None;
 
-        public static readonly LoggingOption Default = new LoggingOption
+        internal static readonly LoggingOption Default = new LoggingOption
         {
             RuleFail = DEFAULT_RULEFAIL,
             RulePass = DEFAULT_RULEPASS,

--- a/src/PSRule/Configuration/OutputOption.cs
+++ b/src/PSRule/Configuration/OutputOption.cs
@@ -16,7 +16,7 @@ namespace PSRule.Configuration
         private const OutputFormat DEFAULT_FORMAT = OutputFormat.None;
         private const OutputStyle DEFAULT_STYLE = OutputStyle.Client;
 
-        public static readonly OutputOption Default = new OutputOption
+        internal static readonly OutputOption Default = new OutputOption
         {
             As = DEFAULT_AS,
             Encoding = DEFAULT_ENCODING,

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -29,7 +29,7 @@ namespace PSRule.Configuration
 
         private string SourcePath;
 
-        private static readonly PSRuleOption Default = new PSRuleOption
+        internal static readonly PSRuleOption Default = new PSRuleOption
         {
             Binding = BindingOption.Default,
             Execution = ExecutionOption.Default,
@@ -262,27 +262,17 @@ namespace PSRule.Configuration
             {
                 option.Input.ObjectPath = (string)value;
             }
+            if (index.TryPopValue("input.targettype", out value))
+            {
+                option.Input.TargetType = AsStringArray(value);
+            }
             if (index.TryGetValue("logging.limitdebug", out value))
             {
-                if (value.GetType().IsArray)
-                {
-                    option.Logging.LimitDebug = ((object[])value).OfType<string>().ToArray();
-                }
-                else
-                {
-                    option.Logging.LimitDebug = new string[] { value.ToString() };
-                }
+                option.Logging.LimitDebug = AsStringArray(value);
             }
             if (index.TryGetValue("logging.limitverbose", out value))
             {
-                if (value.GetType().IsArray)
-                {
-                    option.Logging.LimitVerbose = ((object[])value).OfType<string>().ToArray();
-                }
-                else
-                {
-                    option.Logging.LimitVerbose = new string[] { value.ToString() };
-                }
+                option.Logging.LimitVerbose = AsStringArray(value);
             }
             if (index.TryGetValue("logging.rulefail", out value))
             {
@@ -427,6 +417,11 @@ namespace PSRule.Configuration
                 .WithNamingConvention(new CamelCaseNamingConvention())
                 .Build();
             return s.Serialize(this);
+        }
+
+        private static string[] AsStringArray(object value)
+        {
+            return value.GetType().IsArray ? ((object[])value).OfType<string>().ToArray() : new string[] { value.ToString() };
         }
     }
 }

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -156,6 +156,9 @@ namespace PSRule.Host
             state.Commands.Add(BuiltInCmdlets);
             state.Commands.Add(BuiltInAliases);
 
+            // Set thread options
+            state.ThreadOptions = PSThreadOptions.UseCurrentThread;
+
             // Set execution policy
             SetExecutionPolicy(state: state, executionPolicy: Microsoft.PowerShell.ExecutionPolicy.RemoteSigned);
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -78,6 +78,9 @@ function Invoke-PSRule {
         [String]$ObjectPath,
 
         [Parameter(Mandatory = $False)]
+        [String[]]$TargetType,
+
+        [Parameter(Mandatory = $False)]
         [String[]]$Culture,
 
         [Parameter(Mandatory = $True, ValueFromPipeline = $True, ParameterSetName = 'Input')]
@@ -130,6 +133,9 @@ function Invoke-PSRule {
         }
         if ($PSBoundParameters.ContainsKey('ObjectPath')) {
             $Option.Input.ObjectPath = $ObjectPath;
+        }
+        if ($PSBoundParameters.ContainsKey('TargetType')) {
+            $Option.Input.TargetType = $TargetType;
         }
         if ($PSBoundParameters.ContainsKey('As')) {
             $Option.Output.As = $As;
@@ -207,6 +213,9 @@ function Test-PSRuleTarget {
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
+        [PSRule.Rules.RuleOutcome]$Outcome = [PSRule.Rules.RuleOutcome]::Processed,
+
+        [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format,
 
@@ -232,6 +241,9 @@ function Test-PSRuleTarget {
 
         [Parameter(Mandatory = $False)]
         [String]$ObjectPath,
+
+        [Parameter(Mandatory = $False)]
+        [String[]]$TargetType,
 
         [Parameter(Mandatory = $False)]
         [String]$Culture
@@ -283,6 +295,9 @@ function Test-PSRuleTarget {
         if ($PSBoundParameters.ContainsKey('ObjectPath')) {
             $Option.Input.ObjectPath = $ObjectPath;
         }
+        if ($PSBoundParameters.ContainsKey('TargetType')) {
+            $Option.Input.TargetType = $TargetType;
+        }
         if ($PSBoundParameters.ContainsKey('Culture')) {
             $Option.Output.Culture = $Culture;
         }
@@ -293,6 +308,7 @@ function Test-PSRuleTarget {
         $builder = [PSRule.Pipeline.PipelineBuilder]::Test($sourceFiles, $Option);
         $builder.Name($Name);
         $builder.Tag($Tag);
+        $builder.Limit($Outcome);
 
         if ($PSBoundParameters.ContainsKey('InputPath')) {
             $inputPaths = GetFilePath -Path $InputPath -Verbose:$VerbosePreference;
@@ -385,6 +401,9 @@ function Assert-PSRule {
         [String]$ObjectPath,
 
         [Parameter(Mandatory = $False)]
+        [String[]]$TargetType,
+
+        [Parameter(Mandatory = $False)]
         [String[]]$Culture,
 
         [Parameter(Mandatory = $True, ValueFromPipeline = $True, ParameterSetName = 'Input')]
@@ -436,6 +455,9 @@ function Assert-PSRule {
         }
         if ($PSBoundParameters.ContainsKey('ObjectPath')) {
             $Option.Input.ObjectPath = $ObjectPath;
+        }
+        if ($PSBoundParameters.ContainsKey('TargetType')) {
+            $Option.Input.TargetType = $TargetType;
         }
         if ($PSBoundParameters.ContainsKey('Style')) {
             $Option.Output.Style = $Style;
@@ -893,6 +915,10 @@ function New-PSRuleOption {
         [Alias('InputObjectPath')]
         [String]$ObjectPath = '',
 
+        # Sets the Input.TargetType option
+        [Parameter(Mandatory = $False)]
+        [String[]]$InputTargetType,
+
         # Sets the Logging.LimitDebug option
         [Parameter(Mandatory = $False)]
         [String[]]$LoggingLimitDebug = $Null,
@@ -1058,6 +1084,10 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [Alias('InputObjectPath')]
         [String]$ObjectPath = '',
+
+        # Sets the Input.TargetType option
+        [Parameter(Mandatory = $False)]
+        [String[]]$InputTargetType,
 
         # Sets the Logging.LimitDebug option
         [Parameter(Mandatory = $False)]
@@ -1620,6 +1650,10 @@ function SetOptions {
         [Alias('InputObjectPath')]
         [String]$ObjectPath = '',
 
+        # Sets the Input.TargetType option
+        [Parameter(Mandatory = $False)]
+        [String[]]$InputTargetType,
+
         # Sets the Logging.LimitDebug option
         [Parameter(Mandatory = $False)]
         [String[]]$LoggingLimitDebug = $Null,
@@ -1697,6 +1731,11 @@ function SetOptions {
         # Sets option Input.ObjectPath
         if ($PSBoundParameters.ContainsKey('ObjectPath')) {
             $Option.Input.ObjectPath = $ObjectPath;
+        }
+
+         # Sets option Input.TargetType
+         if ($PSBoundParameters.ContainsKey('InputTargetType')) {
+            $Option.Input.TargetType = $InputTargetType;
         }
 
         # Sets option Logging.LimitDebug

--- a/src/PSRule/Pipeline/BaselineContext.cs
+++ b/src/PSRule/Pipeline/BaselineContext.cs
@@ -83,7 +83,7 @@ namespace PSRule.Pipeline
             }
         }
 
-        private sealed class BindingOption : IBindingOption
+        private sealed class BindingOption : IBindingOption, IEquatable<BindingOption>
         {
             public BindingOption(string[] targetName, string[] targetType, bool ignoreCase)
             {
@@ -97,6 +97,31 @@ namespace PSRule.Pipeline
             public string[] TargetName { get; }
 
             public string[] TargetType { get; }
+
+            public override bool Equals(object obj)
+            {
+                return obj is BindingOption option && Equals(option);
+            }
+
+            public bool Equals(BindingOption other)
+            {
+                return other != null &&
+                    IgnoreCase == other.IgnoreCase &&
+                    TargetName == other.TargetName &&
+                    TargetType == other.TargetType;
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked // Overflow is fine
+                {
+                    int hash = 17;
+                    hash = hash * 23 + (IgnoreCase ? IgnoreCase.GetHashCode() : 0);
+                    hash = hash * 23 + (TargetName != null ? TargetName.GetHashCode() : 0);
+                    hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
+                    return hash;
+                }
+            }
         }
 
         public void UseScope(string moduleName)

--- a/src/PSRule/Pipeline/InvokeResult.cs
+++ b/src/PSRule/Pipeline/InvokeResult.cs
@@ -47,6 +47,11 @@ namespace PSRule.Pipeline
             get { return _Fail; }
         }
 
+        internal RuleOutcome Outcome
+        {
+            get { return _Outcome; }
+        }
+
         /// <summary>
         /// Get the individual records for the target object.
         /// </summary>
@@ -105,7 +110,6 @@ namespace PSRule.Pipeline
             {
                 return RuleOutcome.Pass;
             }
-
             return outcome;
         }
     }

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -59,9 +59,6 @@ namespace PSRule.Pipeline
             Option.Execution.InconclusiveWarning = option.Execution.InconclusiveWarning ?? ExecutionOption.Default.InconclusiveWarning;
             Option.Execution.NotProcessedWarning = option.Execution.NotProcessedWarning ?? ExecutionOption.Default.NotProcessedWarning;
 
-            Option.Input.Format = option.Input.Format ?? InputOption.Default.Format;
-            Option.Input.ObjectPath = option.Input.ObjectPath ?? InputOption.Default.ObjectPath;
-
             Option.Logging.RuleFail = option.Logging.RuleFail ?? LoggingOption.Default.RuleFail;
             Option.Logging.RulePass = option.Logging.RulePass ?? LoggingOption.Default.RulePass;
             Option.Logging.LimitVerbose = option.Logging.LimitVerbose;
@@ -256,6 +253,9 @@ namespace PSRule.Pipeline
 
                 try
                 {
+                    if (Context.ShouldFilter())
+                        continue;
+
                     // Check if dependency failed
                     if (ruleBlockTarget.Skipped)
                     {

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -142,6 +142,8 @@ namespace PSRule.Pipeline
 
             Option.Binding = new BindingOption(option.Binding);
             Option.Execution = new ExecutionOption(option.Execution);
+            Option.Input = new InputOption(option.Input);
+            Option.Input.Format = Option.Input.Format ?? InputOption.Default.Format;
             Option.Output = new OutputOption(option.Output);
             return this;
         }
@@ -180,7 +182,7 @@ namespace PSRule.Pipeline
                 logger: Logger,
                 option: Option,
                 hostContext: HostContext,
-                binder: new TargetBinder(bindTargetName: bindTargetName, bindTargetType: bindTargetType),
+                binder: new TargetBinder(bindTargetName, bindTargetType, Option.Input.TargetType),
                 baseline: GetBaselineContext(),
                 unresolved: unresolved
             );

--- a/src/PSRule/Pipeline/TargetBinder.cs
+++ b/src/PSRule/Pipeline/TargetBinder.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
+using System;
+using System.Collections.Generic;
 using System.Management.Automation;
 
 namespace PSRule.Pipeline
@@ -10,26 +12,40 @@ namespace PSRule.Pipeline
     {
         private readonly BindTargetMethod _BindTargetName;
         private readonly BindTargetMethod _BindTargetType;
+        private readonly HashSet<string> _TypeFilter;
 
-        public TargetBinder(BindTargetMethod bindTargetName, BindTargetMethod bindTargetType)
+        internal TargetBinder(BindTargetMethod bindTargetName, BindTargetMethod bindTargetType, string[] typeFilter)
         {
             _BindTargetName = bindTargetName;
             _BindTargetType = bindTargetType;
+            if (typeFilter != null && typeFilter.Length > 0)
+                _TypeFilter = new HashSet<string>(typeFilter, StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// The bound TargetName of the target object.
+        /// </summary>
         public string TargetName { get; private set; }
 
+        /// <summary>
+        /// The bound TargetType of the target object.
+        /// </summary>
         public string TargetType { get; private set; }
 
+        /// <summary>
+        /// Determines if the target object should be filtered.
+        /// </summary>
+        public bool ShouldFilter { get; private set; }
+
+        /// <summary>
+        /// Bind target object based on the supplied baseline.
+        /// </summary>
         public void Bind(BaselineContext baseline, PSObject targetObject)
         {
             var binding = baseline.GetTargetBinding();
-
-            // Bind TargetName
             TargetName = _BindTargetName(binding.TargetName, !binding.IgnoreCase, targetObject);
-
-            // Bind TargetType
             TargetType = _BindTargetType(binding.TargetType, !binding.IgnoreCase, targetObject);
+            ShouldFilter = !(_TypeFilter == null || _TypeFilter.Contains(TargetType));
         }
     }
 }

--- a/src/PSRule/Pipeline/TestPipeline.cs
+++ b/src/PSRule/Pipeline/TestPipeline.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Rules;
+using System.Runtime.InteropServices.ComTypes;
 
 namespace PSRule.Pipeline
 {
@@ -12,21 +13,33 @@ namespace PSRule.Pipeline
 
         private sealed class BooleanWriter : PipelineWriter
         {
-            internal BooleanWriter(WriteOutput output)
-                : base(output) { }
+            private readonly RuleOutcome _Outcome;
+
+            internal BooleanWriter(WriteOutput output, RuleOutcome outcome)
+                : base(output)
+            {
+                _Outcome = outcome;
+            }
 
             public override void Write(object o, bool enumerate)
             {
-                if (!(o is InvokeResult result))
+                if (!(o is InvokeResult result) || !ShouldOutput(result.Outcome))
                     return;
 
                 base.Write(result.IsSuccess(), false);
+            }
+
+            private bool ShouldOutput(RuleOutcome outcome)
+            {
+                return _Outcome == RuleOutcome.All ||
+                    (_Outcome == RuleOutcome.None && outcome == RuleOutcome.None) ||
+                    (_Outcome & outcome) > 0;
             }
         }
 
         protected override PipelineWriter PrepareWriter()
         {
-            return new BooleanWriter(GetOutput());
+            return new BooleanWriter(GetOutput(), Outcome);
         }
     }
 }

--- a/tests/PSRule.Tests/FromFileBaseline.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileBaseline.Rule.ps1
@@ -7,9 +7,8 @@
 
 # Synopsis: Test for baseline
 Rule 'WithBaseline' {
-    # $Rule.TargetName -eq 'TestObject1'
-    # $Rule.TargetType -eq 'TestObjectType'
-    $True
+    $Rule.TargetName -eq 'TestObject1'
+    $Rule.TargetType -eq 'TestObjectType'
 }
 
 # Synopsis: Test for baseline

--- a/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
@@ -73,6 +73,8 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result.Length | Should -Be 1;
             $result[0].RuleName | Should -Be 'WithBaseline';
             $result[0].Outcome | Should -Be 'Pass';
+            $result[0].TargetName | Should -Be 'TestObject1';
+            $result[0].TargetType | Should -Be 'TestObjectType';
         }
 
         It 'With -Module' {
@@ -95,8 +97,12 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result.Length | Should -Be 2;
             $result[0].RuleName | Should -Be 'M4.Rule1';
             $result[0].Outcome | Should -Be 'Fail';
+            $result[0].TargetName | Should -Be 'TestObject1';
+            $result[0].TargetType | Should -Be 'TestObjectType';
             $result[1].RuleName | Should -Be 'M4.Rule2';
             $result[1].Outcome | Should -Be 'Pass';
+            $result[1].TargetName | Should -Be 'TestObject1';
+            $result[1].TargetType | Should -Be 'TestObjectType';
 
             # Module + Workspace + Parameter
             $option = @{

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -360,6 +360,43 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Input.TargetType' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Input.TargetType | Should -Be $Null;
+        }
+
+        It 'from Hashtable' {
+            # With single item
+            $option = New-PSRuleOption -Option @{ 'Input.TargetType' = 'virtualMachine' };
+            $option.Input.TargetType | Should -BeIn 'virtualMachine';
+
+            # With array
+            $option = New-PSRuleOption -Option @{ 'Input.TargetType' = 'virtualMachine', 'virtualNetwork' };
+            $option.Input.TargetType.Length | Should -Be 2;
+            $option.Input.TargetType | Should -BeIn 'virtualMachine', 'virtualNetwork';
+        }
+
+        It 'from YAML' {
+            # With single item
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Input.TargetType | Should -BeIn 'virtualMachine';
+
+            # With array
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests2.yml');
+            $option.Input.TargetType | Should -BeIn 'virtualMachine', 'virtualNetwork';
+
+            # With flat single item
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests3.yml');
+            $option.Input.TargetType | Should -BeIn 'virtualMachine';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InputTargetType 'virtualMachine', 'virtualNetwork' -Path $emptyOptionsFilePath;
+            $option.Input.TargetType | Should -BeIn 'virtualMachine', 'virtualNetwork';
+        }
+    }
+
     Context 'Read Logging.LimitDebug' {
         It 'from default' {
             $option = New-PSRuleOption;

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -33,6 +33,8 @@ execution:
 input:
   format: Yaml
   objectPath: items
+  targetType:
+  - virtualMachine
 
 # Configure logging options
 logging:

--- a/tests/PSRule.Tests/PSRule.Tests2.yml
+++ b/tests/PSRule.Tests/PSRule.Tests2.yml
@@ -1,14 +1,5 @@
 # These are options for unit tests
 
-# Configure baseline
-rule:
-  include:
-  - rule1
-  - rule2
-  exclude:
-  - rule3
-  - rule4
-
 # Configure binding
 binding:
   targetName:
@@ -17,3 +8,18 @@ binding:
   targetType:
   - ResourceType
   - kind
+
+# Configure input
+input:
+  targetType:
+  - virtualMachine
+  - virtualNetwork
+
+# Configure baseline
+rule:
+  include:
+  - rule1
+  - rule2
+  exclude:
+  - rule3
+  - rule4

--- a/tests/PSRule.Tests/PSRule.Tests3.yml
+++ b/tests/PSRule.Tests/PSRule.Tests3.yml
@@ -1,11 +1,15 @@
 # These are options for unit tests
 
-# Configure baseline
-rule:
-  include: [ 'rule1' ]
-  exclude: [ 'rule3' ]
-
 # Configure binding
 binding:
   targetName: [ 'ResourceName' ]
   targetType: [ 'ResourceType' ]
+
+# Configure input
+input:
+  targetType: [ 'virtualMachine' ]
+
+# Configure baseline
+rule:
+  include: [ 'rule1' ]
+  exclude: [ 'rule3' ]

--- a/tests/PSRule.Tests/TargetNameBindingTests.cs
+++ b/tests/PSRule.Tests/TargetNameBindingTests.cs
@@ -28,7 +28,7 @@ namespace PSRule
             var pso1 = PSObject.AsPSObject(testObject1);
             var pso2 = PSObject.AsPSObject(testObject2);
 
-            PipelineContext.CurrentThread = PipelineContext.New(logger: null, option: new PSRuleOption(), hostContext: null, binder: new TargetBinder(bindTargetName: null, bindTargetType: null), baseline: null, unresolved: null);
+            PipelineContext.CurrentThread = PipelineContext.New(logger: null, option: new PSRuleOption(), hostContext: null, binder: new TargetBinder(null, null, null), baseline: null, unresolved: null);
             var actual1 = PipelineHookActions.BindTargetName(null, false, pso1);
             var actual2 = PipelineHookActions.BindTargetName(null, false, pso2);
 


### PR DESCRIPTION
## PR Summary

- Fixed missing `Markdown` input format in options schema. #315
- Added `-TargetType` parameter to filter input objects by target type. #176
  - This parameter applies to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget`.
- **Breaking change**: Unprocessed object results are not returned from `Test-PSRuleTarget` by default. #318
  - Previously unprocessed objects returned `$True`, now unprocessed objects return no result.
  - Use `-Outcome All` to return `$True` for unprocessed objects the same as <= v0.10.0.

Fixes #315 
Fixes #176 
Fixes #318 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
