### PR TITLE
Fixed null reference on bound property #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed null reference exception when bound property is null. [#323](https://github.com/Microsoft/PSRule/issues/323)
+
 ## v0.11.0-B1910014 (pre-release)
 
 - Fixed missing `Markdown` input format in options schema. [#315](https://github.com/Microsoft/PSRule/issues/315)

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -35,7 +35,7 @@ namespace PSRule
         public static string ValueAsString(this PSObject o, string propertyName, bool caseSensitive)
         {
             var p = o.Properties[propertyName];
-            if (p == null)
+            if (p == null || p.Value == null)
                 return null;
 
             if (caseSensitive && !StringComparer.Ordinal.Equals(p.Name, propertyName))


### PR DESCRIPTION
## PR Summary

- Fixed null reference exception when bound property is null. #323

Fixes #323 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
