### PR TITLE
Added input format for PowerShell data files #368

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added input format for reading PowerShell data `.psd1` files. [#368](https://github.com/Microsoft/PSRule/issues/368)
+  - `PowerShellData` has been added to `Input.Format`.
+  - See `about_PSRule_Options` for details.
+
 ## v0.13.0-B1912027 (pre-release)
 
 - Added configuration helper for strings arrays. [#363](https://github.com/Microsoft/PSRule/issues/363)

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -105,10 +105,13 @@ Accept wildcard characters: False
 Configures the input format for when a string is passed in as a target object.
 
 When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
-Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+Set this option to either `Yaml`, `Json`, `Markdown`, `PowerShellData` to have PSRule deserialize the object.
 
 When the `-InputPath` parameter is used with a file path or URL.
-If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+If the `Detect` format is used, the file extension will be used to automatically detect the format.
+When `-InputPath` is not used, `Detect` is the same as `None`.
+
+See `about_PSRule_Options` for details.
 
 This parameter takes precedence over the `Input.Format` option if set.
 
@@ -116,7 +119,7 @@ This parameter takes precedence over the `Input.Format` option if set.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Markdown, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -265,10 +265,13 @@ Accept wildcard characters: False
 Configures the input format for when a string is passed in as a target object.
 
 When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
-Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+Set this option to either `Yaml`, `Json`, `Markdown`, `PowerShellData` to have PSRule deserialize the object.
 
 When the `-InputPath` parameter is used with a file path or URL.
-If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+If the `Detect` format is used, the file extension will be used to automatically detect the format.
+When `-InputPath` is not used, `Detect` is the same as `None`.
+
+See `about_PSRule_Options` for details.
 
 This parameter takes precedence over the `Input.Format` option if set.
 
@@ -276,7 +279,7 @@ This parameter takes precedence over the `Input.Format` option if set.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Markdown, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -306,6 +306,7 @@ Sets the `Input.Format` option to configure the input format for when a string i
 Type: InputFormat
 Parameter Sets: (All)
 Aliases: InputFormat
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -256,7 +256,7 @@ Sets the `Input.Format` option to configure the input format for when a string i
 Type: InputFormat
 Parameter Sets: (All)
 Aliases: InputFormat
-Accepted values: None, Yaml, Json, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -175,10 +175,13 @@ Accept wildcard characters: False
 Configures the input format for when a string is passed in as a target object.
 
 When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
-Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
+Set this option to either `Yaml`, `Json`, `Markdown`, `PowerShellData` to have PSRule deserialize the object.
 
 When the `-InputPath` parameter is used with a file path or URL.
-If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+If the `Detect` format is used, the file extension will be used to automatically detect the format.
+When `-InputPath` is not used, `Detect` is the same as `None`.
+
+See `about_PSRule_Options` for details.
 
 This parameter takes precedence over the `Input.Format` option if set.
 
@@ -186,7 +189,7 @@ This parameter takes precedence over the `Input.Format` option if set.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Markdown, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -439,10 +439,7 @@ Configures the input format for when a string is passed in as a target object.
 Use this option with `Assert-PSRule`, `Invoke-PSRule` or `Test-PSRuleTarget`.
 
 When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
-Set this option to either `Yaml`, `Json` or `Markdown` to have PSRule deserialize the object.
-
-When the `-InputPath` parameter is used with a file path or URL.
-If the `Detect` format is used, the file extension (either `.yaml`, `.yml`, `.json` or `.md`) will be used to automatically detect the format as YAML, JSON or Markdown.
+Set this option to either `Yaml`, `Json`, `Markdown`, `PowerShellData` to have PSRule deserialize the object.
 
 The `-Format` parameter will override any value set in configuration.
 
@@ -452,10 +449,19 @@ The following formats are available:
 - Yaml - Treat strings as one or more YAML objects.
 - Json - Treat strings as one or more JSON objects.
 - Markdown - Treat strings as a markdown object.
-- Detect - Detect format based on file extension.
+- PowerShellData - Treat strings as a PowerShell data object.
+- Detect - Detect format based on file extension. This is the default.
 
-Detection only applies when used with the `-InputPath` parameter.
-In all other cases, `Detect` is the same as `None`. This is the default configuration.
+When the `-InputPath` parameter is used with a file path or URL.
+If the `Detect` format is used, the file extension will be used to automatically detect the format.
+When `-InputPath` is not used, `Detect` is the same as `None`.
+
+Detect uses matches the following file extensions:
+
+- Yaml - `.yaml` or `.yml`
+- Json - `.json`
+- Markdown - `.md`
+- PowerShellData - `.psd1`
 
 The `Markdown` format does not parse the whole markdown document.
 Specifically this format deserializes YAML front matter from the top of the document if any exists.

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -102,6 +102,7 @@
                         "Yaml",
                         "Json",
                         "Markdown",
+                        "PowerShellData",
                         "Detect"
                     ],
                     "default": "Detect"

--- a/src/PSRule/Configuration/InputFormat.cs
+++ b/src/PSRule/Configuration/InputFormat.cs
@@ -20,6 +20,8 @@ namespace PSRule.Configuration
 
         Markdown = 3,
 
+        PowerShellData = 4,
+
         Detect = 255
     }
 }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -46,7 +46,7 @@ function Invoke-PSRule {
         [PSRule.Configuration.ResultFormat]$As = [PSRule.Configuration.ResultFormat]::Detail,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format = [PSRule.Configuration.InputFormat]::Detect,
 
         [Parameter(Mandatory = $False)]
@@ -218,7 +218,7 @@ function Test-PSRuleTarget {
         [PSRule.Rules.RuleOutcome]$Outcome = [PSRule.Rules.RuleOutcome]::Processed,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format,
 
         # A list of paths to check for rule definitions
@@ -367,7 +367,7 @@ function Assert-PSRule {
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [PSRule.Configuration.InputFormat]$Format = [PSRule.Configuration.InputFormat]::Detect,
 
         [Parameter(Mandatory = $False)]
@@ -917,7 +917,7 @@ function New-PSRuleOption {
 
         # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
@@ -1091,7 +1091,7 @@ function Set-PSRuleOption {
 
         # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
@@ -1663,7 +1663,7 @@ function SetOptions {
 
         # Sets the Input.Format option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'Detect')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -168,6 +168,13 @@ namespace PSRule.Pipeline
                     return PipelineReceiverActions.ConvertFromMarkdown(sourceObject, next);
                 });
             }
+            else if (Option.Input.Format == InputFormat.PowerShellData)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromPowerShellData(sourceObject, next);
+                });
+            }
             else if (Option.Input.Format == InputFormat.Detect && _InputPath != null)
             {
                 AddVisitTargetObjectAction((sourceObject, next) =>

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -124,7 +124,7 @@ namespace PSRule.Pipeline
         /// </summary>
         private static bool TryGetTargetName(PSObject targetObject, string propertyName, out string targetName)
         {
-            targetName = targetObject.Properties[propertyName]?.Value?.ToString();
+            targetName = targetObject.ValueAsString(propertyName, false);
             return targetName != null;
         }
 

--- a/src/PSRule/Runtime/ObjectHelper.cs
+++ b/src/PSRule/Runtime/ObjectHelper.cs
@@ -134,6 +134,14 @@ namespace PSRule.Runtime
             }
         }
 
+        public static bool GetField(PSObject targetObject, string name, bool caseSensitive, out object value)
+        {
+            if (targetObject.BaseObject != null && targetObject.BaseObject is IDictionary dictionary)
+                return TryDictionary(dictionary, name, caseSensitive, out value);
+
+            return TryPropertyValue(targetObject, name, caseSensitive, out value);
+        }
+
         public static bool GetField(IBindingContext bindingContext, object targetObject, string name, bool caseSensitive, out object value)
         {
             // Try to load nameToken from cache

--- a/tests/PSRule.Tests/InputFormatDeserializerTests.cs
+++ b/tests/PSRule.Tests/InputFormatDeserializerTests.cs
@@ -18,33 +18,73 @@ namespace PSRule
             var actual = PipelineReceiverActions.ConvertFromYaml(GetYamlContent(), PipelineReceiverActions.PassThru).ToArray();
 
             Assert.Equal(2, actual.Length);
-            Assert.Equal("TestObject1", actual[0].Properties["targetName"].Value);
-            Assert.Equal("Test", actual[0].PropertyValue<PSObject>("spec").PropertyValue<PSObject>("properties").PropertyValue<string>("kind"));
-            Assert.Equal(2, actual[1].PropertyValue<PSObject>("spec").PropertyValue<PSObject>("properties").PropertyValue<int>("value2"));
-            Assert.Equal(2, actual[1].PropertyValue<PSObject>("spec").PropertyValue<PSObject>("properties").PropertyValue<PSObject[]>("array").Length);
+            Assert.Equal("TestObject1", actual[0].PropertyValue<string>("targetName"));
+            Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
+            Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value2"));
+            Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<PSObject[]>("array").Length);
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
         }
 
         [Fact]
-        public void DeserialObjectsJson()
+        public void DeserializeObjectsJson()
         {
             var actual = PipelineReceiverActions.ConvertFromJson(GetJsonContent(), PipelineReceiverActions.PassThru).ToArray();
 
             Assert.Equal(2, actual.Length);
-            Assert.Equal("TestObject1", actual[0].Properties["targetName"].Value);
-            Assert.Equal("Test", actual[0].PropertyValue<PSObject>("spec").PropertyValue<PSObject>("properties").PropertyValue<string>("kind"));
-            Assert.Equal(2, actual[1].PropertyValue<PSObject>("spec").PropertyValue<PSObject>("properties").PropertyValue<int>("value2"));
-            Assert.Equal(2, actual[1].PropertyValue<PSObject>("spec").PropertyValue<PSObject>("properties").PropertyValue<PSObject[]>("array").Length);
+            Assert.Equal("TestObject1", actual[0].PropertyValue<string>("targetName"));
+            Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
+            Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value2"));
+            Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<PSObject[]>("array").Length);
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
         }
 
-        private string GetYamlContent()
+        [Fact]
+        public void DeserializeObjectsMarkdown()
+        {
+            var actual = PipelineReceiverActions.ConvertFromMarkdown(GetMarkdownContent(), PipelineReceiverActions.PassThru).ToArray();
+
+            Assert.Single(actual);
+            Assert.Equal("TestObject1", actual[0].PropertyValue<string>("targetName"));
+            Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
+            Assert.Equal(1, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value1"));
+            Assert.Equal(2, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<PSObject[]>("array").Length);
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
+        }
+
+        [Fact]
+        public void DeserializeObjectsPowerShellData()
+        {
+            var actual = PipelineReceiverActions.ConvertFromPowerShellData(GetDataContent(), PipelineReceiverActions.PassThru).ToArray();
+
+            Assert.Single(actual);
+            Assert.Equal("TestObject1", actual[0].PropertyValue<string>("targetName"));
+            Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
+            Assert.Equal(1, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value1"));
+            Assert.Equal(2, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<Array>("array").Length);
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
+        }
+
+        private static string GetYamlContent()
         {
             var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ObjectFromFile.yaml");
             return File.ReadAllText(path);
         }
 
-        private string GetJsonContent()
+        private static string GetJsonContent()
         {
             var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ObjectFromFile.json");
+            return File.ReadAllText(path);
+        }
+
+        private static string GetMarkdownContent()
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ObjectFromFile.md");
+            return File.ReadAllText(path);
+        }
+
+        private static string GetDataContent()
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ObjectFromFile.psd1");
             return File.ReadAllText(path);
         }
     }

--- a/tests/PSRule.Tests/ObjectFromFile.psd1
+++ b/tests/PSRule.Tests/ObjectFromFile.psd1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# An object described in a PowerShell data file for unit testing
+
+@{
+    targetName = 'TestObject1'
+    spec = @{
+        properties = @{
+            value1 = 1
+            kind = 'Test'
+            array = @(
+                @{
+                    id = 1
+                },
+                @{
+                    id = 2
+                }
+            )
+            array2 = @(
+                "1"
+                "2"
+                "3"
+            )
+        }
+    }
+}

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -360,6 +360,26 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result.TargetName | Should -BeIn 'TestObject1';
             $result.IsSuccess() | Should -Be $True;
         }
+
+        It 'PowerShellData String' {
+            $data = Get-Content -Path (Join-Path -Path $here -ChildPath 'ObjectFromFile.psd1') -Raw;
+            $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputObject $data -Format PowerShellData);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 1;
+            $result | Should -BeOfType PSRule.Rules.RuleRecord;
+            $result.TargetName | Should -BeIn 'TestObject1';
+            $result.IsSuccess() | Should -Be $True;
+        }
+
+        It 'PowerShellData FileInfo' {
+            $file = Get-ChildItem -Path (Join-Path -Path $here -ChildPath 'ObjectFromFile.psd1') -File;
+            $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputObject $file -Format PowerShellData);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 1;
+            $result | Should -BeOfType PSRule.Rules.RuleRecord;
+            $result.TargetName | Should -BeIn 'TestObject1';
+            $result.IsSuccess() | Should -Be $True;
+        }
     }
 
     Context 'Using -OutputFormat' {

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -30,6 +30,12 @@
     <None Update="FromFile.Rule.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="ObjectFromFile.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="ObjectFromFile.psd1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ObjectFromFile.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## PR Summary

- Added input format for reading PowerShell data `.psd1` files. #368 
  - `PowerShellData` has been added to `Input.Format`.
  - See `about_PSRule_Options` for details.

Fixes #368 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
