### PR TITLE
Pre-release v0.13.0-B1912005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0-B1912005 (pre-release)
+
 - Added semantic version assertion helper `Version`. [#344](https://github.com/Microsoft/PSRule/issues/344)
 - Added string affix assertion helpers. [#353](https://github.com/Microsoft/PSRule/issues/353)
   - Added methods `StartsWith`, `EndsWith` and `Contains`. See `about_PSRule_Assert` for usage details.


### PR DESCRIPTION
## PR Summary

- Added semantic version assertion helper `Version`. #344
- Added string affix assertion helpers. #353
  - Added methods `StartsWith`, `EndsWith` and `Contains`. See `about_PSRule_Assert` for usage details.
- Added `WithReason` to append/ replace reasons from assertion result. #354

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
