### PR TITLE
Pre-release v0.12.0-B1912002

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0-B1912002 (pre-release)
+
 - Fixed TargetType fall back to type name. [#339](https://github.com/Microsoft/PSRule/issues/339)
 - Added custom field binding. [#321](https://github.com/Microsoft/PSRule/issues/321)
   - Added new option `Binding.Field` available in baselines to configure binding.


### PR DESCRIPTION
## PR Summary

- Fixed TargetType fall back to type name. #339
- Added custom field binding. #321
  - Added new option `Binding.Field` available in baselines to configure binding.
- Added parameter alias `-f` for `-InputPath`. #340
  - `-f` was added to `Invoke-PSRule`, `Assert-PSRule` and `Test-PSRuleTarget` cmdlets.
- **Important change**: Added `$PSRule` generic context variable. #341
  - Deprecated `TargetName`, `TargetType` and `TargetObject` properties on `$Rule`.
  - Use `TargetName`, `TargetType` and `TargetObject` on `$PSRule` instead.
  - Properties `TargetName`, `TargetType` and `TargetObject` on `$Rule` will be removed in the future.
  - Going forward `$Rule` will only contain properties that relate to the current rule context.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
