### PR TITLE
Added links and notes to help #382

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed JSON de-serialization fails with single object. [#379](https://github.com/Microsoft/PSRule/issues/379)
 - Fixed stack overflow when parsing malformed JSON. [#380](https://github.com/Microsoft/PSRule/issues/380)
+- Added rule documentation links and notes to help. [#382](https://github.com/Microsoft/PSRule/issues/382)
+  - Added `-Full` switch to `Get-PSRuleHelp` to display links and notes sections.
 
 ## v0.13.0-B1912043 (pre-release)
 

--- a/docs/commands/PSRule/en-US/Get-PSRuleHelp.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleHelp.md
@@ -9,18 +9,23 @@ schema: 2.0.0
 
 ## SYNOPSIS
 
-Get documentation for a rule.
+Displays information about a rule.
 
 ## SYNTAX
 
 ```text
-Get-PSRuleHelp [-Module <String>] [-Online] [[-Name] <String>] [-Path <String>] [-Option <PSRuleOption>]
- [-Culture <String>] [<CommonParameters>]
+Get-PSRuleHelp [-Module <String>] [-Online] [-Full] [[-Name] <String>] [-Path <String>]
+ [-Option <PSRuleOption>] [-Culture <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-Get documentation for a rule.
+The `Get-PSRuleHelp` cmdlet display information about a rule.
+
+By default, this cmdlet will look for rules in the current path and loaded modules.
+To get help for a specific rule or module use the `-Name` or `-Module` parameters.
+
+If the rule has an online version of the documentation, use the `-Online` parameter to view it in your default web browser.
 
 ## EXAMPLES
 
@@ -134,6 +139,22 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Full
+
+Display additional information such as notes and links.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/concepts/PSRule/en-US/about_PSRule_Docs.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Docs.md
@@ -28,7 +28,8 @@ Each rule can include the following documentation:
 - Synopsis - A brief description on the intended purpose of the rule.
 - Description - A detailed description on the intended purpose of the rule.
 - Recommendation - A detailed explanation of the requirements to pass the rule.
-- Note - Any additional information or background.
+- Notes - Any additional information or configuration options.
+- Links - Any links to external references.
 
 See cmdlet help for detailed information on the `Get-PSRuleHelp` cmdlet.
 
@@ -49,7 +50,8 @@ Rule documentation is composed of markdown files, one per rule. When creating ru
 
 The markdown files for each rule is automatically discovered based on naming convention.
 
-Markdown is saved in a file with the same filename as the rule name with the `.md` extension. The file name should match the same case exactly, with a lower case extension.
+Markdown is saved in a file with the same filename as the rule name with the `.md` extension.
+The file name should match the same case exactly, with a lower case extension.
 
 As an example, the `storageAccounts.UseHttps.md` markdown file would be created.
 
@@ -67,7 +69,8 @@ This directory PSRule will look for these markdown files depends on how the rule
 - If the rules are loose (not part of a module), PSRule will search for documentation in the `.\<culture>\` subdirectory relative to where the rule script _.ps1_ file is located.
 - When the rules are shipped as part of a module, PSRule will search for documentation in the `.\<culture>\` subdirectory relative to where the module manifest _.psd1_ file is located.
 
-The `<culture>` subdirectory will be the current culture that PowerShell is executed under (the same as `(Get-Culture).Name`). Alternatively, the culture can set by using the `-Culture` parameter of PSRule cmdlets.
+The `<culture>` subdirectory will be the current culture that PowerShell is executed under (the same as `(Get-Culture).Name`).
+Alternatively, the culture can set by using the `-Culture` parameter of PSRule cmdlets.
 
 The markdown of each file uses following structure.
 
@@ -92,11 +95,16 @@ The markdown of each file uses following structure.
 
 ## NOTES
 
-{{ Additional information or background }}
+{{ Additional information or configuration options }}
+
+## LINKS
+
+{{ Links to external references }}
 
 ```
 
-Optionally, one or more annotations formatted as YAML key value pairs can be included. i.e. `severity: Critical`
+Optionally, one or more annotations formatted as YAML key value pairs can be included.
+i.e. `severity: Critical`
 
 ## NOTE
 

--- a/docs/scenarios/rule-docs/en-US/metadata.Name.md
+++ b/docs/scenarios/rule-docs/en-US/metadata.Name.md
@@ -20,3 +20,18 @@ The `app.kubernetes.io/name` label should be used to specify the name of the app
 ## RECOMMENDATION
 
 Consider setting the recommended label `app.kubernetes.io/name` on deployment and service resources.
+
+## NOTES
+
+The Kubernetes recommended labels include:
+
+- `app.kubernetes.io/name`
+- `app.kubernetes.io/instance`
+- `app.kubernetes.io/version`
+- `app.kubernetes.io/component`
+- `app.kubernetes.io/part-of`
+- `app.kubernetes.io/managed-by`
+
+## LINKS
+
+- [Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)

--- a/docs/scenarios/rule-docs/rule-docs.md
+++ b/docs/scenarios/rule-docs/rule-docs.md
@@ -139,22 +139,30 @@ The basic structure of markdown help is as follows:
 
 ```text
 ---
-{{ Info.Annotations }}
+{{ Annotations }}
 ---
 
-# {{ Info.DisplayName }}
+# {{ Name of rule }}
 
 ## SYNOPSIS
 
-{{ Info.Synopsis }}
+{{ A brief summary of the rule }}
 
 ## DESCRIPTION
 
-{{ Info.Description }}
+{{ A detailed description of the rule }}
 
 ## RECOMMENDATION
 
-{{ Info.Recommendation }}
+{{ A detailed explanation of the steps required to pass the rule }}
+
+## NOTES
+
+{{ Additional information or configuration options }}
+
+## LINKS
+
+{{ Links to external references }}
 
 ```
 
@@ -251,6 +259,8 @@ Any text following the heading is interpreted by PSRule and included in output.
 The recommendation is displayed when using the `Invoke-PSRule` and `Get-PSRuleHelp` cmdlets.
 
 The _recommendation_ is intended to identify corrective actions that can be taken to address any failures.
+Avoid using URLs within the recommendations.
+Use the _links_ section to include references to external sources.
 
 PSRule supports semantic line breaks, and will automatically run together lines into a single paragraph.
 Use a blank line to separate paragraphs.
@@ -261,6 +271,58 @@ For example:
 ## RECOMMENDATION
 
 Consider setting the recommended label `app.kubernetes.io/name` on deployment and service resources.
+```
+
+### Notes section
+
+The notes section is indicated by the heading `## NOTES`.
+Any text following the heading is interpreted by PSRule and included in pipeline output.
+Notes are excluded when formating output as YAML and JSON.
+
+To view any included notes use the `Get-PSRuleHelp` cmdlet with the `-Full` switch.
+
+Use notes to include additional information such configuration options.
+
+PSRule supports semantic line breaks, and will automatically run together lines into a single paragraph.
+Use a blank line to separate paragraphs.
+
+For example:
+
+```text
+## NOTES
+
+The Kubernetes recommended labels include:
+
+- `app.kubernetes.io/name`
+- `app.kubernetes.io/instance`
+- `app.kubernetes.io/version`
+- `app.kubernetes.io/component`
+- `app.kubernetes.io/part-of`
+- `app.kubernetes.io/managed-by`
+```
+
+### Links section
+
+The links section is indicated by the heading `## LINKS`.
+Any markdown links following the heading are interpreted by PSRule and included in pipeline output.
+Links are excluded when formating output as YAML and JSON.
+
+To view any included links use the `Get-PSRuleHelp` cmdlet with the `-Full` switch.
+
+Use links to reference external sources with a URL.
+
+To specify links, use the markdown syntax `[display name](url)`.
+Include each link on a separate line.
+To improve display in web rendered markdown, use a list of links by prefixing the line with `-`.
+
+Additional text such as `See additional information:` is useful for web rendered views, but ignored by PSRule.
+
+For example:
+
+```text
+## LINKS
+
+- [Recommended Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
 ```
 
 ## Localizing documentation files

--- a/src/PSRule.Benchmark/Benchmark.Rule.ps1
+++ b/src/PSRule.Benchmark/Benchmark.Rule.ps1
@@ -5,12 +5,12 @@
 # A set of benchmark rules for testing PSRule performance
 #
 
-# Description: A rule for testing PSRule performance
+# Synopsis: A rule for testing PSRule performance
 Rule 'Benchmark' {
     1 -eq 1;
 }
 
-# Description: A rule for testing PSRule performance
+# Synopsis: A rule for testing PSRule performance
 Rule 'BenchmarkIf' -If { 1 -eq 1 } {
     1 -eq 1;
 }
@@ -19,7 +19,12 @@ Rule 'BenchmarkType' -Type 'PSRule.Benchmark.TargetObject' {
     1 -eq 1;
 }
 
-# Description: A rule for testing PSRule performance
+# Synopsis: A rule for testing PSRule performance
+Rule 'BenchmarkHelp' {
+    1 -eq 1;
+}
+
+# Synopsis: A rule for testing PSRule performance
 Rule 'BenchmarkExists' {
 
 }

--- a/src/PSRule.Benchmark/PSRule.cs
+++ b/src/PSRule.Benchmark/PSRule.cs
@@ -38,6 +38,7 @@ namespace PSRule.Benchmark
     {
         private PSObject[] _TargetObject;
         private IPipeline _GetPipeline;
+        private IPipeline _GetHelpPipeline;
         private IPipeline _InvokePipeline;
         private IPipeline _InvokeIfPipeline;
         private IPipeline _InvokeTypePipeline;
@@ -50,6 +51,7 @@ namespace PSRule.Benchmark
         public void Prepare()
         {
             PrepareGetPipeline();
+            PrepareGetHelpPipeline();
             PrepareInvokePipeline();
             PrepareInvokeIfPipeline();
             PrepareInvokeTypePipeline();
@@ -66,6 +68,15 @@ namespace PSRule.Benchmark
             option.Rule.Include = new string[] { "Benchmark" };
             var builder = PipelineBuilder.Get(GetSource(), option);
             _GetPipeline = builder.Build();
+        }
+
+        private void PrepareGetHelpPipeline()
+        {
+            var option = new PSRuleOption();
+            option.Rule.Include = new string[] { "BenchmarkHelp" };
+            option.Output.Culture = new string[] { "en-ZZ" };
+            var builder = PipelineBuilder.GetHelp(GetSource(), option);
+            _GetHelpPipeline = builder.Build();
         }
 
         private void PrepareInvokePipeline()
@@ -174,6 +185,9 @@ namespace PSRule.Benchmark
 
         [Benchmark]
         public void Get() => RunPipelineNull(_GetPipeline);
+
+        [Benchmark]
+        public void GetHelp() => RunPipelineNull(_GetHelpPipeline);
 
         [Benchmark]
         public void Within() => RunPipelineTargets(_InvokeWithinPipeline);

--- a/src/PSRule.Benchmark/en-ZZ/BenchmarkHelp.md
+++ b/src/PSRule.Benchmark/en-ZZ/BenchmarkHelp.md
@@ -1,7 +1,6 @@
 ---
 category: Security
 severity: Critical
-online version:
 ---
 
 # Use specific tags
@@ -25,7 +24,4 @@ The `latest` tag automatically uses `imagePullPolicy: Always` instead of the def
 
 ## LINKS
 
-- [PSRule]
 - [Stable tags](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-image-tag-version#stable-tags)
-
-[PSRule]: https://github.com/Microsoft/PSRule

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -151,7 +151,7 @@ namespace PSRule.Commands
         private static bool TryDocument(string path, out RuleDocument document)
         {
             var reader = new MarkdownReader(yamlHeaderOnly: false);
-            var stream = reader.Read(markdown: File.ReadAllText(path), path);
+            var stream = reader.Read(File.ReadAllText(path), path);
             var lexer = new RuleLexer();
             document = lexer.Process(stream);
             return document != null;

--- a/src/PSRule/PSRule.Format.ps1xml
+++ b/src/PSRule/PSRule.Format.ps1xml
@@ -112,6 +112,50 @@
       </CustomControl>
     </Control>
     <Control>
+      <Name>Help-Notes</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+              <CustomItem>
+                <Text AssemblyName="PSRule" BaseName="PSRule.Resources.DocumentStrings" ResourceId="Notes"/>
+                <NewLine />
+                <Frame>
+                  <LeftIndent>4</LeftIndent>
+                  <CustomItem>
+                    <ExpressionBinding>
+                      <PropertyName>Notes</PropertyName>
+                    </ExpressionBinding>
+                    <NewLine/>
+                  </CustomItem>
+                </Frame>
+              </CustomItem>
+            </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
+      <Name>Help-Links</Name>
+      <CustomControl>
+        <CustomEntries>
+          <CustomEntry>
+              <CustomItem>
+                <Text AssemblyName="PSRule" BaseName="PSRule.Resources.DocumentStrings" ResourceId="Links"/>
+                <NewLine />
+                <Frame>
+                  <LeftIndent>4</LeftIndent>
+                  <CustomItem>
+                    <ExpressionBinding>
+                      <ScriptBlock>$_.GetLinkString();</ScriptBlock>
+                    </ExpressionBinding>
+                    <NewLine/>
+                  </CustomItem>
+                </Frame>
+              </CustomItem>
+            </CustomEntry>
+        </CustomEntries>
+      </CustomControl>
+    </Control>
+    <Control>
       <Name>Option-Yaml</Name>
       <CustomControl>
         <CustomEntries>
@@ -377,6 +421,71 @@
                                   <ExpressionBinding>
                                     <CustomControlName>Help-Recommendation</CustomControlName>
                                   </ExpressionBinding>
+                                </CustomItem>
+                              </Frame>
+                            </CustomItem>
+                          </Frame>
+                        </CustomItem>
+                      </Frame>
+                    </CustomItem>
+                  </Frame>
+                </CustomItem>
+              </CustomEntry>
+            </CustomEntries>
+      </CustomControl>
+    </View>
+    <View>
+      <Name>PSRule.Rules.RuleHelpInfo+Full</Name>
+      <ViewSelectedBy>
+        <TypeName>PSRule.Rules.RuleHelpInfo+Full</TypeName>
+      </ViewSelectedBy>
+      <CustomControl>
+         <CustomEntries>
+              <CustomEntry>
+                <CustomItem>
+                  <ExpressionBinding>
+                    <CustomControlName>Help-Name</CustomControlName>
+                  </ExpressionBinding>
+                  <Frame>
+                    <CustomItem>
+                      <NewLine />
+                      <ExpressionBinding>
+                        <CustomControlName>Help-DisplayName</CustomControlName>
+                      </ExpressionBinding>
+                      <Frame>
+                        <CustomItem>
+                          <NewLine />
+                          <ExpressionBinding>
+                            <CustomControlName>Help-Synopsis</CustomControlName>
+                          </ExpressionBinding>
+                          <Frame>
+                            <CustomItem>
+                              <NewLine />
+                              <ExpressionBinding>
+                                <CustomControlName>Help-Description</CustomControlName>
+                              </ExpressionBinding>
+                              <Frame>
+                                <CustomItem>
+                                  <NewLine />
+                                  <ExpressionBinding>
+                                    <CustomControlName>Help-Recommendation</CustomControlName>
+                                  </ExpressionBinding>
+                                  <Frame>
+                                    <CustomItem>
+                                      <NewLine />
+                                      <ExpressionBinding>
+                                        <CustomControlName>Help-Notes</CustomControlName>
+                                      </ExpressionBinding>
+                                      <Frame>
+                                        <CustomItem>
+                                          <NewLine />
+                                          <ExpressionBinding>
+                                            <CustomControlName>Help-Links</CustomControlName>
+                                          </ExpressionBinding>
+                                        </CustomItem>
+                                      </Frame>
+                                    </CustomItem>
+                                  </Frame>
                                 </CustomItem>
                               </Frame>
                             </CustomItem>

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -759,6 +759,9 @@ function Get-PSRuleHelp {
         [Parameter(Mandatory = $False)]
         [Switch]$Online = $False,
 
+        [Parameter(Mandatory = $False)]
+        [Switch]$Full = $False,
+
         # The name of the rule to get documentation for.
         [Parameter(Position = 0, Mandatory = $False)]
         [Alias('n')]
@@ -840,6 +843,9 @@ function Get-PSRuleHelp {
 
         if ($Online) {
             $builder.Online();
+        }
+        if ($Full) {
+            $builder.Full();
         }
 
         $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);

--- a/src/PSRule/Parser/MarkdownReader.cs
+++ b/src/PSRule/Parser/MarkdownReader.cs
@@ -220,7 +220,7 @@ namespace PSRule.Parser
             var startOfLine = _Stream.IsStartOfLine;
 
             // Get the text
-            var text = (_PreserveFormatting) ? _Stream.CaptureUntil(LineEndingCharacters, ignoreEscaping: true) : UnwrapStyleMarkers(_Stream, out textStyle);
+            var text = _PreserveFormatting ? _Stream.CaptureUntil(LineEndingCharacters, ignoreEscaping: true) : UnwrapStyleMarkers(_Stream, out textStyle);
 
             // Set the line ending
             var ending = GetEnding(_Stream.SkipLineEnding(max: 2));
@@ -231,7 +231,6 @@ namespace PSRule.Parser
             if (_Context != MarkdownReaderMode.List && startOfLine && IsList(text))
             {
                 _Context = MarkdownReaderMode.List;
-
                 if (_Output.Current != null && _Output.Current.Flag.IsEnding() && !_Output.Current.Flag.ShouldPreserve())
                     _Output.Current.Flag |= MarkdownTokens.Preserve;
             }

--- a/src/PSRule/Parser/RuleLexer.cs
+++ b/src/PSRule/Parser/RuleLexer.cs
@@ -49,18 +49,15 @@ namespace PSRule.Parser
                         Description(stream, doc) ||
                         Recommendation(stream, doc) ||
                         Notes(stream, doc) ||
-                        RelatedLinks(stream, doc);
+                        Links(stream, doc);
 
                     if (matching)
-                    {
                         continue;
-                    }
                 }
 
                 // Skip the current token
                 stream.Next();
             }
-
             return doc;
         }
 
@@ -70,13 +67,10 @@ namespace PSRule.Parser
         private bool Synopsis(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Synopsis))
-            {
                 return false;
-            }
 
             doc.Synopsis = TextBlock(stream);
             stream.SkipUntilHeader();
-
             return true;
         }
 
@@ -86,13 +80,10 @@ namespace PSRule.Parser
         private bool Description(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Description))
-            {
                 return false;
-            }
 
             doc.Description = TextBlock(stream);
             stream.SkipUntilHeader();
-
             return true;
         }
 
@@ -102,13 +93,10 @@ namespace PSRule.Parser
         private bool Recommendation(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Recommendation))
-            {
                 return false;
-            }
 
             doc.Recommendation = TextBlock(stream);
             stream.SkipUntilHeader();
-
             return true;
         }
 
@@ -118,33 +106,28 @@ namespace PSRule.Parser
         private bool Notes(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Notes))
-            {
                 return false;
-            }
 
             doc.Notes = TextBlock(stream);
             stream.SkipUntilHeader();
-
             return true;
         }
 
-        private bool RelatedLinks(TokenStream stream, RuleDocument doc)
+        /// <summary>
+        /// Read links.
+        /// </summary>
+        private bool Links(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Links))
-            {
                 return false;
-            }
 
-            List<Link> links = new List<Link>();
-
+            var links = new List<Link>();
             stream.Next();
-
-            while (stream.IsTokenType(MarkdownTokenType.Link, MarkdownTokenType.LinkReference, MarkdownTokenType.LineBreak))
+            while (stream.IsTokenType(MarkdownTokenType.Link, MarkdownTokenType.LinkReference, MarkdownTokenType.LineBreak, MarkdownTokenType.Text))
             {
-                if (stream.IsTokenType(MarkdownTokenType.LineBreak))
+                if (stream.IsTokenType(MarkdownTokenType.LineBreak) || stream.IsTokenType(MarkdownTokenType.Text))
                 {
                     stream.Next();
-
                     continue;
                 }
 
@@ -160,37 +143,28 @@ namespace PSRule.Parser
                     var target = stream.ResolveLinkTarget(link.Uri);
                     link.Uri = target.Text;
                 }
-
                 links.Add(link);
-
                 stream.Next();
             }
-
             stream.SkipUntilHeader();
-
             doc.Links = links.ToArray();
-
             return true;
         }
 
         private TextBlock TextBlock(TokenStream stream)
         {
             var useBreak = stream.Current.IsDoubleLineEnding();
-
             stream.Next();
-
             var text = ReadText(stream);
-
             return new TextBlock(text: text, formatOption: useBreak ? FormatOptions.LineBreak : FormatOptions.None);
         }
 
         /// <summary>
         /// Read tokens from the stream as text.
         /// </summary>
-        private string ReadText(TokenStream stream, bool includeNonYamlFencedBlocks = false)
+        private static string ReadText(TokenStream stream, bool includeNonYamlFencedBlocks = false)
         {
             var sb = new StringBuilder();
-
             while (stream.IsTokenType(MarkdownTokenType.Text, MarkdownTokenType.Link, MarkdownTokenType.FencedBlock, MarkdownTokenType.LineBreak))
             {
                 if (stream.IsTokenType(MarkdownTokenType.Text))
@@ -202,16 +176,12 @@ namespace PSRule.Parser
                 {
                     AppendEnding(sb, stream.Peak(-1));
                     sb.Append(stream.Current.Meta);
-
                     if (!string.IsNullOrEmpty(stream.Current.Text))
-                    {
                         sb.AppendFormat(" ({0})", stream.Current.Text);
-                    }
                 }
                 else if (stream.IsTokenType(MarkdownTokenType.LinkReference))
                 {
                     AppendEnding(sb, stream.Peak(-1));
-
                     sb.Append(stream.Current.Meta);
                 }
                 else if (stream.IsTokenType(MarkdownTokenType.FencedBlock))
@@ -220,52 +190,37 @@ namespace PSRule.Parser
                     if (!includeNonYamlFencedBlocks || string.Equals(stream.Current.Meta, "yaml", StringComparison.OrdinalIgnoreCase))
                     {
                         if (stream.PeakTokenType(-1) == MarkdownTokenType.LineBreak)
-                        {
                             AppendEnding(sb, stream.Peak(-1));
-                        }
 
                         break;
                     }
-
                     AppendEnding(sb, stream.Peak(-1), preserveEnding: true);
                     sb.Append(stream.Current.Text);
                 }
                 else if (stream.IsTokenType(MarkdownTokenType.LineBreak))
-                {
                     AppendEnding(sb, stream.Peak(-1));
-                }
 
                 stream.Next();
             }
 
             if (stream.EOF && stream.Peak(-1).Flag.HasFlag(MarkdownTokens.Preserve) && stream.Peak(-1).Flag.HasFlag(MarkdownTokens.LineEnding))
-            {
                 AppendEnding(sb, stream.Peak(-1));
-            }
 
             return sb.ToString();
         }
 
-        private void AppendEnding(StringBuilder stringBuilder, MarkdownToken token, bool preserveEnding = false)
+        private static void AppendEnding(StringBuilder stringBuilder, MarkdownToken token, bool preserveEnding = false)
         {
             if (token == null || stringBuilder.Length == 0 || !token.Flag.IsEnding())
-            {
                 return;
-            }
 
             if (!preserveEnding && token.Flag.ShouldPreserve())
-            {
                 preserveEnding = true;
-            }
 
             if (token.IsDoubleLineEnding())
-            {
                 stringBuilder.Append(preserveEnding ? string.Concat(Environment.NewLine, Environment.NewLine) : Environment.NewLine);
-            }
             else if (token.IsSingleLineEnding())
-            {
                 stringBuilder.Append(preserveEnding ? Environment.NewLine : Space);
-            }
         }
     }
 }

--- a/src/PSRule/Resources/DocumentStrings.Designer.cs
+++ b/src/PSRule/Resources/DocumentStrings.Designer.cs
@@ -79,7 +79,7 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to RELATED LINKS.
+        ///   Looks up a localized string similar to LINKS.
         /// </summary>
         internal static string Links {
             get {

--- a/src/PSRule/Resources/DocumentStrings.resx
+++ b/src/PSRule/Resources/DocumentStrings.resx
@@ -124,7 +124,7 @@
     <value>DISPLAY NAME</value>
   </data>
   <data name="Links" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>LINKS</value>
   </data>
   <data name="ModuleName" xml:space="preserve">
     <value>MODULE NAME</value>

--- a/src/PSRule/Rules/RuleHelpInfo.cs
+++ b/src/PSRule/Rules/RuleHelpInfo.cs
@@ -4,6 +4,8 @@
 using Newtonsoft.Json;
 using System;
 using System.Collections;
+using System.Text;
+using YamlDotNet.Serialization;
 
 namespace PSRule.Rules
 {
@@ -19,6 +21,19 @@ namespace PSRule.Rules
             Name = name;
             DisplayName = displayName;
             ModuleName = moduleName;
+        }
+
+        public sealed class Link
+        {
+            internal Link(string name, string uri)
+            {
+                Name = name;
+                Uri = uri;
+            }
+
+            public string Name { get; private set; }
+
+            public string Uri { get; private set; }
         }
 
         /// <summary>
@@ -63,8 +78,14 @@ namespace PSRule.Rules
         /// <summary>
         /// Additional notes for the rule.
         /// </summary>
-        [JsonProperty(PropertyName = "notes")]
+        [JsonIgnore, YamlIgnore]
         public string Notes { get; internal set; }
+
+        /// <summary>
+        /// Reference links for the rule.
+        /// </summary>
+        [JsonIgnore, YamlIgnore]
+        public Link[] Links { get; internal set; }
 
         /// <summary>
         /// Metadata annotations for the rule.
@@ -85,6 +106,28 @@ namespace PSRule.Rules
                 return result;
 
             return null;
+        }
+
+        /// <summary>
+        /// Get a view link string for display in rule help.
+        /// </summary>
+        public string GetLinkString()
+        {
+            if (Links == null)
+                return null;
+
+            var sb = new StringBuilder();
+            for (var i = 0; i < Links.Length; i++)
+            {
+                sb.Append(Links[i].Name);
+                if (!string.IsNullOrEmpty(Links[i].Uri))
+                {
+                    sb.Append(": ");
+                    sb.Append(Links[i].Uri);
+                }
+                sb.Append(Environment.NewLine);
+            }
+            return sb.ToString();
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Added rule documentation links and notes to help. #382
  - Added `-Full` switch to `Get-PSRuleHelp` to display links and notes sections.

Fixes #382 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
