### PR TITLE
Pre-release v0.11.0-B1910014

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.11.0-B1910014 (pre-release)
+
 - Fixed missing `Markdown` input format in options schema. [#315](https://github.com/Microsoft/PSRule/issues/315)
 - Added `-TargetType` parameter to filter input objects by target type. [#176](https://github.com/Microsoft/PSRule/issues/176)
   - This parameter applies to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget`.


### PR DESCRIPTION
## PR Summary

- Fixed missing `Markdown` input format in options schema. #315
- Added `-TargetType` parameter to filter input objects by target type. #176
  - This parameter applies to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget`.
- **Breaking change**: Unprocessed object results are not returned from `Test-PSRuleTarget` by default. #318
  - Previously unprocessed objects returned `$True`, now unprocessed objects return no result.
  - Use `-Outcome All` to return `$True` for unprocessed objects the same as <= v0.10.0.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
