### PR TITLE
Pre-release v0.12.0-B1912007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.12.0-B1912007 (pre-release)
+
 - Fixed multiple value tag filtering. [#346](https://github.com/Microsoft/PSRule/issues/346)
 - Added filtering for rules against a baseline with `Get-PSRule`. [#345](https://github.com/Microsoft/PSRule/issues/345)
 


### PR DESCRIPTION
## PR Summary

- Fixed multiple value tag filtering. #346
- Added filtering for rules against a baseline with `Get-PSRule`. #345

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
