### PR TITLE
Disable flaky PSScriptAnalyzer tests #299

### DIFF
--- a/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
@@ -57,19 +57,19 @@ Describe 'PSRule' -Tag 'PowerShellGallery' {
         }
     }
 
-    Context 'Static analysis' {
-        It 'Has no quality errors' {
-            $modulePath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule);
-            $result = @(Invoke-ScriptAnalyzer -Path $modulePath -Verbose);
+    # Context 'Static analysis' {
+    #     It 'Has no quality errors' {
+    #         $modulePath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule);
+    #         $result = @(Invoke-ScriptAnalyzer -Path $modulePath -Verbose);
 
-            $warningCount = ($result | Where-Object { $_.Severity -eq 'Warning' } | Measure-Object).Count;
-            $errorCount = ($result | Where-Object { $_.Severity -eq 'Error' } | Measure-Object).Count;
+    #         $warningCount = ($result | Where-Object { $_.Severity -eq 'Warning' } | Measure-Object).Count;
+    #         $errorCount = ($result | Where-Object { $_.Severity -eq 'Error' } | Measure-Object).Count;
 
-            if ($warningCount -gt 0) {
-                Write-Warning -Message "PSScriptAnalyzer reports $warningCount warnings.";
-            }
+    #         if ($warningCount -gt 0) {
+    #             Write-Warning -Message "PSScriptAnalyzer reports $warningCount warnings.";
+    #         }
 
-            $errorCount | Should -BeLessOrEqual 0;
-        }
-    }
+    #         $errorCount | Should -BeLessOrEqual 0;
+    #     }
+    # }
 }


### PR DESCRIPTION
## PR Summary

- PSScriptAnalyzer tests intermittently fail based on an exception occurring between PSScriptAnalyzer and PowerShell. These tests will be disabled until the upstream issue can be resolved. #229

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
