### PR TITLE
Added semver assertion helper #344 #353 #354

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Added semantic version assertion helper `Version`. [#344](https://github.com/Microsoft/PSRule/issues/344)
+- Added string affix assertion helpers. [#353](https://github.com/Microsoft/PSRule/issues/353)
+  - Added methods `StartsWith`, `EndsWith` and `Contains`. See `about_PSRule_Assert` for usage details.
+- Added `WithReason` to append/ replace reasons from assertion result. [#354](https://github.com/Microsoft/PSRule/issues/354)
+
 ## v0.12.0
 
 What's changed since v0.11.0:

--- a/README.md
+++ b/README.md
@@ -223,11 +223,15 @@ The following commands exist in the `PSRule` module:
 The following conceptual topics exist in the `PSRule` module:
 
 - [Assert](docs/concepts/PSRule/en-US/about_PSRule_Assert.md)
+  - [Contains](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#contains)
+  - [EndsWith](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#endswith)
   - [HasDefaultValue](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasdefaultvalue)
   - [HasField](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfield)
   - [HasFieldValue](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfieldvalue)
   - [JsonSchema](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#jsonschema)
   - [NullOrEmpty](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#nullorempty)
+  - [StartsWith](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#startswith)
+  - [Version](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#version)
 - [Baselines](docs/concepts/PSRule/en-US/about_PSRule_Baseline.md)
   - [Baseline specs](docs/concepts/PSRule/en-US/about_PSRule_Baseline.md#baseline-specs)
   - [Baseline scopes](docs/concepts/PSRule/en-US/about_PSRule_Baseline.md#baseline-scopes)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -244,7 +244,7 @@ The following parameters are accepted:
 
 - `inputObject` - The object being checked for the specified field.
 - `field` - The name of the field to check. This is a case insensitive compare.
-- `version` (optional) - A version constraint, see below for details of version constrain format.
+- `constraint` (optional) - A version constraint, see below for details of version constrain format.
 
 The following are supported constraints:
 

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -349,6 +349,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The version constraint &apos;{0}&apos; is not valid..
+        /// </summary>
+        internal static string VersionConstraintInvalid {
+            get {
+                return ResourceManager.GetString("VersionConstraintInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The Within parameter Value must be a string when the Like parameter is used..
         /// </summary>
         internal static string WithinLikeNotString {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -221,6 +221,10 @@
   <data name="VariableConditionScope" xml:space="preserve">
     <value>The variable '${0}' can only be used within a Rule block.</value>
   </data>
+  <data name="VersionConstraintInvalid" xml:space="preserve">
+    <value>The version constraint '{0}' is not valid.</value>
+    <comment>When a version constrain is used with $Assert.Version that is invalid.</comment>
+  </data>
   <data name="WithinLikeNotString" xml:space="preserve">
     <value>The Within parameter Value must be a string when the Like parameter is used.</value>
   </data>

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -61,6 +61,24 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not contain &apos;{1}&apos;..
+        /// </summary>
+        internal static string Contains {
+            get {
+                return ResourceManager.GetString("Contains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not end with &apos;{1}&apos;..
+        /// </summary>
+        internal static string EndsWith {
+            get {
+                return ResourceManager.GetString("EndsWith", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to None of the field(s) existed: {0}.
         /// </summary>
         internal static string Exists {
@@ -169,11 +187,38 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not start with &apos;{1}&apos;..
+        /// </summary>
+        internal static string StartsWith {
+            get {
+                return ResourceManager.GetString("StartsWith", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not a string..
+        /// </summary>
+        internal static string String {
+            get {
+                return ResourceManager.GetString("String", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to None of the type name(s) match: {0}.
         /// </summary>
         internal static string TypeOf {
             get {
                 return ResourceManager.GetString("TypeOf", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not a version string..
+        /// </summary>
+        internal static string Version {
+            get {
+                return ResourceManager.GetString("Version", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -223,6 +223,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The version &apos;{0}&apos; does not match the constraint &apos;{1}&apos;..
+        /// </summary>
+        internal static string VersionContraint {
+            get {
+                return ResourceManager.GetString("VersionContraint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The field value didn&apos;t match the set..
         /// </summary>
         internal static string Within {

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -176,6 +176,9 @@
   <data name="Version" xml:space="preserve">
     <value>The field value '{0}' is not a version string.</value>
   </data>
+  <data name="VersionContraint" xml:space="preserve">
+    <value>The version '{0}' does not match the constraint '{1}'.</value>
+  </data>
   <data name="Within" xml:space="preserve">
     <value>The field value didn't match the set.</value>
     <comment>Included when the value does not match the set.</comment>

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Contains" xml:space="preserve">
+    <value>The field '{0}' does not contain '{1}'.</value>
+  </data>
+  <data name="EndsWith" xml:space="preserve">
+    <value>The field '{0}' does not end with '{1}'.</value>
+  </data>
   <data name="Exists" xml:space="preserve">
     <value>None of the field(s) existed: {0}</value>
     <comment>Included when none of the fields exist.</comment>
@@ -157,9 +163,18 @@
   <data name="NullParameter" xml:space="preserve">
     <value>The parameter '{0}' is null.</value>
   </data>
+  <data name="StartsWith" xml:space="preserve">
+    <value>The field '{0}' does not start with '{1}'.</value>
+  </data>
+  <data name="String" xml:space="preserve">
+    <value>The field value '{0}' is not a string.</value>
+  </data>
   <data name="TypeOf" xml:space="preserve">
     <value>None of the type name(s) match: {0}</value>
     <comment>Included when none of the specified type names match.</comment>
+  </data>
+  <data name="Version" xml:space="preserve">
+    <value>The field value '{0}' is not a version string.</value>
   </data>
   <data name="Within" xml:space="preserve">
     <value>The field value didn't match the set.</value>

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -20,12 +20,13 @@ namespace PSRule.Runtime
     /// </summary>
     public sealed class Assert
     {
+        private const string COMMASEPARATOR = ", ";
+
         public AssertResult Create(bool condition, string reason = null)
         {
             if (PipelineContext.CurrentThread.ExecutionScope != ExecutionScope.Condition)
-            {
                 throw new RuleRuntimeException(string.Format(PSRuleResources.VariableConditionScope, "Assert"));
-            }
+
             return new AssertResult(this, condition, reason);
         }
 
@@ -42,16 +43,12 @@ namespace PSRule.Runtime
         public AssertResult JsonSchema(PSObject inputObject, string uri)
         {
             // Guard parameters
-            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(uri, nameof(uri), out result))
-            {
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) || GuardNullOrEmptyParam(uri, nameof(uri), out result))
                 return result;
-            }
 
             // Get the schema
             if (!(TryReadJson(uri, out string schemaContent)))
-            {
                 return Fail(reason: string.Format(ReasonStrings.JsonSchemaNotFound, uri));
-            }
 
             var s = new JsonSerializer();
             JsonSchemaOptions.OutputFormat = SchemaValidationOutputFormat.Basic;
@@ -65,65 +62,47 @@ namespace PSRule.Runtime
 
             // Schema is valid
             if (schemaResults.IsValid)
-            {
                 return Pass();
-            }
 
             // Handle schema invalid
             result = Fail();
 
             if (!string.IsNullOrEmpty(schemaResults.ErrorMessage))
-            {
                 result.AddReason(string.Format(ReasonStrings.JsonSchemaInvalid, schemaResults.InstanceLocation.ToString(), schemaResults.ErrorMessage));
-            }
 
             foreach (var r in schemaResults.NestedResults)
-            {
                 if (!string.IsNullOrEmpty(r.ErrorMessage))
-                {
                     result.AddReason(string.Format(ReasonStrings.JsonSchemaInvalid, r.InstanceLocation.ToString(), r.ErrorMessage));
-                }
-            }
+
             return result;
         }
 
         public AssertResult HasField(PSObject inputObject, string field, bool caseSensitive = false)
         {
             // Guard parameters
-            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
-            {
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, caseSensitive, out object fieldValue, out result))
                 return result;
-            }
 
             // Assert
-            if (!ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: caseSensitive, value: out object fieldValue))
-            {
-                return Fail(string.Format(ReasonStrings.HasField, field));
-            }
             return Pass();
         }
 
         public AssertResult HasFieldValue(PSObject inputObject, string field, object expectedValue = null)
         {
             // Guard parameters
-            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
-            {
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) || GuardNullOrEmptyParam(field, nameof(field), out result))
                 return result;
-            }
 
             // Assert
             if (!ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: false, value: out object fieldValue))
-            {
                 return Fail(string.Format(ReasonStrings.HasField, field));
-            }
             else if (IsEmpty(fieldValue))
-            {
                 return Fail(string.Format(ReasonStrings.HasFieldValue, field));
-            }
             else if (expectedValue != null && !IsValue(fieldValue, expectedValue))
-            {
                 return Fail(string.Format(ReasonStrings.HasExpectedFieldValue, field, fieldValue));
-            }
+
             return Pass();
         }
 
@@ -133,32 +112,108 @@ namespace PSRule.Runtime
         public AssertResult HasDefaultValue(PSObject inputObject, string field, object defaultValue)
         {
             // Guard parameters
-            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
-            {
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) || GuardNullOrEmptyParam(field, nameof(field), out result))
                 return result;
-            }
 
             // Assert
             if (!ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: false, value: out object fieldValue) || IsValue(fieldValue, defaultValue))
-            {
                 return Pass();
-            }
+
             return Fail(string.Format(ReasonStrings.HasExpectedFieldValue, field, fieldValue));
         }
 
         public AssertResult NullOrEmpty(PSObject inputObject, string field)
         {
             // Guard parameters
-            if (TryNull(inputObject, nameof(inputObject), out AssertResult result) || TryNullOrEmpty(field, nameof(field), out result))
-            {
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result))
                 return result;
-            }
 
             // Assert
             if (ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: false, value: out object fieldValue) && !IsEmpty(fieldValue))
-            {
                 return Fail(string.Format(ReasonStrings.NullOrEmpty, field));
-            }
+
+            return Pass();
+        }
+
+        /// <summary>
+        /// The object field value should start with the any of the specified prefixes. Only applies to strings.
+        /// </summary>
+        public AssertResult StartsWith(PSObject inputObject, string field, string[] prefix, bool caseSensitive = false)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, false, out object fieldValue, out result) ||
+                GuardString(fieldValue, out string value, out result))
+                return result;
+
+            // Assert
+            for (var i = 0; i < prefix.Length; i++)
+                if (value.StartsWith(prefix[i], caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+                    return Pass();
+            
+            return Fail(string.Format(ReasonStrings.StartsWith, field, string.Join(COMMASEPARATOR, prefix)));
+        }
+
+        /// <summary>
+        /// The object field value should end with the any of the specified suffix. Only applies to strings.
+        /// </summary>
+        public AssertResult EndsWith(PSObject inputObject, string field, string[] suffix, bool caseSensitive = false)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, false, out object fieldValue, out result) ||
+                GuardString(fieldValue, out string value, out result))
+                return result;
+
+            // Assert
+            for (var i = 0; i < suffix.Length; i++)
+                if (value.EndsWith(suffix[i], caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+                    return Pass();
+
+            return Fail(string.Format(ReasonStrings.EndsWith, field, string.Join(COMMASEPARATOR, suffix)));
+        }
+
+        /// <summary>
+        /// The object field value should contain with the any of the specified text. Only applies to strings.
+        /// </summary>
+        public AssertResult Contains(PSObject inputObject, string field, string[] text, bool caseSensitive = false)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, false, out object fieldValue, out result) ||
+                GuardString(fieldValue, out string value, out result))
+                return result;
+
+            // Assert
+            for (var i = 0; i < text.Length; i++)
+                if (value.IndexOf(text[i], caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) >= 0)
+                    return Pass();
+
+            return Fail(string.Format(ReasonStrings.Contains, field, string.Join(COMMASEPARATOR, text)));
+        }
+
+        /// <summary>
+        /// The object field value should match the version constraint. Only applies to strings.
+        /// </summary>
+        public AssertResult Version(PSObject inputObject, string field, string version = null)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, false, out object fieldValue, out result) ||
+                GuardSemanticVersion(fieldValue, out SemanticVersion.Version value, out result))
+                return result;
+
+            var constraint = Runtime.SemanticVersion.TryParseConstraint(version, out SemanticVersion.Constraint c) ? c : null;
+
+            // Assert
+            if (constraint != null && !constraint.Equals(value))
+                return Fail();
+
             return Pass();
         }
 
@@ -174,42 +229,84 @@ namespace PSRule.Runtime
             // Unwrap as required
             var expectedBase = expectedValue;
             if (expectedValue is PSObject pso)
-            {
                 expectedBase = pso.BaseObject;
-            }
 
             if (fieldValue is string && expectedBase is string)
-            {
                 return StringComparer.OrdinalIgnoreCase.Equals(fieldValue, expectedBase);
-            }
-            else if (expectedBase.Equals(fieldValue))
+
+            return expectedBase.Equals(fieldValue);
+        }
+
+        private bool TryString(object obj, out string value)
+        {
+            value = null;
+            if (obj is string svalue)
             {
+                value = svalue;
                 return true;
             }
-
             return false;
         }
 
-        private bool TryNull(object value, string parameterName, out AssertResult result)
+        private bool GuardNullParam(object value, string parameterName, out AssertResult result)
         {
-            result = value == null ? FailNull(parameterName) : null;
+            result = value == null ? GuardNullParam(parameterName) : null;
             return result != null;
         }
 
-        private bool TryNullOrEmpty(string value, string parameterName, out AssertResult result)
-        {
-            result = string.IsNullOrEmpty(value) ? FailNullOrEmpty(parameterName) : null;
-            return result != null;
-        }
-
-        private AssertResult FailNull(string parameterName)
+        private AssertResult GuardNullParam(string parameterName)
         {
             return Fail(reason: string.Format(ReasonStrings.NullParameter, parameterName));
         }
 
-        private AssertResult FailNullOrEmpty(string parameterName)
+        /// <summary>
+        /// Fails of the value is null or empty.
+        /// </summary>
+        /// <returns>Returns true if the field does not exist.</returns>
+        private bool GuardNullOrEmptyParam(string value, string parameterName, out AssertResult result)
+        {
+            result = string.IsNullOrEmpty(value) ? GuardNullOrEmptyParam(parameterName) : null;
+            return result != null;
+        }
+
+        private AssertResult GuardNullOrEmptyParam(string parameterName)
         {
             return Fail(reason: string.Format(ReasonStrings.NullOrEmptyParameter, parameterName));
+        }
+
+        /// <summary>
+        /// Fails if the field does not exist.
+        /// </summary>
+        /// <returns>Returns true if the field does not exist.</returns>
+        private bool GuardField(PSObject inputObject, string field, bool caseSensitive, out object fieldValue, out AssertResult result)
+        {
+            result = null;
+            if (ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field, caseSensitive: caseSensitive, value: out fieldValue))
+                return false;
+
+            result = Fail(string.Format(ReasonStrings.HasField, field));
+            return true;
+        }
+
+        private bool GuardSemanticVersion(object fieldValue, out SemanticVersion.Version value, out AssertResult result)
+        {
+            result = null;
+            value = null;
+            if (TryString(fieldValue, out string sversion) && Runtime.SemanticVersion.TryParseVersion(sversion, out value))
+                return false;
+
+            result = Fail(string.Format(ReasonStrings.Version, fieldValue));
+            return true;
+        }
+
+        private bool GuardString(object fieldValue, out string value, out AssertResult result)
+        {
+            result = null;
+            if (TryString(fieldValue, out value))
+                return false;
+
+            result = Fail(string.Format(ReasonStrings.String, fieldValue));
+            return true;
         }
 
         private bool TryReadJson(string uri, out string json)
@@ -236,7 +333,6 @@ namespace PSRule.Runtime
                     return true;
                 }
             }
-
             return false;
         }
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -199,7 +199,7 @@ namespace PSRule.Runtime
         /// <summary>
         /// The object field value should match the version constraint. Only applies to strings.
         /// </summary>
-        public AssertResult Version(PSObject inputObject, string field, string version = null)
+        public AssertResult Version(PSObject inputObject, string field, string constraint = null)
         {
             // Guard parameters
             if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
@@ -208,11 +208,11 @@ namespace PSRule.Runtime
                 GuardSemanticVersion(fieldValue, out SemanticVersion.Version value, out result))
                 return result;
 
-            var constraint = Runtime.SemanticVersion.TryParseConstraint(version, out SemanticVersion.Constraint c) ? c : null;
+            Runtime.SemanticVersion.TryParseConstraint(constraint, out SemanticVersion.Constraint c);
 
             // Assert
-            if (constraint != null && !constraint.Equals(value))
-                return Fail();
+            if (c != null && !c.Equals(value))
+                return Fail(string.Format(ReasonStrings.VersionContraint, value, constraint));
 
             return Pass();
         }

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -17,12 +17,10 @@ namespace PSRule.Runtime
         {
             _Assert = assert;
             Result = value;
-
             if (!Result)
             {
                 _Reason = new List<string>();
-                if (!string.IsNullOrEmpty(reason))
-                    _Reason.Add(reason);
+                AddReason(reason);
             }
         }
 
@@ -43,10 +41,24 @@ namespace PSRule.Runtime
         public void AddReason(string text)
         {
             // Ignore reasons if this is a pass.
-            if (Result)
+            if (Result || string.IsNullOrEmpty(text))
                 return;
 
             _Reason.Add(text);
+        }
+
+        /// <summary>
+        /// Adds a reason, and optionally replace existing reasons.
+        /// </summary>
+        /// <param name="text">The text of a reason to add. This text should already be localized for the currently culture.</param>
+        /// <param name="replace">When set to true, existing reasons are cleared.</param>
+        public AssertResult WithReason(string text, bool replace = false)
+        {
+            if (replace && _Reason != null)
+                _Reason.Clear();
+
+            AddReason(text);
+            return this;
         }
 
         /// <summary>
@@ -87,6 +99,14 @@ namespace PSRule.Runtime
         public bool Equals(bool other)
         {
             return Result == other;
+        }
+
+        public override string ToString()
+        {
+            if (_Reason == null)
+                return string.Empty;
+
+            return string.Join(" ", _Reason.ToArray());
         }
     }
 }

--- a/src/PSRule/Runtime/SemanticVersion.cs
+++ b/src/PSRule/Runtime/SemanticVersion.cs
@@ -1,0 +1,445 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Pipeline;
+using PSRule.Resources;
+using System;
+using System.Diagnostics;
+
+namespace PSRule.Runtime
+{
+    /// <summary>
+    /// A helper for comparing semantic version strings.
+    /// </summary>
+    internal static class SemanticVersion
+    {
+        private const char MINOR = '^';
+        private const char PATCH = '~';
+        private const char EQUAL = '=';
+        private const char VUPPER = 'V';
+        private const char VLOWER = 'v';
+        private const char GREATER = '>';
+        private const char LESS = '<';
+        private const char SEPARATOR = '.';
+        private const char DASH = '-';
+        private const char PLUS = '+';
+        private const char ZERO = '0';
+
+        internal enum CompareFlag : byte
+        {
+            None = 0,
+
+            /// <summary>
+            /// Major.Minor.Patch bits must match.
+            /// </summary>
+            Equals = 1,
+
+            /// <summary>
+            /// Major.Minor bits must match, Patch can equal to or greater.
+            /// </summary>
+            PatchUplift = 2,
+
+            /// <summary>
+            /// Major bit must match, Minor.Patch can be equal to or greater.
+            /// </summary>
+            MinorUplift = 4,
+
+            GreaterThan = 8,
+
+            LessThan = 16
+        }
+
+        [DebuggerDisplay("{_Major}.{_Minor}.{_Patch}")]
+        internal sealed class Constraint
+        {
+            private readonly CompareFlag _Flag;
+            private readonly int _Major;
+            private readonly int _Minor;
+            private readonly int _Patch;
+            private readonly string _Prerelease;
+
+            internal Constraint(int major, int minor, int patch, string prerelease, CompareFlag flag)
+            {
+                _Flag = flag == CompareFlag.None ? CompareFlag.Equals : flag;
+                _Major = major;
+                _Minor = minor;
+                _Patch = patch;
+                _Prerelease = prerelease;
+            }
+
+            public static bool TryParse(string value, out Constraint constraint)
+            {
+                return TryParseConstraint(value, out constraint);
+            }
+
+            public bool Equals(System.Version version)
+            {
+                return Equals(version.Major, version.Minor, version.Build, string.Empty);
+            }
+
+            public bool Equals(Version version)
+            {
+                return Equals(version.Major, version.Minor, version.Patch, version.PreRelease);
+            }
+
+            public bool Equals(int major, int minor, int patch, string prerelease)
+            {
+                if (_Flag == CompareFlag.Equals)
+                    return EQ(major, minor, patch, prerelease);
+
+                if ((_Flag == CompareFlag.MinorUplift || _Flag == CompareFlag.PatchUplift) && major != _Major)
+                    return false;
+
+                if (_Flag == CompareFlag.PatchUplift && (minor != _Minor || patch < _Patch))
+                    return false;
+
+                if (_Flag == CompareFlag.MinorUplift && (minor < _Minor || (minor == _Minor && patch < _Patch)))
+                    return false;
+
+                if (_Flag == CompareFlag.GreaterThan && !GT(major, minor, patch, prerelease))
+                    return false;
+
+                if (_Flag == (CompareFlag.GreaterThan | CompareFlag.Equals) && !(GT(major, minor, patch, prerelease) || EQ(major, minor, patch, prerelease)))
+                    return false;
+
+                if (_Flag == CompareFlag.LessThan && !LT(major, minor, patch, prerelease))
+                    return false;
+
+                if (_Flag == (CompareFlag.LessThan | CompareFlag.Equals) && !(LT(major, minor, patch, prerelease) || EQ(major, minor, patch, prerelease)))
+                    return false;
+
+                return true;
+            }
+
+            private bool EQ(int major, int minor, int patch, string prerelease)
+            {
+                return EQCore(major, minor, patch) && PR(prerelease) == 0;
+            }
+
+            private bool EQCore(int major, int minor, int patch)
+            {
+                return (_Major == -1 || _Major == major) && (_Minor == -1 || _Minor == minor) && (_Patch == -1 || _Patch == patch);
+            }
+
+            private bool GT(int major, int minor, int patch, string prerelease)
+            {
+                if (!string.IsNullOrEmpty(prerelease))
+                    return EQCore(major, minor, patch) && PR(prerelease) > 0;
+
+                return (major > _Major) ||
+                    (major == _Major && minor > _Minor) ||
+                    (major == _Major && minor == _Minor && patch > _Patch) ||
+                    (major == _Major && minor == _Minor && patch == _Patch && PR(prerelease) > 0);
+            }
+
+            private bool LT(int major, int minor, int patch, string prerelease)
+            {
+                if (!string.IsNullOrEmpty(prerelease))
+                    return EQCore(major, minor, patch) && PR(prerelease) < 0;
+
+                return major < _Major ||
+                    (major == _Major && minor < _Minor) ||
+                    (major == _Major && minor == _Minor && patch < _Patch) ||
+                    (major == _Major && minor == _Minor && patch == _Patch && PR(prerelease) < 0);
+            }
+
+            private int PR(string prerelease)
+            {
+                if (string.IsNullOrEmpty(prerelease))
+                    return string.IsNullOrEmpty(_Prerelease) ? 0 : 1;
+                else if (string.IsNullOrEmpty(_Prerelease))
+                    return -1;
+
+                if (prerelease.Length == _Prerelease.Length)
+                    return string.Compare(prerelease, _Prerelease);
+
+                var compareLength = prerelease.Length > _Prerelease.Length ? _Prerelease.Length : prerelease.Length;
+                var left = prerelease.Substring(0, compareLength);
+                var right = _Prerelease.Substring(0, compareLength);
+                if (left == right)
+                    return prerelease.Length == compareLength ? -1 : 1;
+
+                return string.Compare(left, right);
+            }
+        }
+
+        internal sealed class Version : IComparable<Version>, IEquatable<Version>
+        {
+            public readonly int Major;
+            public readonly int Minor;
+            public readonly int Patch;
+            public readonly string PreRelease;
+            public readonly string Build;
+
+            internal Version(int major, int minor, int patch, string prerelease, string build)
+            {
+                Major = major;
+                Minor = minor;
+                Patch = patch;
+                PreRelease = prerelease;
+                Build = build;
+            }
+
+            public static bool TryParse(string value, out Version version)
+            {
+                return TryParseVersion(value, out version);
+            }
+
+            public override string ToString()
+            {
+                return string.Concat(Major, '.', Minor, '.', Patch);
+            }
+
+            public bool Equals(Version other)
+            {
+                return other != null &&
+                    Equals(other.Major, other.Minor, other.Patch);
+            }
+
+            public bool Equals(int major, int minor, int patch)
+            {
+                return major == Major &&
+                    minor == Minor &&
+                    patch == Patch;
+            }
+
+            public int CompareTo(Version value)
+            {
+                if (value == null)
+                    return 1;
+
+                if (Major != value.Major)
+                    return Major > value.Major ? 32 : -32;
+
+                if (Minor != value.Minor)
+                    return Minor > value.Minor ? 16 : -16;
+
+                if (Patch != value.Patch)
+                    return Patch > value.Patch ? 8 : -8;
+
+                return 0;
+            }
+        }
+
+        private sealed class VersionStream
+        {
+            private readonly string _Value;
+            private int _Position;
+            private char _Current;
+
+            internal VersionStream(string value)
+            {
+                _Value = value;
+                _Position = 0;
+                _Current = _Value.Length > 0 ? _Value[0] : char.MinValue;
+            }
+
+            internal bool EOF
+            {
+                get { return _Position >= _Value.Length; }
+            }
+
+            internal void Next()
+            {
+                if (EOF || ++_Position >= _Value.Length)
+                    return;
+
+                _Current = _Value[_Position];
+            }
+
+            internal bool TryConstraint(out CompareFlag flag)
+            {
+                SkipLeading();
+                flag = CompareFlag.None;
+                while (!EOF && IsConstraint(_Current))
+                {
+                    if (_Current == MINOR)
+                        flag = CompareFlag.MinorUplift;
+                    else if (_Current == PATCH)
+                        flag = CompareFlag.PatchUplift;
+                    else if (_Current == EQUAL)
+                        flag |= CompareFlag.Equals;
+                    else if (_Current == GREATER)
+                        flag |= CompareFlag.GreaterThan;
+                    else if (_Current == LESS)
+                        flag |= CompareFlag.LessThan;
+
+                    Next();
+                }
+                return flag != CompareFlag.None;
+            }
+
+            private void SkipLeading()
+            {
+                if (!EOF && _Position == 0 && (_Current == EQUAL || _Current == VUPPER || _Current == VLOWER))
+                    Next();
+            }
+
+            internal bool TryDigit(out int digit)
+            {
+                var pos = _Position;
+                var count = 0;
+                while (!EOF && IsVersionDigit(_Current))
+                {
+                    count++;
+                    Next();
+                }
+                digit = count > 0 ? int.Parse(_Value.Substring(pos, count)) : 0;
+                return count > 0;
+            }
+
+            internal bool TrySegments(out int[] segments)
+            {
+                segments = new int[] { -1, -1, -1, -1 };
+                var segmentIndex = 0;
+                while (!EOF)
+                {
+                    if (!IsAllowedChar(_Current))
+                        return false;
+
+                    if (TryDigit(out int digit))
+                        segments[segmentIndex++] = digit;
+
+                    if (IsSeparator(_Current))
+                        Next();
+
+                    if (IsWildcard(_Current))
+                    {
+                        segments[segmentIndex++] = -1;
+                        Next();
+                    }
+
+                    if (_Current == DASH || _Current == PLUS)
+                        return true;
+                }
+                return segmentIndex > 0;
+            }
+
+            internal bool TryPrerelease(out string label)
+            {
+                label = string.Empty;
+                if (EOF || _Current != DASH)
+                    return true;
+
+                Next();
+                var start = _Position;
+                if (_Current == ZERO)
+                    return false;
+
+                while (!EOF && IsPrereleaseChar(_Current))
+                    Next();
+
+                label = _Value.Substring(start, _Position - start);
+                return label.Length > 0;
+            }
+
+            internal bool TryBuild(out string label)
+            {
+                label = string.Empty;
+                if (EOF || _Current != PLUS)
+                    return true;
+
+                Next();
+                var start = _Position;
+                if (_Current == ZERO)
+                    return false;
+
+                while (!EOF && IsBuildChar(_Current))
+                    Next();
+
+                label = _Value.Substring(start, _Position - start);
+                return label.Length > 0;
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsConstraint(char c)
+            {
+                return c == MINOR || c == PATCH || c == EQUAL || c == GREATER || c == LESS;
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsVersionDigit(char c)
+            {
+                return char.IsDigit(c);
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsWildcard(char c)
+            {
+                return c == '*' || c == 'X' || c == 'x';
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsSeparator(char c)
+            {
+                return c == SEPARATOR;
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsAllowedChar(char c)
+            {
+                return IsVersionDigit(c) || IsSeparator(c) || IsWildcard(c) || c == DASH || c == PLUS;
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsPrereleaseChar(char c)
+            {
+                return char.IsDigit(c) || IsLetter(c) || c == DASH || c == SEPARATOR;
+            }
+
+            [DebuggerStepThrough()]
+            private static bool IsBuildChar(char c)
+            {
+                return char.IsDigit(c) || IsLetter(c);
+            }
+
+            /// <summary>
+            /// Is the character within the reduced set of allowed characters. a-z or A-Z.
+            /// </summary>
+            [DebuggerStepThrough()]
+            private static bool IsLetter(char c)
+            {
+                var nc = (int)c;
+                return (nc >= 0x41 && nc <= 0x5a) || (nc >= 0x61 && nc <= 0x7a);
+            }
+        }
+
+        public static bool TryParseConstraint(string value, out Constraint constraint)
+        {
+            constraint = null;
+            if (string.IsNullOrEmpty(value))
+                return true;
+
+            var stream = new VersionStream(value);
+            while (!stream.EOF)
+            {
+                stream.TryConstraint(out CompareFlag flag);
+                if (!stream.TrySegments(out int[] segments))
+                    throw new RuleRuntimeException(string.Format(PSRuleResources.VersionConstraintInvalid, value));
+
+                if (!stream.TryPrerelease(out string prerelease) || !stream.TryBuild(out _) || !stream.EOF)
+                    throw new RuleRuntimeException(string.Format(PSRuleResources.VersionConstraintInvalid, value));
+
+                constraint = new Constraint(segments[0], segments[1], segments[2], prerelease, flag);
+            }
+            return true;
+        }
+
+        public static bool TryParseVersion(string value, out Version version)
+        {
+            version = null;
+            if (string.IsNullOrEmpty(value))
+                return false;
+
+            var stream = new VersionStream(value);
+            if (!stream.TrySegments(out int[] segments))
+                return false;
+
+            stream.TryPrerelease(out string prerelease);
+            stream.TryBuild(out string build);
+
+            version = new Version(segments[0], segments[1], segments[2], prerelease, build);
+            return true;
+        }
+    }
+}

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Pipeline;
+using System;
+using System.Management.Automation;
+using Xunit;
+
+namespace PSRule
+{
+    [Trait(LANGUAGE, LANGUAGEELEMENT)]
+    public sealed class AssertTests
+    {
+        private const string LANGUAGE = "Language";
+        private const string LANGUAGEELEMENT = "Variable";
+
+        [Fact]
+        public void Assertion()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var actual1 = assert.Create(false, "Test reason");
+            var actual2 = assert.Create(true, "Test reason");
+            Assert.Equal("Test reason", actual1.ToString());
+            Assert.False(actual1.Result);
+            Assert.Equal(string.Empty, actual2.ToString());
+            Assert.True(actual2.Result);
+
+            actual1.WithReason("Alternate reason");
+            Assert.Equal("Test reason Alternate reason", actual1.ToString());
+            actual1.WithReason("Alternate reason", true);
+            Assert.Equal("Alternate reason", actual1.ToString());
+        }
+
+        [Fact]
+        public void StartsWith()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject((name: "name", value: "abcdefg"), (name: "value", value: 123));
+
+            Assert.True(assert.StartsWith(value, "name", new string[] { "123", "ab" }).Result);
+            Assert.True(assert.StartsWith(value, "name", new string[] { "123", "ab" }, caseSensitive: true).Result);
+            Assert.True(assert.StartsWith(value, "name", new string[] { "ABC" }).Result);
+            Assert.False(assert.StartsWith(value, "name", new string[] { "123", "cd" }).Result);
+            Assert.False(assert.StartsWith(value, "name", new string[] { "123", "fg" }).Result);
+            Assert.False(assert.StartsWith(value, "name", new string[] { "abcdefgh" }).Result);
+            Assert.False(assert.StartsWith(value, "name", new string[] { "ABC" }, caseSensitive: true).Result);
+            Assert.False(assert.StartsWith(value, "name", new string[] { "123", "cd" }).Result);
+        }
+
+        [Fact]
+        public void EndsWith()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject((name: "name", value: "abcdefg"), (name: "value", value: 123));
+
+            Assert.True(assert.EndsWith(value, "name", new string[] { "123", "fg" }).Result);
+            Assert.True(assert.EndsWith(value, "name", new string[] { "123", "fg" }, caseSensitive: true).Result);
+            Assert.True(assert.EndsWith(value, "name", new string[] { "EFG" }).Result);
+            Assert.False(assert.EndsWith(value, "name", new string[] { "123", "cd" }).Result);
+            Assert.False(assert.EndsWith(value, "name", new string[] { "123", "ab" }).Result);
+            Assert.False(assert.EndsWith(value, "name", new string[] { "abcdefgh" }).Result);
+            Assert.False(assert.EndsWith(value, "name", new string[] { "EFG" }, caseSensitive: true).Result);
+            Assert.False(assert.EndsWith(value, "name", new string[] { "123", "cd" }).Result);
+        }
+
+        [Fact]
+        public void Contains()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject((name: "name", value: "abcdefg"), (name: "value", value: 123));
+
+            Assert.True(assert.Contains(value, "name", new string[] { "123", "ab" }).Result);
+            Assert.True(assert.Contains(value, "name", new string[] { "123", "ab" }, caseSensitive: true).Result);
+            Assert.True(assert.Contains(value, "name", new string[] { "ABC" }).Result);
+            Assert.True(assert.Contains(value, "name", new string[] { "123", "cd" }).Result);
+            Assert.True(assert.Contains(value, "name", new string[] { "123", "fg" }).Result);
+            Assert.False(assert.Contains(value, "name", new string[] { "abcdefgh" }).Result);
+            Assert.False(assert.Contains(value, "name", new string[] { "ABC" }, caseSensitive: true).Result);
+            Assert.True(assert.Contains(value, "name", new string[] { "123", "cd" }).Result);
+        }
+
+        [Fact]
+        public void Version()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject(
+                (name: "version", value: "1.2.3"),
+                (name: "version2", value: "1.2.3-alpha.7"),
+                (name: "version3", value: "3.4.5-alpha.9"),
+                (name: "notversion", value: "x.y.z")
+            );
+
+            Assert.True(assert.Version(value, "version", "1.2.3").Result);
+            Assert.False(assert.Version(value, "version", "0.2.3").Result);
+            Assert.False(assert.Version(value, "version", "2.2.3").Result);
+            Assert.False(assert.Version(value, "version", "1.1.3").Result);
+            Assert.False(assert.Version(value, "version", "1.3.3").Result);
+            Assert.False(assert.Version(value, "version", "1.2.2").Result);
+            Assert.False(assert.Version(value, "version", "1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", "v1.2.3").Result);
+            Assert.True(assert.Version(value, "version", "V1.2.3").Result);
+            Assert.True(assert.Version(value, "version", "=1.2.3").Result);
+            Assert.False(assert.Version(value, "version", "=0.2.3").Result);
+            Assert.False(assert.Version(value, "version", "=2.2.3").Result);
+            Assert.False(assert.Version(value, "version", "=1.1.3").Result);
+            Assert.False(assert.Version(value, "version", "=1.3.3").Result);
+            Assert.False(assert.Version(value, "version", "=1.2.2").Result);
+            Assert.False(assert.Version(value, "version", "=1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", "^1.2.3").Result);
+            Assert.False(assert.Version(value, "version", "^0.2.3").Result);
+            Assert.False(assert.Version(value, "version", "^2.2.3").Result);
+            Assert.True(assert.Version(value, "version", "^1.1.3").Result);
+            Assert.False(assert.Version(value, "version", "^1.3.3").Result);
+            Assert.True(assert.Version(value, "version", "^1.2.2").Result);
+            Assert.False(assert.Version(value, "version", "^1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", "~1.2.3").Result);
+            Assert.False(assert.Version(value, "version", "~0.2.3").Result);
+            Assert.False(assert.Version(value, "version", "~2.2.3").Result);
+            Assert.False(assert.Version(value, "version", "~1.1.3").Result);
+            Assert.False(assert.Version(value, "version", "~1.3.3").Result);
+            Assert.True(assert.Version(value, "version", "~1.2.2").Result);
+            Assert.False(assert.Version(value, "version", "~1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", "1.x").Result);
+            Assert.True(assert.Version(value, "version", "1.X.x").Result);
+            Assert.True(assert.Version(value, "version", "1.*").Result);
+            Assert.True(assert.Version(value, "version", "*").Result);
+            Assert.True(assert.Version(value, "version", "").Result);
+            Assert.True(assert.Version(value, "version").Result);
+            Assert.False(assert.Version(value, "version", "1.3.x").Result);
+
+            Assert.False(assert.Version(value, "version", ">1.2.3").Result);
+            Assert.True(assert.Version(value, "version", ">0.2.3").Result);
+            Assert.False(assert.Version(value, "version", ">2.2.3").Result);
+            Assert.True(assert.Version(value, "version", ">1.1.3").Result);
+            Assert.False(assert.Version(value, "version", ">1.3.3").Result);
+            Assert.True(assert.Version(value, "version", ">1.2.2").Result);
+            Assert.False(assert.Version(value, "version", ">1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", ">=1.2.3").Result);
+            Assert.True(assert.Version(value, "version", ">=0.2.3").Result);
+            Assert.False(assert.Version(value, "version", ">=2.2.3").Result);
+            Assert.True(assert.Version(value, "version", ">=1.1.3").Result);
+            Assert.False(assert.Version(value, "version", ">=1.3.3").Result);
+            Assert.True(assert.Version(value, "version", ">=1.2.2").Result);
+            Assert.False(assert.Version(value, "version", ">=1.2.4").Result);
+
+            Assert.False(assert.Version(value, "version", "<1.2.3").Result);
+            Assert.False(assert.Version(value, "version", "<0.2.3").Result);
+            Assert.True(assert.Version(value, "version", "<2.2.3").Result);
+            Assert.False(assert.Version(value, "version", "<1.1.3").Result);
+            Assert.True(assert.Version(value, "version", "<1.3.3").Result);
+            Assert.False(assert.Version(value, "version", "<1.2.2").Result);
+            Assert.True(assert.Version(value, "version", "<1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", "<=1.2.3").Result);
+            Assert.False(assert.Version(value, "version", "<=0.2.3").Result);
+            Assert.True(assert.Version(value, "version", "<=2.2.3").Result);
+            Assert.False(assert.Version(value, "version", "<=1.1.3").Result);
+            Assert.True(assert.Version(value, "version", "<=1.3.3").Result);
+            Assert.False(assert.Version(value, "version", "<=1.2.2").Result);
+            Assert.True(assert.Version(value, "version", "<=1.2.4").Result);
+
+            Assert.True(assert.Version(value, "version", ">1.0.0").Result);
+            Assert.True(assert.Version(value, "version", "<2.0.0").Result);
+
+            Assert.True(assert.Version(value, "version", ">1.2.3-alpha.3").Result);
+            Assert.True(assert.Version(value, "version2", ">1.2.3-alpha.3").Result);
+            Assert.False(assert.Version(value, "version3", ">1.2.3-alpha.3").Result);
+
+            Assert.False(assert.Version(value, "notversion", null).Result);
+            Assert.Throws<RuleRuntimeException>(() => assert.Version(value, "version", "2.0.0<").Result);
+            Assert.Throws<RuleRuntimeException>(() => assert.Version(value, "version", "z2.0.0").Result);
+        }
+
+        private static void SetContext()
+        {
+            var context = PipelineContext.New(null, new Configuration.PSRuleOption(), null, null, null, null);
+            context.ExecutionScope = ExecutionScope.Condition;
+        }
+
+        private static PSObject GetObject(params (string name, object value)[] properties)
+        {
+            var result = new PSObject();
+            for (var i = 0; properties != null && i < properties.Length; i++)
+                result.Properties.Add(new PSNoteProperty(properties[i].Item1, properties[i].Item2));
+
+            return result;
+        }
+
+        private static Runtime.Assert GetAssertionHelper()
+        {
+            return new Runtime.Assert();
+        }
+    }
+}

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -57,10 +57,8 @@ Rule 'Assert.HasDefaultValue' {
 
 # Synopsis: Test for $Assert.HasEmptyField
 Rule 'Assert.NullOrEmpty' {
-    AllOf {
-        $Assert.NullOrEmpty($TargetObject, 'Type')
-        $Assert.NullOrEmpty($TargetObject, 'Value')
-        $Assert.NullOrEmpty($TargetObject, 'String')
-        $Assert.NullOrEmpty($TargetObject, 'Array')
-    }
+    $Assert.NullOrEmpty($TargetObject, 'Type')
+    $Assert.NullOrEmpty($TargetObject, 'Value')
+    $Assert.NullOrEmpty($TargetObject, 'String')
+    $Assert.NullOrEmpty($TargetObject, 'Array')
 }

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -23,6 +23,16 @@ Rule 'Assert.Complete' {
         $Assert.HasField($TargetObject, 'OtherField').Complete()
 }
 
+# Synopsis: Test for $Assert.Contains
+Rule 'Assert.Contains' {
+    $Assert.Contains($TargetObject, 'OtherField', @('abc', 'th'))
+}
+
+# Synopsis: Test for $Assert.EndsWith
+Rule 'Assert.EndsWith' {
+    $Assert.EndsWith($TargetObject, 'Name', '1')
+}
+
 # Synopsis: Test for $Assert.JsonSchema
 Rule 'Assert.JsonSchema' {
     $Assert.JsonSchema($TargetObject, 'tests/PSRule.Tests/FromFile.Json.schema.json')
@@ -61,4 +71,14 @@ Rule 'Assert.NullOrEmpty' {
     $Assert.NullOrEmpty($TargetObject, 'Value')
     $Assert.NullOrEmpty($TargetObject, 'String')
     $Assert.NullOrEmpty($TargetObject, 'Array')
+}
+
+# Synopsis: Test for $Assert.StartsWith
+Rule 'Assert.StartsWith' {
+    $Assert.StartsWith($TargetObject, 'Version', '2.0')
+}
+
+# Synopsis: Test for $Assert.Version
+Rule 'Assert.Version' {
+    $Assert.Version($TargetObject, 'Version', '>1.0.0')
 }

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -40,6 +40,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 OtherField = 'Other'
                 Int = 1
                 Bool = $True
+                Version = '2.0.0'
             }
             [PSCustomObject]@{
                 Name = 'TestObject2'
@@ -51,6 +52,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 Bool = $False
                 OtherBool = $False
                 OtherInt = 2
+                Version = '1.0.0'
             }
         )
 
@@ -68,6 +70,38 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[1].TargetName | Should -Be 'TestObject2';
             $result[1].Reason.Length | Should -Be 1;
             $result[1].Reason | Should -Be 'The field ''Type'' does not exist.';
+        }
+
+        It 'Contains' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Contains');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 1;
+            $result[1].Reason | Should -BeLike "The field '*' does not exist.";
+        }
+
+        It 'EndsWith' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.EndsWith');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 1;
+            $result[1].Reason | Should -BeLike "The field '*' does not end with '*'.";
         }
 
         It 'JsonSchema' {
@@ -150,6 +184,38 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[0].TargetName | Should -Be 'TestObject1';
             $result[0].Reason.Length | Should -Be 4;
             $result[0].Reason | Should -BeLike "The field '*' is not empty.";
+        }
+
+        It 'StartsWith' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.StartsWith');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 1;
+            $result[1].Reason | Should -BeLike "The field '*' does not start with '*'.";
+        }
+
+        It 'Version' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Version');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 1;
+            $result[1].Reason | Should -BeLike "The version '*' does not match the constraint '*'.";
         }
     }
 

--- a/tests/PSRule.Tests/SemanticVersionTests.cs
+++ b/tests/PSRule.Tests/SemanticVersionTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class SemanticVersionTests
+    {
+        [Fact]
+        public void Version()
+        {
+            Assert.True(Runtime.SemanticVersion.TryParseVersion("1.2.3-alpha.3+7223b39", out Runtime.SemanticVersion.Version actual1));
+            Assert.Equal(1, actual1.Major);
+            Assert.Equal(2, actual1.Minor);
+            Assert.Equal(3, actual1.Patch);
+            Assert.Equal("alpha.3", actual1.PreRelease);
+            Assert.Equal("7223b39", actual1.Build);
+        }
+
+        [Fact]
+        public void Constraint()
+        {
+            Runtime.SemanticVersion.TryParseVersion("1.2.3", out Runtime.SemanticVersion.Version version1);
+            Runtime.SemanticVersion.TryParseVersion("1.2.3-alpha.3+7223b39", out Runtime.SemanticVersion.Version version2);
+            Runtime.SemanticVersion.TryParseVersion("3.4.5-alpha.9", out Runtime.SemanticVersion.Version version3);
+            Runtime.SemanticVersion.TryParseVersion("3.4.5", out Runtime.SemanticVersion.Version version4);
+
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("1.2.3", out Runtime.SemanticVersion.Constraint actual1));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("1.2.3-alpha.3", out Runtime.SemanticVersion.Constraint actual2));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint(">1.2.3-alpha.3", out Runtime.SemanticVersion.Constraint actual3));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint(">1.2.3-alpha.1", out Runtime.SemanticVersion.Constraint actual4));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("<1.2.3-beta", out Runtime.SemanticVersion.Constraint actual5));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("^1.2.3-alpha", out Runtime.SemanticVersion.Constraint actual6));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("<3.4.6", out Runtime.SemanticVersion.Constraint actual7));
+
+            Assert.True(actual1.Equals(version1));
+            Assert.False(actual2.Equals(version1));
+            Assert.True(actual3.Equals(version1));
+            Assert.True(actual4.Equals(version1));
+            Assert.False(actual5.Equals(version1));
+            Assert.True(actual6.Equals(version1));
+            Assert.True(actual7.Equals(version1));
+
+            Assert.False(actual1.Equals(version2));
+            Assert.True(actual2.Equals(version2));
+            Assert.False(actual3.Equals(version2));
+            Assert.True(actual4.Equals(version2));
+            Assert.True(actual5.Equals(version2));
+            Assert.True(actual6.Equals(version2));
+            Assert.False(actual7.Equals(version2));
+
+            Assert.False(actual1.Equals(version3));
+            Assert.False(actual2.Equals(version3));
+            Assert.False(actual3.Equals(version3));
+            Assert.False(actual4.Equals(version3));
+            Assert.False(actual5.Equals(version3));
+            Assert.False(actual6.Equals(version3));
+            Assert.False(actual7.Equals(version3));
+
+            Assert.False(actual1.Equals(version4));
+            Assert.False(actual2.Equals(version4));
+            Assert.True(actual3.Equals(version4));
+            Assert.True(actual4.Equals(version4));
+            Assert.False(actual5.Equals(version4));
+            Assert.False(actual6.Equals(version4));
+            Assert.True(actual7.Equals(version4));
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added semantic version assertion helper `Version`. #344
- Added string affix assertion helpers. #353
  - Added methods `StartsWith`, `EndsWith` and `Contains`. See `about_PSRule_Assert` for usage details.
- Added `WithReason` to append/ replace reasons from assertion result. #354

Fixes #344 
Fixes #353 
Fixes #354 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
