### PR TITLE
Added aliases for OutputFormat and Module #384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed stack overflow when parsing malformed JSON. [#380](https://github.com/Microsoft/PSRule/issues/380)
 - Added rule documentation links and notes to help. [#382](https://github.com/Microsoft/PSRule/issues/382)
   - Added `-Full` switch to `Get-PSRuleHelp` to display links and notes sections.
+- Added aliases for `-OutputFormat` (`-o`) and `-Module` (`-m`) parameters. [#384](https://github.com/Microsoft/PSRule/issues/384)
 
 ## v0.13.0-B1912043 (pre-release)
 

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -175,7 +175,7 @@ When both `-Path` and `-Module` are specified, rule definitions from both are di
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: m
 
 Required: False
 Position: Named
@@ -300,7 +300,7 @@ The `Wide` format is not applicable to `Assert-PSRule`.
 ```yaml
 Type: OutputFormat
 Parameter Sets: (All)
-Aliases:
+Aliases: o
 Accepted values: None, Yaml, Json, NUnit3, Csv
 
 Required: False

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -194,7 +194,7 @@ When both `-Path` and `-Module` are specified, rule definitions from both are di
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: m
 
 Required: False
 Position: Named
@@ -235,7 +235,7 @@ The following format options are available:
 ```yaml
 Type: OutputFormat
 Parameter Sets: (All)
-Aliases:
+Aliases: o
 Accepted values: None, Wide
 
 Required: False

--- a/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
@@ -44,7 +44,7 @@ When both `-Path` and `-Module` are specified, baseline definitions from both ar
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: m
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Get-PSRuleHelp.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleHelp.md
@@ -98,7 +98,7 @@ Results can be filtered by using `-Name`, `-Path` or `-Module`.
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: m
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -342,7 +342,7 @@ When both `-Path` and `-Module` are specified, rule definitions from both are di
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: m
 
 Required: False
 Position: Named
@@ -400,7 +400,7 @@ The following format options are available:
 ```yaml
 Type: OutputFormat
 Parameter Sets: (All)
-Aliases:
+Aliases: o
 Accepted values: None, Yaml, Json, NUnit3, Csv, Wide
 
 Required: False

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -252,7 +252,7 @@ When both `-Path` and `-Module` are specified, rule definitions from both are di
 ```yaml
 Type: String[]
 Parameter Sets: (All)
-Aliases:
+Aliases: m
 
 Required: False
 Position: Named

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -36,6 +36,7 @@ function Invoke-PSRule {
         [String[]]$InputPath,
 
         [Parameter(Mandatory = $False)]
+        [Alias('m')]
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
@@ -54,6 +55,7 @@ function Invoke-PSRule {
 
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv', 'Wide')]
+        [Alias('o')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = [PSRule.Configuration.OutputFormat]::None,
 
         [Parameter(Mandatory = $False)]
@@ -212,6 +214,7 @@ function Test-PSRuleTarget {
         [String[]]$InputPath,
 
         [Parameter(Mandatory = $False)]
+        [Alias('m')]
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
@@ -364,6 +367,7 @@ function Assert-PSRule {
         [String[]]$InputPath,
 
         [Parameter(Mandatory = $False)]
+        [Alias('m')]
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
@@ -395,6 +399,7 @@ function Assert-PSRule {
 
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv')]
+        [Alias('o')]
         [PSRule.Configuration.OutputFormat]$OutputFormat,
 
         [Parameter(Mandatory = $False)]
@@ -529,6 +534,7 @@ function Get-PSRule {
     [OutputType([PSRule.Rules.Rule])]
     param (
         [Parameter(Mandatory = $False)]
+        [Alias('m')]
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
@@ -536,6 +542,7 @@ function Get-PSRule {
 
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Wide')]
+        [Alias('o')]
         [PSRule.Configuration.OutputFormat]$OutputFormat,
 
         [Parameter(Mandatory = $False)]
@@ -563,7 +570,6 @@ function Get-PSRule {
         [Parameter(Mandatory = $False)]
         [Switch]$IncludeDependencies
     )
-
     begin {
         Write-Verbose -Message "[Get-PSRule]::BEGIN";
 
@@ -657,6 +663,7 @@ function Get-PSRuleBaseline {
     [OutputType([PSRule.Rules.Baseline])]
     param (
         [Parameter(Mandatory = $False)]
+        [Alias('m')]
         [String[]]$Module,
 
         [Parameter(Mandatory = $False)]
@@ -677,7 +684,6 @@ function Get-PSRuleBaseline {
         [Parameter(Mandatory = $False)]
         [String]$Culture
     )
-
     begin {
         Write-Verbose -Message "[Get-PSRuleBaseline] BEGIN::";
 
@@ -754,6 +760,7 @@ function Get-PSRuleHelp {
     [OutputType([PSRule.Rules.RuleHelpInfo])]
     param (
         [Parameter(Mandatory = $False)]
+        [Alias('m')]
         [String]$Module,
 
         [Parameter(Mandatory = $False)]


### PR DESCRIPTION
## PR Summary

- Added aliases for `-OutputFormat` (`-o`) and `-Module` (`-m`) parameters. #384

Fixes #384 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
