### PR TITLE
Add custom field binding #321 #339 #340 #341

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,8 +19,8 @@
             "/docs/scenarios/*/ps-rule.yaml"
         ],
         "./schemas/PSRule-language.schema.json": [
-            "/tests/PSRule.Tests/**.rule.yaml",
-            "/docs/scenarios/*/*.rule.yaml"
+            "/tests/PSRule.Tests/**.Rule.yaml",
+            "/docs/scenarios/*/*.Rule.yaml"
         ]
     },
     "[yaml]": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- Fixed TargetType fall back to type name. [#339](https://github.com/Microsoft/PSRule/issues/339)
+- Added custom field binding. [#321](https://github.com/Microsoft/PSRule/issues/321)
+  - Added new option `Binding.Field` available in baselines to configure binding.
+- Added parameter alias `-f` for `-InputPath`. [#340](https://github.com/Microsoft/PSRule/issues/340)
+  - `-f` was added to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget` cmdlets.
+- **Important change**: Added `$PSRule` generic context variable. [#341](https://github.com/Microsoft/PSRule/issues/341)
+  - Deprecated `TargetName`, `TargetType` and `TargetObject` properties on `$Rule`.
+  - Use `TargetName`, `TargetType` and `TargetObject` on `$PSRule` instead.
+  - Properties `TargetName`, `TargetType` and `TargetObject` on `$Rule` will be removed in the future.
+  - Going forward `$Rule` will only contain properties that relate to the current rule context.
+
 ## v0.12.0-B1911013 (pre-release)
 
 - Fixed NUnit serialization issue for unprocessed rules. [#332](https://github.com/Microsoft/PSRule/issues/332)

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Creating documentation](docs/concepts/PSRule/en-US/about_PSRule_Docs.md#creating-documentation)
 - [Options](docs/concepts/PSRule/en-US/about_PSRule_Options.md)
   - [Binding.IgnoreCase](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingignorecase)
+  - [Binding.Field](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingfield)
   - [Binding.TargetName](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingtargetname)
   - [Binding.TargetType](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingtargettype)
   - [Configuration](docs/concepts/PSRule/en-US/about_PSRule_Options.md#configuration)
@@ -263,6 +264,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [$Assert](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#assert)
   - [$Configuration](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#configuration)
   - [$LocalizedData](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#localizeddata)
+  - [$PSRule](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#psrule)
   - [$Rule](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#rule)
   - [$TargetObject](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#targetobject)
 

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -91,7 +91,7 @@ Instead of processing objects from the pipeline, import objects file the specifi
 ```yaml
 Type: String[]
 Parameter Sets: InputPath
-Aliases:
+Aliases: f
 
 Required: True
 Position: Named

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -355,7 +355,7 @@ Instead of processing objects from the pipeline, import objects file the specifi
 ```yaml
 Type: String[]
 Parameter Sets: InputPath
-Aliases:
+Aliases: f
 
 Required: True
 Position: Named

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -16,12 +16,12 @@ Create options to configure PSRule execution.
 ```text
 New-PSRuleOption [[-Path] <String>] [[-Option] <PSRuleOption>] [-Configuration <ConfigurationOption>]
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
- [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>]
- [-TargetType <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
+ [-TargetName <String[]>] [-TargetType <String[]>] [-InconclusiveWarning <Boolean>]
+ [-NotProcessedWarning <Boolean>] [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -192,8 +192,9 @@ Accept wildcard characters: False
 
 ### -BindingIgnoreCase
 
-Sets the option `Binding.IgnoreCase`. The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not.
-See about_PSRule_Baseline for more information.
+Sets the option `Binding.IgnoreCase`.
+The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -207,10 +208,29 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -BindingField
+
+Sets the option `Binding.Field`.
+The option specified one or more custom field bindings.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -TargetName
 
-Sets the option `Binding.TargetName`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to.
-See about_PSRule_Baseline for more information.
+Sets the option `Binding.TargetName`.
+This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
@@ -226,8 +246,9 @@ Accept wildcard characters: False
 
 ### -TargetType
 
-Sets the option `Binding.TargetType`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to.
-See about_PSRule_Baseline for more information.
+Sets the option `Binding.TargetType`.
+This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
@@ -243,7 +264,9 @@ Accept wildcard characters: False
 
 ### -InconclusiveWarning
 
-Sets the option `Execution.InconclusiveWarning`. The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive. See about_PSRule_Options for more information.
+Sets the option `Execution.InconclusiveWarning`.
+The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -259,7 +282,9 @@ Accept wildcard characters: False
 
 ### -NotProcessedWarning
 
-Sets the option `Execution.NotProcessedWarning`. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See about_PSRule_Options for more information.
+Sets the option `Execution.NotProcessedWarning`.
+The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -15,7 +15,7 @@ Sets options that configure PSRule execution.
 
 ```text
 Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-AllowClobber]
- [-BindingIgnoreCase <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
+ [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
  [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
  [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
@@ -142,7 +142,9 @@ Accept wildcard characters: False
 
 ### -BindingIgnoreCase
 
-Sets the option `Binding.IgnoreCase`. The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not. See about_PSRule_Options for more information.
+Sets the option `Binding.IgnoreCase`.
+The option `Binding.IgnoreCase` determines if binding operations are case-sensitive or not.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -156,9 +158,29 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -BindingField
+
+Sets the option `Binding.Field`.
+The option specified one or more custom field bindings.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -TargetName
 
-Sets the option `Binding.TargetName`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to. See about_PSRule_Options for more information.
+Sets the option `Binding.TargetName`.
+This option specifies one or more properties of _TargetObject_ to use to bind _TargetName_ to.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
@@ -174,7 +196,9 @@ Accept wildcard characters: False
 
 ### -TargetType
 
-Sets the option `Binding.TargetType`. This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to. See about_PSRule_Options for more information.
+Sets the option `Binding.TargetType`.
+This option specifies one or more properties of _TargetObject_ to use to bind _TargetType_ to.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: String[]
@@ -190,7 +214,9 @@ Accept wildcard characters: False
 
 ### -InconclusiveWarning
 
-Sets the option `Execution.InconclusiveWarning`. The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive. See about_PSRule_Options for more information.
+Sets the option `Execution.InconclusiveWarning`.
+The `Execution.InconclusiveWarning` option determines if a warning is generated when the outcome of a rule is inconclusive.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean
@@ -206,7 +232,9 @@ Accept wildcard characters: False
 
 ### -NotProcessedWarning
 
-Sets the `Execution.NotProcessedWarning` option. The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule. See about_PSRule_Options for more information.
+Sets the `Execution.NotProcessedWarning` option.
+The `Execution.NotProcessedWarning` option determines if a warning is generated when an object is not processed by any rule.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: Boolean

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -265,7 +265,7 @@ Instead of processing objects from the pipeline, import objects file the specifi
 ```yaml
 Type: String[]
 Parameter Sets: InputPath
-Aliases:
+Aliases: f
 
 Required: True
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
@@ -14,6 +14,7 @@ A baseline includes a set of rule and configuration options that are used for ev
 The following baseline options can be configured:
 
 - [Binding.IgnoreCase](about_PSRule_Options.md#bindingignorecase)
+- [Binding.Field](about_PSRule_Options.md#bindingfield)
 - [Binding.TargetName](about_PSRule_Options.md#bindingtargetname)
 - [Binding.TargetType](about_PSRule_Options.md#bindingtargettype)
 - [Configuration](about_PSRule_Options.md#configuration)
@@ -59,6 +60,9 @@ metadata:
   name: Baseline1
 spec:
   binding:
+    field:
+      id:
+      - ResourceId
     targetName:
     - Name
     - ResourceName
@@ -119,6 +123,9 @@ After precedence is determined, baselines are merged and null values are ignored
 # Configures binding
 binding:
   ignoreCase: false
+  field:
+    id:
+    - ResourceId
   targetName:
   - ResourceName
   - AlternateName

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -33,6 +33,7 @@ The following workspace options are available for use:
 Additionally the following baseline options can be included:
 
 - [Binding.IgnoreCase](#bindingignorecase)
+- [Binding.Field](#bindingfield)
 - [Binding.TargetName](#bindingtargetname)
 - [Binding.TargetType](#bindingtargettype)
 - [Configuration](#configuration)
@@ -114,7 +115,8 @@ This is because not all operation systems treat case in the same way.
 ### Binding.IgnoreCase
 
 When evaluating an object, PSRule extracts a few key properties from the object to help filter rules and display output results.
-The process of extract these key properties is called _binding_. The properties that PSRule uses for binding can be customized by providing a order list of alternative properties to use.
+The process of extract these key properties is called _binding_.
+The properties that PSRule uses for binding can be customized by providing a order list of alternative properties to use.
 See [`Binding.TargetName`](#bindingtargetname) and [`Binding.TargetType`](#bindingtargettype) for these options.
 
 - By default, custom property binding finds the first matching property by name regardless of case. i.e. `Binding.IgnoreCase` is `true`.
@@ -143,6 +145,48 @@ Set-PSRuleOption -BindingIgnoreCase $False;
 # YAML: Using the binding/ignoreCase property
 binding:
   ignoreCase: false
+```
+
+### Binding.Field
+
+When an object is passed from the pipeline, PSRule automatically extracts fields from object properties.
+PSRule provides standard fields such as `TargetName` and `TargetType`.
+In addition to standard fields, custom fields can be bound.
+Custom fields are available to rules and included in output.
+
+PSRule uses the following logic to determine which property should be used for binding:
+
+- By default PSRule will not extract any custom fields.
+- If custom fields are configured, PSRule will attempt to bind the field.
+  - If **none** of the configured property names exist, the field will be skipped.
+  - If more then one property name is configured, the order they are specified in the configuration determines precedence.
+    - i.e. The first configured property name will take precedence over the second property name.
+  - By default the property name will be matched ignoring case sensitivity. To use a case sensitive match, configure the [Binding.IgnoreCase](#bindingignorecase) option.
+
+Custom field bindings can be specified using:
+
+```powershell
+# PowerShell: Using the BindingField parameter
+$option = New-PSRuleOption -BindingField @{ id = 'ResourceId', 'AlternativeId' };
+```
+
+```powershell
+# PowerShell: Using the Binding.Field hashtable key
+$option = New-PSRuleOption -Option @{ 'Binding.Field' = @{ id = 'ResourceId', 'AlternativeId' } };
+```
+
+```powershell
+# PowerShell: Using the BindingField parameter to set YAML
+Set-PSRuleOption -BindingField @{ id = 'ResourceId', 'AlternativeId' };
+```
+
+```yaml
+# YAML: Using the binding/field property
+binding:
+  field:
+    id:
+    - ResourceId
+    - AlternativeId
 ```
 
 ### Binding.TargetName
@@ -1034,6 +1078,10 @@ suppression:
 # Configure baseline options
 binding:
   ignoreCase: false
+  field:
+    id:
+    - ResourceId
+    - AlternativeId
   targetName:
   - ResourceName
   - AlternateName
@@ -1093,6 +1141,7 @@ suppression: { }
 # Configure baseline options
 binding:
   ignoreCase: true
+  field: { }
   targetName:
   - TargetName
   - Name

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -20,6 +20,7 @@ The following variables are available for use:
 - [$Assert](#assert)
 - [$Configuration](#configuration)
 - [$LocalizedData](#localizeddata)
+- [$PSRule](#psrule)
 - [$Rule](#rule)
 - [$TargetObject](#targetobject)
 
@@ -123,17 +124,45 @@ This rule returns a warning message similar to:
 LocalizedMessage for en-ZZ. Format=TestType.
 ```
 
+### PSRule
+
+An object representing the current context during execution.
+
+The following section properties are available for public read access:
+
+- `Field` - A hashtable of custom bound fields. See option `Binding.Field` for more information.
+- `TargetObject` - The object currently being processed on the pipeline.
+- `TargetName` - The name of the object currently being processed on the pipeline. This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
+- `TargetType` - The type of the object currently being processed on the pipeline. This property will automatically bind to `PSObject.TypeNames[0]` by default.
+
+Syntax:
+
+```powershell
+$PSRule
+```
+
+Examples:
+
+```powershell
+# Synopsis: This rule determines if the target object matches the naming convention
+Rule 'resource.NamingConvention' {
+    $PSRule.TargetName.ToLower() -ceq $PSRule.TargetName
+}
+```
+
 ### Rule
 
-An object representing the current object model of the rule during execution.
+An object representing the current rule during execution.
 
 The following section properties are available for public read access:
 
 - `RuleName` - The name of the rule.
 - `RuleId` - A unique identifier for the rule.
-- `TargetObject` - The object currently being processed on the pipeline.
-- `TargetName` - The name of the object currently being processed on the pipeline. This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
-- `TargetType` - The type of the object currently being processed on the pipeline. This property will automatically bind to `PSObject.TypeNames[0]` by default.
+- `TargetObject` - (deprecated) The object currently being processed on the pipeline.
+- `TargetName` - (deprecated) The name of the object currently being processed on the pipeline. This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
+- `TargetType` - (deprecated) The type of the object currently being processed on the pipeline. This property will automatically bind to `PSObject.TypeNames[0]` by default.
+
+**Note:** Use `TargetName`, `TargetType` and `TargetObject` on `$PSRule` instead.
 
 Syntax:
 
@@ -184,5 +213,6 @@ An online version of this document is available at https://github.com/Microsoft/
 - Assert
 - Configuration
 - LocalizedData
+- PSRule
 - Rule
 - TargetObject

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -67,6 +67,19 @@
                             "description": "Determines if custom binding uses ignores case when matching properties. The default is true.",
                             "default": true
                         },
+                        "field": {
+                            "type": "object",
+                            "title": "Field",
+                            "description": "Custom fields to bind.",
+                            "additionalProperties": {
+                                "type": "array",
+                                "description": "A custom field to bind.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "uniqueItems": true
+                            }
+                        },
                         "targetName": {
                             "type": "array",
                             "title": "Bind TargetName",

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -13,7 +13,7 @@
             "title": "Configuration values",
             "description": "A set of key/ value configuration options for rules."
         },
-        "binding-v0.3.0": {
+        "binding-option": {
             "type": "object",
             "title": "Object binding",
             "description": "Configure property/ object binding options.",
@@ -23,6 +23,19 @@
                     "title": "Ignore case",
                     "description": "Determines if custom binding uses ignores case when matching properties. The default is true.",
                     "default": true
+                },
+                "field": {
+                    "type": "object",
+                    "title": "Field",
+                    "description": "Custom fields to bind.",
+                    "additionalProperties": {
+                        "type": "array",
+                        "description": "A custom field to bind.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "uniqueItems": true
+                    }
                 },
                 "targetName": {
                     "type": "array",
@@ -270,7 +283,7 @@
                     "type": "object",
                     "oneOf": [
                         {
-                            "$ref": "#/definitions/binding-v0.3.0"
+                            "$ref": "#/definitions/binding-option"
                         }
                     ]
                 },

--- a/src/PSRule/Configuration/BaselineOption.cs
+++ b/src/PSRule/Configuration/BaselineOption.cs
@@ -62,6 +62,9 @@ namespace PSRule.Configuration
             if (properties.TryPopValue("binding.ignorecase", out object value))
                 option.Binding.IgnoreCase = bool.Parse(value.ToString());
 
+            if (properties.TryPopValue("binding.field", out value) && value is Hashtable map)
+                option.Binding.Field = new FieldMap(map);
+
             if (properties.TryPopValue("binding.targetname", out value))
             {
                 if (value.GetType().IsArray)

--- a/src/PSRule/Configuration/BindingOption.cs
+++ b/src/PSRule/Configuration/BindingOption.cs
@@ -21,6 +21,7 @@ namespace PSRule.Configuration
         public BindingOption()
         {
             IgnoreCase = null;
+            Field = null;
             TargetName = null;
             TargetType = null;
         }
@@ -28,6 +29,7 @@ namespace PSRule.Configuration
         public BindingOption(BindingOption option)
         {
             IgnoreCase = option.IgnoreCase;
+            Field = option.Field;
             TargetName = option.TargetName;
             TargetType = option.TargetType;
         }
@@ -41,6 +43,7 @@ namespace PSRule.Configuration
         {
             return other != null &&
                 IgnoreCase == other.IgnoreCase &&
+                Field == other.Field &&
                 TargetName == other.TargetName &&
                 TargetType == other.TargetType;
         }
@@ -51,6 +54,7 @@ namespace PSRule.Configuration
             {
                 int hash = 17;
                 hash = hash * 23 + (IgnoreCase.HasValue ? IgnoreCase.Value.GetHashCode() : 0);
+                hash = hash * 23 + (Field != null ? Field.GetHashCode() : 0);
                 hash = hash * 23 + (TargetName != null ? TargetName.GetHashCode() : 0);
                 hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
                 return hash;
@@ -62,6 +66,12 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public bool? IgnoreCase { get; set; }
+
+        /// <summary>
+        /// One or more custom fields to bind.
+        /// </summary>
+        [DefaultValue(null)]
+        public FieldMap Field { get; set; }
 
         /// <summary>
         /// One or more property names to use to bind TargetName.

--- a/src/PSRule/Configuration/FieldMap.cs
+++ b/src/PSRule/Configuration/FieldMap.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// A mapping of fields to property names.
+    /// </summary>
+    public sealed class FieldMap : DynamicObject, IEnumerable<KeyValuePair<string, string[]>>
+    {
+        private readonly Dictionary<string, string[]> _Map;
+
+        public FieldMap()
+        {
+            _Map = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal FieldMap(Dictionary<string, string[]> map)
+        {
+            _Map = new Dictionary<string, string[]>(map, StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal FieldMap(Hashtable map)
+            : this()
+        {
+            var index = PSRuleOption.BuildIndex(map);
+            Load(this, index);
+        }
+
+        public int Count
+        {
+            get { return _Map.Count; }
+        }
+
+        public static implicit operator FieldMap(Hashtable hashtable)
+        {
+            return new FieldMap(hashtable);
+        }
+
+        public bool TryField(string fieldName, out string[] fields)
+        {
+            return _Map.TryGetValue(fieldName, out fields);
+        }
+
+        internal void Set(string fieldName, string[] fields)
+        {
+            _Map[fieldName] = fields;
+        }
+
+        internal static void Load(FieldMap map, Dictionary<string, object> properties)
+        {
+            foreach (var property in properties)
+            {
+                if (property.Value is string value && !string.IsNullOrEmpty(value))
+                    map.Set(property.Key, new string[] { value });
+                else if (property.Value is string[] array && array.Length > 0)
+                    map.Set(property.Key, array);
+            }
+        }
+
+        public IEnumerator<KeyValuePair<string, string[]>> GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<string, string[]>>)_Map).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            var found = TryField(binder.Name, out string[] value);
+            result = value;
+            return found;
+        }
+    }
+}

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -198,6 +198,7 @@ namespace PSRule.Configuration
             var d = new DeserializerBuilder()
                 .IgnoreUnmatchedProperties()
                 .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithTypeConverter(new FieldMapYamlTypeConverter())
                 .WithTypeConverter(new SuppressionRuleYamlTypeConverter())
                 .Build();
             var option = d.Deserialize<PSRuleOption>(yaml) ?? new PSRuleOption();
@@ -242,23 +243,23 @@ namespace PSRule.Configuration
 
             // Start loading matching values
 
-            if (index.TryGetValue("execution.languagemode", out object value))
+            if (index.TryPopValue("execution.languagemode", out object value))
             {
                 option.Execution.LanguageMode = (LanguageMode)Enum.Parse(typeof(LanguageMode), (string)value);
             }
-            if (index.TryGetValue("execution.inconclusivewarning", out value))
+            if (index.TryPopValue("execution.inconclusivewarning", out value))
             {
                 option.Execution.InconclusiveWarning = bool.Parse(value.ToString());
             }
-            if (index.TryGetValue("execution.notprocessedwarning", out value))
+            if (index.TryPopValue("execution.notprocessedwarning", out value))
             {
                 option.Execution.NotProcessedWarning = bool.Parse(value.ToString());
             }
-            if (index.TryGetValue("input.format", out value))
+            if (index.TryPopValue("input.format", out value))
             {
                 option.Input.Format = (InputFormat)Enum.Parse(typeof(InputFormat), (string)value);
             }
-            if (index.TryGetValue("input.objectpath", out value))
+            if (index.TryPopValue("input.objectpath", out value))
             {
                 option.Input.ObjectPath = (string)value;
             }
@@ -266,39 +267,39 @@ namespace PSRule.Configuration
             {
                 option.Input.TargetType = AsStringArray(value);
             }
-            if (index.TryGetValue("logging.limitdebug", out value))
+            if (index.TryPopValue("logging.limitdebug", out value))
             {
                 option.Logging.LimitDebug = AsStringArray(value);
             }
-            if (index.TryGetValue("logging.limitverbose", out value))
+            if (index.TryPopValue("logging.limitverbose", out value))
             {
                 option.Logging.LimitVerbose = AsStringArray(value);
             }
-            if (index.TryGetValue("logging.rulefail", out value))
+            if (index.TryPopValue("logging.rulefail", out value))
             {
                 option.Logging.RuleFail = (OutcomeLogStream)Enum.Parse(typeof(OutcomeLogStream), (string)value);
             }
-            if (index.TryGetValue("logging.rulepass", out value))
+            if (index.TryPopValue("logging.rulepass", out value))
             {
                 option.Logging.RulePass = (OutcomeLogStream)Enum.Parse(typeof(OutcomeLogStream), (string)value);
             }
-            if (index.TryGetValue("output.as", out value))
+            if (index.TryPopValue("output.as", out value))
             {
                 option.Output.As = (ResultFormat)Enum.Parse(typeof(ResultFormat), (string)value);
             }
-            if (index.TryGetValue("output.encoding", out value))
+            if (index.TryPopValue("output.encoding", out value))
             {
                 option.Output.Encoding = (OutputEncoding)Enum.Parse(typeof(OutputEncoding), (string)value);
             }
-            if (index.TryGetValue("output.format", out value))
+            if (index.TryPopValue("output.format", out value))
             {
                 option.Output.Format = (OutputFormat)Enum.Parse(typeof(OutputFormat), (string)value);
             }
-            if (index.TryGetValue("output.path", out value))
+            if (index.TryPopValue("output.path", out value))
             {
                 option.Output.Path = (string)value;
             }
-            if (index.TryGetValue("output.style", out value))
+            if (index.TryPopValue("output.style", out value))
             {
                 option.Output.Style = (OutputStyle)Enum.Parse(typeof(OutputStyle), (string)value);
             }
@@ -393,9 +394,8 @@ namespace PSRule.Configuration
         {
             var index = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
             foreach (DictionaryEntry entry in hashtable)
-            {
                 index.Add(entry.Key.ToString(), entry.Value);
-            }
+
             return index;
         }
 
@@ -415,6 +415,7 @@ namespace PSRule.Configuration
         {
             var s = new SerializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithTypeConverter(new FieldMapYamlTypeConverter())
                 .Build();
             return s.Serialize(this);
         }

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -10,6 +10,30 @@ using System.Management.Automation.Runspaces;
 namespace PSRule.Host
 {
     /// <summary>
+    /// A dynamic variable $PSRule used during Rule execution.
+    /// </summary>
+    internal sealed class PSRuleVariable : PSVariable
+    {
+        private const string VARIABLE_NAME = "PSRule";
+
+        private readonly Runtime.PSRule _Value;
+
+        public PSRuleVariable()
+            : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
+        {
+            _Value = new Runtime.PSRule();
+        }
+
+        public override object Value
+        {
+            get
+            {
+                return _Value;
+            }
+        }
+    }
+
+    /// <summary>
     /// A dynamic variable $Rule used during Rule execution.
     /// </summary>
     internal sealed class RuleVariable : PSVariable

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -184,6 +184,7 @@ namespace PSRule.Host
             var d = new DeserializerBuilder()
                 .IgnoreUnmatchedProperties()
                 .WithNamingConvention(new CamelCaseNamingConvention())
+                .WithTypeConverter(new FieldMapYamlTypeConverter())
                 .WithNodeDeserializer(
                     inner => new LanguageBlockDeserializer(inner),
                     s => s.InsteadOf<ObjectNodeDeserializer>())

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -100,6 +100,7 @@ VariablesToExport = @(
     'Assert'
     'Configuration'
     'LocalizedData'
+    'PSRule'
     'Rule'
     'TargetObject'
 )

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -32,6 +32,7 @@ function Invoke-PSRule {
     [OutputType([System.String])]
     param (
         [Parameter(Mandatory = $True, ParameterSetName = 'InputPath')]
+        [Alias('f')]
         [String[]]$InputPath,
 
         [Parameter(Mandatory = $False)]
@@ -207,6 +208,7 @@ function Test-PSRuleTarget {
     [OutputType([System.Boolean])]
     param (
         [Parameter(Mandatory = $True, ParameterSetName = 'InputPath')]
+        [Alias('f')]
         [String[]]$InputPath,
 
         [Parameter(Mandatory = $False)]
@@ -358,6 +360,7 @@ function Assert-PSRule {
     [OutputType([System.String])]
     param (
         [Parameter(Mandatory = $True, ParameterSetName = 'InputPath')]
+        [Alias('f')]
         [String[]]$InputPath,
 
         [Parameter(Mandatory = $False)]
@@ -884,6 +887,10 @@ function New-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [System.Boolean]$BindingIgnoreCase = $True,
 
+        # Sets the Binding.Field option
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$BindingField,
+
         # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
         [Alias('BindingTargetName')]
@@ -1053,6 +1060,10 @@ function Set-PSRuleOption {
         # Sets the Binding.IgnoreCase option
         [Parameter(Mandatory = $False)]
         [System.Boolean]$BindingIgnoreCase = $True,
+
+        # Sets the Binding.Field option
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$BindingField,
 
         # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
@@ -1622,6 +1633,10 @@ function SetOptions {
         [Parameter(Mandatory = $False)]
         [System.Boolean]$BindingIgnoreCase = $True,
 
+        # Sets the Binding.Field option
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$BindingField,
+
         # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
         [Alias('BindingTargetName')]
@@ -1704,6 +1719,11 @@ function SetOptions {
         # Sets option Binding.IgnoreCase
         if ($PSBoundParameters.ContainsKey('BindingIgnoreCase')) {
             $Option.Binding.IgnoreCase = $BindingIgnoreCase;
+        }
+
+        # Sets option Binding.Field
+        if ($PSBoundParameters.ContainsKey('BindingField')) {
+            $Option.Binding.Field = $BindingField;
         }
 
         # Sets option Binding.TargetName
@@ -1856,6 +1876,7 @@ function InitEditorServices {
                 'Assert'
                 'Configuration'
                 'LocalizedData'
+                'PSRule'
                 'Rule'
                 'TargetObject'
             );
@@ -1886,6 +1907,8 @@ function InitCompletionServices {
 [PSRule.Runtime.Assert]$Assert = New-Object -TypeName 'PSRule.Runtime.Assert';
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignment', '', Justification = 'Variable is used for editor discovery only.')]
 [PSObject]$Configuration = $Null;
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignment', '', Justification = 'Variable is used for editor discovery only.')]
+[PSRule.Runtime.PSRule]$PSRule = New-Object -TypeName 'PSRule.Runtime.PSRule';
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignment', '', Justification = 'Variable is used for editor discovery only.')]
 [PSRule.Runtime.Rule]$Rule = New-Object -TypeName 'PSRule.Runtime.Rule';
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignment', '', Justification = 'Variable is used for editor discovery only.')]

--- a/src/PSRule/Pipeline/GetBaselinePipeline.cs
+++ b/src/PSRule/Pipeline/GetBaselinePipeline.cs
@@ -42,7 +42,7 @@ namespace PSRule.Pipeline
         {
             var filter = new BaselineFilter(_Name);
             return new GetBaselinePipeline(
-                context: PrepareContext(null, null),
+                context: PrepareContext(null, null, null),
                 source: Source,
                 reader: PrepareReader(),
                 writer: PrepareWriter(),

--- a/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
+++ b/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
@@ -51,7 +51,7 @@ namespace PSRule.Pipeline
 
         public override IPipeline Build()
         {
-            return new GetRuleHelpPipeline(PrepareContext(null, null), Source, PrepareReader(), PrepareWriter());
+            return new GetRuleHelpPipeline(PrepareContext(null, null, null), Source, PrepareReader(), PrepareWriter());
         }
 
         private sealed class HelpWriter : PipelineWriter

--- a/src/PSRule/Pipeline/GetRulePipeline.cs
+++ b/src/PSRule/Pipeline/GetRulePipeline.cs
@@ -45,7 +45,7 @@ namespace PSRule.Pipeline
 
         public override IPipeline Build()
         {
-            return new GetRulePipeline(PrepareContext(null, null), Source, PrepareReader(), PrepareWriter(), _IncludeDependencies);
+            return new GetRulePipeline(PrepareContext(null, null, null), Source, PrepareReader(), PrepareWriter(), _IncludeDependencies);
         }
 
         private OutputFormat SuppressFormat(OutputFormat? format)

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -27,6 +27,7 @@ namespace PSRule.Pipeline
 
         protected BindTargetMethod _BindTargetNameHook;
         protected BindTargetMethod _BindTargetTypeHook;
+        protected BindTargetMethod _BindFieldHook;
 
         protected InvokePipelineBuilderBase(Source[] source)
             : base(source)
@@ -36,6 +37,7 @@ namespace PSRule.Pipeline
             _VisitTargetObject = PipelineReceiverActions.PassThru;
             _BindTargetNameHook = PipelineHookActions.BindTargetName;
             _BindTargetTypeHook = PipelineHookActions.BindTargetType;
+            _BindFieldHook = PipelineHookActions.BindField;
         }
 
         public void Limit(RuleOutcome outcome)
@@ -109,7 +111,7 @@ namespace PSRule.Pipeline
 
         public sealed override IPipeline Build()
         {
-            return new InvokeRulePipeline(PrepareContext(bindTargetName: _BindTargetNameHook, bindTargetType: _BindTargetTypeHook), Source, PrepareReader(), PrepareWriter(), Outcome);
+            return new InvokeRulePipeline(PrepareContext(_BindTargetNameHook, _BindTargetTypeHook, _BindFieldHook), Source, PrepareReader(), PrepareWriter(), Outcome);
         }
 
         private BindTargetMethod AddBindTargetAction(BindTargetFunc action, BindTargetMethod previous)

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -166,7 +166,7 @@ namespace PSRule.Pipeline
             _Baseline = baseline;
         }
 
-        protected PipelineContext PrepareContext(BindTargetMethod bindTargetName, BindTargetMethod bindTargetType)
+        protected PipelineContext PrepareContext(BindTargetMethod bindTargetName, BindTargetMethod bindTargetType, BindTargetMethod bindField)
         {
             var unresolved = new Dictionary<string, ResourceRef>(StringComparer.OrdinalIgnoreCase);
             if (_Baseline is BaselineOption.BaselineRef baselineRef)
@@ -182,7 +182,7 @@ namespace PSRule.Pipeline
                 logger: Logger,
                 option: Option,
                 hostContext: HostContext,
-                binder: new TargetBinder(bindTargetName, bindTargetType, Option.Input.TargetType),
+                binder: new TargetBinder(bindTargetName, bindTargetType, bindField, Option.Input.TargetType),
                 baseline: GetBaselineContext(),
                 unresolved: unresolved
             );

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -153,6 +153,7 @@ namespace PSRule.Pipeline
                     Runspace.DefaultRunspace = _Runspace;
 
                 _Runspace.Open();
+                _Runspace.SessionStateProxy.PSVariable.Set(new PSRuleVariable());
                 _Runspace.SessionStateProxy.PSVariable.Set(new RuleVariable());
                 _Runspace.SessionStateProxy.PSVariable.Set(new LocalizedDataVariable());
                 _Runspace.SessionStateProxy.PSVariable.Set(new AssertVariable());
@@ -437,7 +438,8 @@ namespace PSRule.Pipeline
                 targetName: _Binder.TargetName,
                 targetType: _Binder.TargetType,
                 tag: ruleBlock.Tag,
-                info: ruleBlock.Info
+                info: ruleBlock.Info,
+                field: _Binder.Field
             );
 
             if (_Logger != null)

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -33,11 +33,22 @@ namespace PSRule.Pipeline
         {
             if (propertyNames != null)
                 if (propertyNames.Any(n => n.Contains('.')))
-                    return NestedTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultTargetNameBinding);
+                    return NestedTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultTargetTypeBinding);
                 else
-                    return CustomTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultTargetNameBinding);
+                    return CustomTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultTargetTypeBinding);
 
             return DefaultTargetTypeBinding(targetObject);
+        }
+
+        public static string BindField(string[] propertyNames, bool caseSensitive, PSObject targetObject)
+        {
+            if (propertyNames != null)
+                if (propertyNames.Any(n => n.Contains('.')))
+                    return NestedTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultFieldBinding);
+                else
+                    return CustomTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultFieldBinding);
+
+            return DefaultFieldBinding(targetObject);
         }
 
         /// <summary>
@@ -125,6 +136,11 @@ namespace PSRule.Pipeline
         private static string DefaultTargetTypeBinding(PSObject targetObject)
         {
             return targetObject.TypeNames[0];
+        }
+
+        private static string DefaultFieldBinding(PSObject targetObject)
+        {
+            return null;
         }
     }
 }

--- a/src/PSRule/Pipeline/TargetBinder.cs
+++ b/src/PSRule/Pipeline/TargetBinder.cs
@@ -3,6 +3,7 @@
 
 using PSRule.Configuration;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 
@@ -12,15 +13,73 @@ namespace PSRule.Pipeline
     {
         private readonly BindTargetMethod _BindTargetName;
         private readonly BindTargetMethod _BindTargetType;
+        private readonly BindTargetMethod _BindField;
         private readonly HashSet<string> _TypeFilter;
 
-        internal TargetBinder(BindTargetMethod bindTargetName, BindTargetMethod bindTargetType, string[] typeFilter)
+        internal TargetBinder(BindTargetMethod bindTargetName, BindTargetMethod bindTargetType, BindTargetMethod bindField, string[] typeFilter)
         {
             _BindTargetName = bindTargetName;
             _BindTargetType = bindTargetType;
+            _BindField = bindField;
             if (typeFilter != null && typeFilter.Length > 0)
                 _TypeFilter = new HashSet<string>(typeFilter, StringComparer.OrdinalIgnoreCase);
         }
+
+        private sealed class ImmutableHashtable : Hashtable
+        {
+            private bool _ReadOnly;
+
+            internal ImmutableHashtable()
+                : base(StringComparer.OrdinalIgnoreCase) { }
+
+            public override bool IsReadOnly => _ReadOnly;
+
+            public override void Add(object key, object value)
+            {
+                if (_ReadOnly)
+                    throw new InvalidOperationException();
+
+                base.Add(key, value);
+            }
+
+            public override void Clear()
+            {
+                if (_ReadOnly)
+                    throw new InvalidOperationException();
+
+                base.Clear();
+            }
+
+            public override void Remove(object key)
+            {
+                if (_ReadOnly)
+                    throw new InvalidOperationException();
+
+                base.Remove(key);
+            }
+
+            public override object this[object key]
+            {
+                get => base[key];
+                set
+                {
+                    if (_ReadOnly)
+                        throw new InvalidOperationException();
+
+                    base[key] = value;
+                }
+            }
+
+            internal void Protect()
+            {
+                _ReadOnly = true;
+            }
+        }
+
+        /// <summary>
+        /// Additional bound fields of the target object.
+        /// </summary>
+        public Hashtable Field { get; private set; }
 
         /// <summary>
         /// The bound TargetName of the target object.
@@ -46,6 +105,33 @@ namespace PSRule.Pipeline
             TargetName = _BindTargetName(binding.TargetName, !binding.IgnoreCase, targetObject);
             TargetType = _BindTargetType(binding.TargetType, !binding.IgnoreCase, targetObject);
             ShouldFilter = !(_TypeFilter == null || _TypeFilter.Contains(TargetType));
+            BindField(binding.Field, !binding.IgnoreCase, targetObject);
+        }
+
+        /// <summary>
+        /// Bind additional fields.
+        /// </summary>
+        private void BindField(FieldMap[] map, bool caseSensitive, PSObject targetObject)
+        {
+            var hashtable = new ImmutableHashtable();
+            if (map == null || map.Length == 0)
+                return;
+
+            for (var i = 0; i < map.Length; i++)
+            {
+                if (map[i] == null || map[i].Count == 0)
+                    continue;
+
+                foreach (var field in map[i])
+                {
+                    if (hashtable.ContainsKey(field.Key))
+                        continue;
+
+                    hashtable.Add(field.Key, _BindField(field.Value, caseSensitive, targetObject));
+                }
+            }
+            hashtable.Protect();
+            Field = hashtable;
         }
     }
 }

--- a/src/PSRule/Rules/RuleRecord.cs
+++ b/src/PSRule/Rules/RuleRecord.cs
@@ -18,22 +18,20 @@ namespace PSRule.Rules
     [JsonObject]
     public sealed class RuleRecord
     {
-        internal RuleRecord(string ruleId, string ruleName, PSObject targetObject, string targetName, string targetType, TagSet tag, RuleHelpInfo info, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
+        internal RuleRecord(string ruleId, string ruleName, PSObject targetObject, string targetName, string targetType, TagSet tag, RuleHelpInfo info, Hashtable field, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
         {
             RuleId = ruleId;
             RuleName = ruleName;
             TargetObject = targetObject;
             TargetName = targetName;
             TargetType = targetType;
-
-            if (tag != null)
-            {
-                Tag = tag.ToHashtable();
-            }
-
             Outcome = outcome;
             OutcomeReason = reason;
             Info = info;
+            if (tag != null)
+                Tag = tag.ToHashtable();
+            if (field != null && field.Count > 0)
+                Field = field;
         }
 
         /// <summary>
@@ -83,6 +81,9 @@ namespace PSRule.Rules
         [JsonIgnore]
         [YamlIgnore]
         public PSObject TargetObject { get; internal set; }
+
+        [JsonProperty(PropertyName = "field")]
+        public Hashtable Field { get; internal set; }
 
         [DefaultValue(null)]
         [JsonProperty(PropertyName = "tag")]

--- a/src/PSRule/Runtime/PSRule.cs
+++ b/src/PSRule/Runtime/PSRule.cs
@@ -1,34 +1,25 @@
-﻿// Copyright (c) Microsoft Corporation.
+﻿// Copyright(c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using PSRule.Pipeline;
-using System;
+using System.Collections;
 using System.Management.Automation;
 
 namespace PSRule.Runtime
 {
     /// <summary>
-    /// A set of rule properties that are exposed at runtime through the $Rule variable.
+    /// A set of context properties that are exposed at runtime through the $PSRule variable.
     /// </summary>
-    public sealed class Rule
+    public sealed class PSRule
     {
-        public string RuleName
+        public Hashtable Field
         {
             get
             {
-                return PipelineContext.CurrentThread.RuleRecord.RuleName;
+                return PipelineContext.CurrentThread.RuleRecord.Field;
             }
         }
 
-        public string RuleId
-        {
-            get
-            {
-                return PipelineContext.CurrentThread.RuleRecord.RuleId;
-            }
-        }
-
-        [Obsolete("Use property on $PSRule instead")]
         public PSObject TargetObject
         {
             get
@@ -37,7 +28,6 @@ namespace PSRule.Runtime
             }
         }
 
-        [Obsolete("Use property on $PSRule instead")]
         public string TargetName
         {
             get
@@ -46,7 +36,6 @@ namespace PSRule.Runtime
             }
         }
 
-        [Obsolete("Use property on $PSRule instead")]
         public string TargetType
         {
             get

--- a/tests/PSRule.Tests/Baseline.Rule.yaml
+++ b/tests/PSRule.Tests/Baseline.Rule.yaml
@@ -6,6 +6,12 @@ metadata:
   name: TestBaseline1
 spec:
   binding:
+    field:
+      kind:
+      - kind
+      uniqueIdentifer:
+      - Id
+      - AlternateName
     targetName:
       #field:
       - AlternateName

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -126,13 +126,21 @@ Rule 'ConstrainedTest3' -If { $Null = [Console]::WriteLine('Should fail'); retur
     $True;
 }
 
-# Synopsis: Test automatic variables
-Rule 'VariableTest' {
-    $TargetObject.Name -eq $Rule.RuleName;
+# Synopsis: Test $PSRule automatic variables
+Rule 'VariableContextVariable' {
+    $TargetObject.Name -eq $PSRule.TargetName;
+    $TargetObject.Type -eq $PSRule.TargetType;
+    $TargetObject.Type -eq $PSRule.Field.Kind;
+}
+
+# Synopsis: Test $Rule automatic variables
+Rule 'WithRuleVariable' {
+    $TargetObject.RuleTest -eq $Rule.RuleName;
     $TargetObject.Name -eq $Rule.TargetName;
     $TargetObject.Type -eq $Rule.TargetType;
 }
 
+# Synopsis: Test $Configuration automatic variables
 Rule 'WithConfiguration' {
     $Configuration.Value1 -eq 1
     $Configuration.Value2 -eq 2
@@ -160,9 +168,9 @@ Rule 'WithPWD' {
     $PWD.ToString() -eq $TargetObject.PWD.ToString()
 }
 
-# Synopsis: Test $WithPSCommandPath automatic variable
+# Synopsis: Test $PSCommandPath automatic variable
 Rule 'WithPSCommandPath' {
-    $WithPSCommandPath -eq $TargetObject.WithPSCommandPath
+    $PSCommandPath -eq $TargetObject.PSCommandPath
 }
 
 Rule 'WithCsv' {

--- a/tests/PSRule.Tests/FromFileBaseline.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileBaseline.Rule.ps1
@@ -9,6 +9,7 @@
 Rule 'WithBaseline' {
     $Rule.TargetName -eq 'TestObject1'
     $Rule.TargetType -eq 'TestObjectType'
+    $PSRule.Field.kind -eq 'TestObjectType'
 }
 
 # Synopsis: Test for baseline

--- a/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
@@ -64,6 +64,7 @@ Describe 'Baseline' -Tag 'Baseline' {
             [PSCustomObject]@{
                 AlternateName = 'TestObject1'
                 Kind = 'TestObjectType'
+                Id = '1'
             }
         )
         $result = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline1');
@@ -75,6 +76,7 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result[0].Outcome | Should -Be 'Pass';
             $result[0].TargetName | Should -Be 'TestObject1';
             $result[0].TargetType | Should -Be 'TestObjectType';
+            $result[0].Field.kind | Should -Be 'TestObjectType';
         }
 
         It 'With -Module' {
@@ -91,6 +93,7 @@ Describe 'Baseline' -Tag 'Baseline' {
             $option = @{
                 'Configuration.ruleConfig1' = 'Test2'
                 'Rule.Include' = @('M4.Rule1', 'M4.Rule2')
+                'Binding.Field' = @{ kind = 'Kind' }
             }
             $result = @($testObject | Invoke-PSRule -Module TestModule4 -Option $option);
             $result | Should -Not -BeNullOrEmpty;
@@ -99,6 +102,8 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result[0].Outcome | Should -Be 'Fail';
             $result[0].TargetName | Should -Be 'TestObject1';
             $result[0].TargetType | Should -Be 'TestObjectType';
+            $result[0].Field.kind | Should -Be 'TestObjectType';
+            $result[0].Field.uniqueIdentifer | Should -Be '1';
             $result[1].RuleName | Should -Be 'M4.Rule2';
             $result[1].Outcome | Should -Be 'Pass';
             $result[1].TargetName | Should -Be 'TestObject1';
@@ -114,6 +119,8 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result.Length | Should -Be 1;
             $result[0].RuleName | Should -Be 'M4.Rule2';
             $result[0].Outcome | Should -Be 'Pass';
+            $result[0].Field.kind | Should -Be '1';
+            $result[0].Field.uniqueIdentifer | Should -Be '1';
 
             # Module + Workspace + Parameter + Explicit
             $option = @{

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -966,7 +966,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
         }
         $assertParams = @{
             Path = $ruleFilePath
-            Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain' }
+            Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain'; 'Binding.Field' = @{ extra = 'Name'} }
             Name = 'FromFile1', 'FromFile2', 'FromFile3'
             ErrorVariable = 'errorOut'
             OutputFormat = 'Json'
@@ -988,6 +988,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $resultContent.Length | Should -Be 3;
             $resultContent.RuleName | Should -BeIn 'FromFile1', 'FromFile2', 'FromFile3';
             $resultContent.TargetName | Should -BeIn 'TestObject1';
+            $resultContent.Field.extra | Should -BeIn 'TestObject1';
         }
     }
 
@@ -1683,6 +1684,11 @@ Describe 'Binding' -Tag Common, Binding {
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1' -Option $option;
             $result | Should -Not -BeNullOrEmpty;
             $result.TargetType | Should -Be 'kind';
+
+            $option = @{ 'Binding.TargetType' = 'NotType' };
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1' -Option $option;
+            $result | Should -Not -BeNullOrEmpty;
+            $result.TargetType | Should -Be 'TestType';
         }
 
         It 'Binds to custom type by script' {

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -181,6 +181,33 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Binding.Field' {
+        It 'from default' {
+            $option = New-PSRuleOption;
+            $option.Binding.Field | Should -BeNullOrEmpty;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Binding.Field' = @{ id = 'resourceId' } };
+            $option.Binding.Field | Should -Not -BeNullOrEmpty;
+            $option.Binding.Field.id.Length | Should -Be 1;
+            $option.Binding.Field.id[0] | Should -Be 'resourceId';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Binding.Field | Should -Not -BeNullOrEmpty;
+            $option.Binding.Field.id.Length | Should -Be 1;
+            $option.Binding.Field.id[0] | Should -Be 'resourceId';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -BindingField @{ id = 'resourceId' } -Path $emptyOptionsFilePath;
+            $option.Binding.Field | Should -Not -BeNullOrEmpty;
+            $option.Binding.Field.id.Length | Should -Be 1;
+        }
+    }
+
     Context 'Read Binding.TargetName' {
         It 'from default' {
             $option = New-PSRuleOption;
@@ -696,6 +723,14 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -BindingIgnoreCase $False @optionParams;
             $option.Binding.IgnoreCase | Should -Be $False;
+        }
+    }
+
+    Context 'Read Binding.Field' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -BindingField @{ id = 'resourceId' } @optionParams;
+            $option.Binding.Field | Should -Not -BeNullOrEmpty;
+            $option.Binding.Field.id[0] | Should -Be 'resourceId';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -18,6 +18,9 @@ configuration:
 # Configure binding
 binding:
   ignoreCase: false
+  field:
+    id:
+    - resourceId
   targetName:
   - ResourceName
   targetType:

--- a/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
@@ -39,11 +39,20 @@ Describe 'PSRule variables' -Tag 'Variables' {
             PSScriptRoot = $PSScriptRoot
             PWD = $PWD
             PSCommandPath = $ruleFilePath
+            RuleTest = 'WithRuleVariable'
         }
         $testObject.PSObject.TypeNames.Insert(0, $testObject.Type);
 
+        It '$PSRule' {
+            $option = New-PSRuleOption -BindingField @{ kind = 'Type' };
+            $result = $testObject | Invoke-PSRule -Option $option -Path $ruleFilePath -Name 'VariableContextVariable';
+            $result | Should -Not -BeNullOrEmpty;
+            $result.IsSuccess() | Should -Be $True;
+            $result.TargetName | Should -Be 'VariableTest';
+        }
+
         It '$Rule' {
-            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'VariableTest';
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'WithRuleVariable';
             $result | Should -Not -BeNullOrEmpty;
             $result.IsSuccess() | Should -Be $True;
             $result.TargetName | Should -Be 'VariableTest';

--- a/tests/PSRule.Tests/TargetNameBindingTests.cs
+++ b/tests/PSRule.Tests/TargetNameBindingTests.cs
@@ -28,7 +28,7 @@ namespace PSRule
             var pso1 = PSObject.AsPSObject(testObject1);
             var pso2 = PSObject.AsPSObject(testObject2);
 
-            PipelineContext.CurrentThread = PipelineContext.New(logger: null, option: new PSRuleOption(), hostContext: null, binder: new TargetBinder(null, null, null), baseline: null, unresolved: null);
+            PipelineContext.CurrentThread = PipelineContext.New(logger: null, option: new PSRuleOption(), hostContext: null, binder: new TargetBinder(null, null, null, null), baseline: null, unresolved: null);
             var actual1 = PipelineHookActions.BindTargetName(null, false, pso1);
             var actual2 = PipelineHookActions.BindTargetName(null, false, pso2);
 

--- a/tests/PSRule.Tests/TestModule4/rules/Baseline.Rule.yaml
+++ b/tests/PSRule.Tests/TestModule4/rules/Baseline.Rule.yaml
@@ -5,6 +5,12 @@ metadata:
   name: Module4
 spec:
   binding:
+    field:
+      kind:
+      - Id
+      uniqueIdentifer:
+      - Id
+      - AlternateName
     targetName:
       - AlternateName
     targetType:


### PR DESCRIPTION
## PR Summary

- Fixed TargetType fall back to type name. #339
- Added custom field binding. #321
  - Added new option `Binding.Field` available in baselines to configure binding.
- Added parameter alias `-f` for `-InputPath`. #340
  - `-f` was added to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget` cmdlets.
- **Important change**: Added `$PSRule` generic context variable. #341
  - Deprecated `TargetName`, `TargetType` and `TargetObject` properties on `$Rule`.
  - Use `TargetName`, `TargetType` and `TargetObject` on `$PSRule` instead.
  - Properties `TargetName`, `TargetType` and `TargetObject` on `$Rule` will be removed in the future.
  - Going forward `$Rule` will only contain properties that relate to the current rule context.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
