### PR TITLE
Added -All option to Exists keyword #331

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed NUnit serialization issue for unprocessed rules. [#332](https://github.com/Microsoft/PSRule/issues/332)
+- Added `-All` option to `Exists` keyword. [#331](https://github.com/Microsoft/PSRule/issues/331)
 
 ## v0.11.0
 

--- a/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
+++ b/docs/keywords/PSRule/en-US/about_PSRule_Keywords.md
@@ -32,9 +32,11 @@ A subset of built-in keywords can be used within script preconditions:
 
 ### Rule
 
-A `Rule` definition describes an individual business rule that will be executed against each input object. Input objects can be passed on the PowerShell pipeline or supplied from file.
+A `Rule` definition describes an individual business rule that will be executed against each input object.
+Input objects can be passed on the PowerShell pipeline or supplied from file.
 
-To define a Rule use the `Rule` keyword followed by a name and a pair of squiggly brackets `{`. Within the `{ }` one or more conditions can be used.
+To define a Rule use the `Rule` keyword followed by a name and a pair of squiggly brackets `{`.
+Within the `{ }` one or more conditions can be used.
 
 Conditions determine if the input object either _Pass_ or _Fail_ the rule.
 
@@ -54,7 +56,10 @@ Rule [-Name] <string> [-Tag <hashtable>] [-Type <string[]>] [-If <scriptBlock>] 
 - `Configure` - A set of default configuration values. These values are only used when the baseline configuration does not contain the key.
 - `Body` - A script block that specifies one or more conditions that are required for the rule to _Pass_.
 
-A condition is any valid PowerShell that return either `$True` or `$False`. Optionally, PSRule keywords can be used to help build out conditions quickly. When a rule contains more then one condition, all must return `$True` for the rule to _Pass_. If any one condition returns `$False` the rule has failed.
+A condition is any valid PowerShell that return either `$True` or `$False`.
+Optionally, PSRule keywords can be used to help build out conditions quickly.
+When a rule contains more then one condition, all must return `$True` for the rule to _Pass_.
+If any one condition returns `$False` the rule has failed.
 
 The following restrictions apply:
 
@@ -129,9 +134,13 @@ Rule 'nameMustExist' {
 
 Output:
 
-If **any** the specified field exists then Exists will return `$True`, otherwise `$False`.
+If **any** the specified fields exists then `Exists` will return `$True`, otherwise `$False`.
 
-If `-Not` is used, then if **any** of the specified fields exist then Exists will return `$False` otherwise `$True`.
+If `-Not` is used, then if **any** of the fields exist then `Exists` will return `$False` otherwise `$True`.
+
+If `-All` is used, then then **all** of the fields must exist, or not with the `-Not` switch.
+If all fields exist then `Exists` will return `$True`, otherwise `$False`.
+If `-Not` is used with `-All`, if **all** of the fields exist `Exists` will return `$False` otherwise `$True`.
 
 ### Match
 

--- a/src/PSRule.Benchmark/PSRule.Benchmark.csproj
+++ b/src/PSRule.Benchmark/PSRule.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.2</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.PowerShell.5.1.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.2'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.3" />
   </ItemGroup>
 

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -70,7 +70,7 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The field &apos;{0}&apos; exists..
+        ///   Looks up a localized string similar to The field(s) existed: {0}.
         /// </summary>
         internal static string ExistsNot {
             get {

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -122,7 +122,7 @@
     <comment>Included when none of the fields exist.</comment>
   </data>
   <data name="ExistsNot" xml:space="preserve">
-    <value>The field '{0}' exists.</value>
+    <value>The field(s) existed: {0}</value>
     <comment>Included when any of the fields exist and the -Not switch is used.</comment>
   </data>
   <data name="HasExpectedFieldValue" xml:space="preserve">

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -204,6 +204,9 @@ Rule 'ExistsTest' -Tag @{ keyword = 'Exists' } {
     Exists -Not 'NotName'
     Exists 'Value.Value1'
     Exists 'NotName','Value'
+    Exists 'Value', 'Value2' -All
+    Exists -Not 'NotName1','NotName2'
+    Exists -Not 'Value','NotName2' -All
     @{ Pipeline = 'Value' } | Exists 'Pipeline'
 }
 
@@ -215,6 +218,9 @@ Rule 'ExistsTestNegative' -Tag @{ keyword = 'Exists' } {
         Exists 'name' -CaseSensitive
         Exists 'NotValue.Value1'
         Exists 'Properties.value'
+        Exists -Not 'NotName', 'Value'
+        Exists 'NotName', 'Value2' -All
+        Exists -Not 'Value','Value2' -All
     }
 }
 

--- a/tests/PSRule.Tests/PSRule.Exists.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Exists.Tests.ps1
@@ -30,6 +30,7 @@ Describe 'PSRule -- Exists keyword' -Tag 'Exists' {
                 Value = @{
                     Value1 = 1
                 }
+                Value2 = '2'
                 Properties = $Null
             }
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Tag @{ keyword = 'Exists' };
@@ -44,7 +45,10 @@ Describe 'PSRule -- Exists keyword' -Tag 'Exists' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'ExistsTestNegative' };
             $filteredResult | Should -Not -BeNullOrEmpty;
             $filteredResult.IsSuccess() | Should -Be $False;
-            $filteredResult.Reason | Should -BeLike "None of the field(s) existed: *";
+            $filteredResult.Reason[0..4] | Should -BeLike "None of the field(s) existed: *";
+            $filteredResult.Reason[5] | Should -BeLike "The field(s) existed: *";
+            $filteredResult.Reason[6] | Should -BeLike "None of the field(s) existed: *";
+            $filteredResult.Reason[7] | Should -BeLike "The field(s) existed: *";
         }
 
         It 'If pre-condition' {

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>PSRule</RootNamespace>


### PR DESCRIPTION
## PR Summary

- Added `-All` option to `Exists` keyword. #331 

Fixes #331 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
