### PR TITLE
Pre-release v0.13.0-B1912043

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## Unreleased
 
+## v0.13.0-B1912043 (pre-release)
+
 - Added input format for reading PowerShell data `.psd1` files. [#368](https://github.com/Microsoft/PSRule/issues/368)
   - `PowerShellData` has been added to `Input.Format`.
   - See `about_PSRule_Options` for details.
 - Added numeric comparison assertion helpers. [#374](https://github.com/Microsoft/PSRule/issues/374)
-  - Added methods `Greater`, `GreaterOrEquals`, `Less` and `LessOrEqual`.
+  - Added methods `Greater`, `GreaterOrEqual`, `Less` and `LessOrEqual`.
   - See `about_PSRule_Assert` for usage details.
 
 ## v0.13.0-B1912027 (pre-release)


### PR DESCRIPTION
## PR Summary

- Added input format for reading PowerShell data `.psd1` files. #368
  - `PowerShellData` has been added to `Input.Format`.
  - See `about_PSRule_Options` for details.
- Added numeric comparison assertion helpers. #374
  - Added methods `Greater`, `GreaterOrEqual`, `Less` and `LessOrEqual`.
  - See `about_PSRule_Assert` for usage details.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
