### PR TITLE
Added assert in pre-conditions #386 #387

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added rule documentation links and notes to help. [#382](https://github.com/Microsoft/PSRule/issues/382)
   - Added `-Full` switch to `Get-PSRuleHelp` to display links and notes sections.
 - Added aliases for `-OutputFormat` (`-o`) and `-Module` (`-m`) parameters. [#384](https://github.com/Microsoft/PSRule/issues/384)
+- Improved numeric comparison assertion helpers to support strings. [#387](https://github.com/Microsoft/PSRule/issues/387)
+  - Methods `Greater`, `GreaterOrEqual`, `Less` and `LessOrEqual` now also check string length.
+- Added support for assertion methods to be used within script pre-conditions. [#386](https://github.com/Microsoft/PSRule/issues/386)
 
 ## v0.13.0-B1912043 (pre-release)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -8,7 +8,8 @@ Describes the assertion helper that can be used within PSRule rule definitions.
 
 ## LONG DESCRIPTION
 
-PSRule includes an assertion helper exposed as a built-in variable `$Assert`. The `$Assert` object provides a consistent set of methods to evaluate objects.
+PSRule includes an assertion helper exposed as a built-in variable `$Assert`.
+The `$Assert` object provides a consistent set of methods to evaluate objects.
 
 Each `$Assert` method returns an `AssertResult` object that contains the result of the assertion.
 
@@ -28,7 +29,7 @@ The following built-in assertion methods are provided:
 - [StartsWith](#startswith) - The field value must match at least one prefix.
 - [Version](#version) - The field value must be a semantic version string.
 
-The `$Assert` variable can only be used within a rule definition block.
+The `$Assert` variable can only be used within a rule definition block or script pre-conditions.
 
 ### Using assertion methods
 
@@ -126,6 +127,7 @@ When the field value is:
 
 - An integer, a numerical comparison is used.
 - An array, the number of elements is compared.
+- A string, the length of the string is compared.
 
 The following parameters are accepted:
 
@@ -157,6 +159,7 @@ When the field value is:
 
 - An integer, a numerical comparison is used.
 - An array, the number of elements is compared.
+- A string, the length of the string is compared.
 
 The following parameters are accepted:
 
@@ -304,6 +307,7 @@ When the field value is:
 
 - An integer, a numerical comparison is used.
 - An array, the number of elements is compared.
+- A string, the length of the string is compared.
 
 The following parameters are accepted:
 
@@ -335,6 +339,7 @@ When the field value is:
 
 - An integer, a numerical comparison is used.
 - An array, the number of elements is compared.
+- A string, the length of the string is compared.
 
 The following parameters are accepted:
 
@@ -487,10 +492,12 @@ The following methods are available:
 - `Complete()` - Returns `$True` (Pass) or `$False` (Fail) to the rule record. If the assertion failed, any reasons are automatically added to the rule record. To read the result without adding reason to the rule record use the `Result` property.
 - `Ignore()` - Ignores the result. Nothing future is returned and any reasons are cleared. Use this method when implementing custom handling.
 
-Use of `Complete()` is optional, uncompleted results are automatically completed after the rule has executed.
+Use of `Complete` is optional, uncompleted results are automatically completed after the rule has executed.
 Uncompleted results may return reasons out of sequence.
 
-In this example, `Complete()` is used to find the first field with an empty value.
+Using these advanced methods is not supported in rule script pre-conditions.
+
+In this example, `Complete` is used to find the first field with an empty value.
 
 ```powershell
 Rule 'Assert.HasFieldValue' {

--- a/src/PSRule/Commands/AssertAllOfCommand.cs
+++ b/src/PSRule/Commands/AssertAllOfCommand.cs
@@ -3,7 +3,7 @@
 
 using PSRule.Pipeline;
 using PSRule.Resources;
-using PSRule.Rules;
+using PSRule.Runtime;
 using System.Management.Automation;
 
 namespace PSRule.Commands

--- a/src/PSRule/Commands/AssertAnyOfCommand.cs
+++ b/src/PSRule/Commands/AssertAnyOfCommand.cs
@@ -3,7 +3,7 @@
 
 using PSRule.Pipeline;
 using PSRule.Resources;
-using PSRule.Rules;
+using PSRule.Runtime;
 using System.Management.Automation;
 
 namespace PSRule.Commands

--- a/src/PSRule/Commands/InvokeRuleBlockCommand.cs
+++ b/src/PSRule/Commands/InvokeRuleBlockCommand.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Pipeline;
-using PSRule.Rules;
+using PSRule.Runtime;
 using System;
 using System.Linq;
 using System.Management.Automation;
@@ -45,10 +45,8 @@ namespace PSRule.Commands
                 if (If != null)
                 {
                     PipelineContext.CurrentThread.ExecutionScope = ExecutionScope.Precondition;
-
-                    var ifResult = If.InvokeReturnAsIs() as PSObject;
-
-                    if (ifResult == null || !(ifResult.BaseObject is bool) || !(bool)ifResult.BaseObject)
+                    var ifResult = RuleConditionResult.Create(If.Invoke());
+                    if (!ifResult.AllOf())
                     {
                         PipelineContext.CurrentThread.Logger.DebugMessage("Target failed If precondition");
                         return;

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -229,7 +229,7 @@ namespace PSRule.Host
             ps.Streams.ClearStreams();
             context.VerboseObjectStart();
 
-            var invokeResult = ps.Invoke<RuleConditionResult>().FirstOrDefault();
+            var invokeResult = ps.Invoke<Runtime.RuleConditionResult>().FirstOrDefault();
 
             if (invokeResult == null)
             {

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Host;
+using PSRule.Runtime;
 using System;
 using System.Collections;
 using System.Diagnostics;
@@ -10,9 +11,9 @@ using System.Management.Automation;
 
 namespace PSRule.Rules
 {
-    public delegate bool RulePrecondition();
+    internal delegate bool RulePrecondition();
 
-    public delegate RuleConditionResult RuleCondition();
+    internal delegate RuleConditionResult RuleCondition();
 
     /// <summary>
     /// Define an instance of a rule block. Each rule block has a unique id.

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -24,7 +24,7 @@ namespace PSRule.Runtime
 
         public AssertResult Create(bool condition, string reason = null)
         {
-            if (PipelineContext.CurrentThread.ExecutionScope != ExecutionScope.Condition)
+            if (!(PipelineContext.CurrentThread.ExecutionScope == ExecutionScope.Condition || PipelineContext.CurrentThread.ExecutionScope == ExecutionScope.Precondition))
                 throw new RuleRuntimeException(string.Format(PSRuleResources.VariableConditionScope, "Assert"));
 
             return new AssertResult(this, condition, reason);
@@ -258,7 +258,7 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (TryInt(fieldValue, out int actual) || TryArrayLength(fieldValue, out actual))
+            if (TryInt(fieldValue, out int actual) || TryStringLength(fieldValue, out actual) || TryArrayLength(fieldValue, out actual))
                 return actual > value ? Pass() : Fail(ReasonStrings.Greater, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
@@ -272,7 +272,7 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (TryInt(fieldValue, out int actual) || TryArrayLength(fieldValue, out actual))
+            if (TryInt(fieldValue, out int actual) || TryStringLength(fieldValue, out actual) || TryArrayLength(fieldValue, out actual))
                 return actual >= value ? Pass() : Fail(ReasonStrings.GreaterOrEqual, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
@@ -286,7 +286,7 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (TryInt(fieldValue, out int actual) || TryArrayLength(fieldValue, out actual))
+            if (TryInt(fieldValue, out int actual) || TryStringLength(fieldValue, out actual) || TryArrayLength(fieldValue, out actual))
                 return actual < value ? Pass() : Fail(ReasonStrings.Less, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
@@ -300,7 +300,7 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (TryInt(fieldValue, out int actual) || TryArrayLength(fieldValue, out actual))
+            if (TryInt(fieldValue, out int actual) || TryStringLength(fieldValue, out actual) || TryArrayLength(fieldValue, out actual))
                 return actual <= value ? Pass() : Fail(ReasonStrings.LessOrEqual, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
@@ -346,9 +346,18 @@ namespace PSRule.Runtime
                 value = ivalue;
                 return true;
             }
-            if (int.TryParse(obj.ToString(), out value))
-                return true;
+            value = 0;
+            return false;
+        }
 
+        private static bool TryStringLength(object obj, out int value)
+        {
+            if (obj is string s)
+            {
+                value = s.Length;
+                return true;
+            }
+            value = 0;
             return false;
         }
 

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -194,8 +194,8 @@ namespace PSRule
             Assert.True(assert.Greater(value, "value", 0).Result);
             Assert.True(assert.Greater(value, "value", -1).Result);
 
-            // String int
-            value = GetObject((name: "value", value: "3"));
+            // String
+            value = GetObject((name: "value", value: "abc"));
             Assert.True(assert.Greater(value, "value", 2).Result);
             Assert.False(assert.Greater(value, "value", 3).Result);
             Assert.False(assert.Greater(value, "value", 4).Result);
@@ -225,8 +225,8 @@ namespace PSRule
             Assert.True(assert.GreaterOrEqual(value, "value", 0).Result);
             Assert.True(assert.GreaterOrEqual(value, "value", -1).Result);
 
-            // String int
-            value = GetObject((name: "value", value: "3"));
+            // String
+            value = GetObject((name: "value", value: "abc"));
             Assert.True(assert.GreaterOrEqual(value, "value", 2).Result);
             Assert.True(assert.GreaterOrEqual(value, "value", 3).Result);
             Assert.False(assert.GreaterOrEqual(value, "value", 4).Result);
@@ -256,8 +256,8 @@ namespace PSRule
             Assert.False(assert.Less(value, "value", 0).Result);
             Assert.False(assert.Less(value, "value", -1).Result);
 
-            // String int
-            value = GetObject((name: "value", value: "3"));
+            // String
+            value = GetObject((name: "value", value: "abc"));
             Assert.False(assert.Less(value, "value", 2).Result);
             Assert.False(assert.Less(value, "value", 3).Result);
             Assert.True(assert.Less(value, "value", 4).Result);
@@ -287,8 +287,8 @@ namespace PSRule
             Assert.False(assert.LessOrEqual(value, "value", 0).Result);
             Assert.False(assert.LessOrEqual(value, "value", -1).Result);
 
-            // String int
-            value = GetObject((name: "value", value: "3"));
+            // String
+            value = GetObject((name: "value", value: "abc"));
             Assert.False(assert.LessOrEqual(value, "value", 2).Result);
             Assert.True(assert.LessOrEqual(value, "value", 3).Result);
             Assert.True(assert.LessOrEqual(value, "value", 4).Result);

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -16,6 +16,11 @@ Rule 'Assert.AddMember' {
     $Assert._ExtensionIsValue(2, 'MethodValue2')
 }
 
+# Synopsis: Test for $Assert in script pre-conditions
+Rule 'Assert.Precondition' -If { $Assert.StartsWith($TargetObject, 'Name', 'TestObject1') } {
+    $True;
+}
+
 # Synopsis: Test for $Assert.Complete
 Rule 'Assert.Complete' {
     $Assert.HasField($TargetObject, 'Name').Complete() -and
@@ -37,12 +42,14 @@ Rule 'Assert.EndsWith' {
 Rule 'Assert.Greater' {
     $Assert.Greater($TargetObject, 'CompareNumeric', 2)
     $Assert.Greater($TargetObject, 'CompareArray', 2)
+    $Assert.Greater($TargetObject, 'CompareString', 2)
 }
 
 # Synopsis: Test for $Assert.GreaterOrEqual
 Rule 'Assert.GreaterOrEqual' {
     $Assert.GreaterOrEqual($TargetObject, 'CompareNumeric', 3)
     $Assert.GreaterOrEqual($TargetObject, 'CompareArray', 3)
+    $Assert.GreaterOrEqual($TargetObject, 'CompareString', 3)
 }
 
 # Synopsis: Test for $Assert.HasField
@@ -81,12 +88,14 @@ Rule 'Assert.JsonSchema' {
 Rule 'Assert.Less' {
     $Assert.Less($TargetObject, 'CompareNumeric', 2)
     $Assert.Less($TargetObject, 'CompareArray', 2)
+    $Assert.Less($TargetObject, 'CompareString', 2)
 }
 
 # Synopsis: Test for $Assert.LessOrEqual
 Rule 'Assert.LessOrEqual' {
     $Assert.LessOrEqual($TargetObject, 'CompareNumeric', 0)
     $Assert.LessOrEqual($TargetObject, 'CompareArray', 0)
+    $Assert.LessOrEqual($TargetObject, 'CompareString', 0)
 }
 
 # Synopsis: Test for $Assert.HasEmptyField

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -43,6 +43,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 Version = '2.0.0'
                 CompareNumeric = 3
                 CompareArray = 1, 2, 3
+                CompareString = 'abc'
             }
             [PSCustomObject]@{
                 Name = 'TestObject2'
@@ -57,8 +58,23 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 Version = '1.0.0'
                 CompareNumeric = 0
                 CompareArray = @()
+                CompareString = ''
             }
         )
+
+        It 'In pre-conditions' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Precondition' -Outcome All -WarningAction SilentlyContinue);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].Outcome | Should -Be 'Pass';
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].Outcome | Should -Be 'None';
+            $result[1].TargetName | Should -Be 'TestObject2';
+        }
 
         It 'Complete' {
             $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Complete');
@@ -120,7 +136,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             # Negative case
             $result[1].IsSuccess() | Should -Be $False;
             $result[1].TargetName | Should -Be 'TestObject2';
-            $result[1].Reason.Length | Should -Be 2;
+            $result[1].Reason.Length | Should -Be 3;
             $result[1].Reason | Should -BeLike "The value '*' was not > '*'.";
         }
 
@@ -136,7 +152,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             # Negative case
             $result[1].IsSuccess() | Should -Be $False;
             $result[1].TargetName | Should -Be 'TestObject2';
-            $result[1].Reason.Length | Should -Be 2;
+            $result[1].Reason.Length | Should -Be 3;
             $result[1].Reason | Should -BeLike "The value '*' was not >= '*'.";
         }
 
@@ -218,7 +234,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             # Negative case
             $result[0].IsSuccess() | Should -Be $False;
             $result[0].TargetName | Should -Be 'TestObject1';
-            $result[0].Reason.Length | Should -Be 2;
+            $result[0].Reason.Length | Should -Be 3;
             $result[0].Reason | Should -BeLike "The value '*' was not < '*'.";
         }
 
@@ -234,7 +250,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             # Negative case
             $result[0].IsSuccess() | Should -Be $False;
             $result[0].TargetName | Should -Be 'TestObject1';
-            $result[0].Reason.Length | Should -Be 2;
+            $result[0].Reason.Length | Should -Be 3;
             $result[0].Reason | Should -BeLike "The value '*' was not <= '*'.";
         }
 


### PR DESCRIPTION
## PR Summary

- Improved numeric comparison assertion helpers to support strings. #387
  - Methods `Greater`, `GreaterOrEqual`, `Less` and `LessOrEqual` now also check string length.
- Added support for assertion methods to be used within script pre-conditions. #386

Fixes #386 
Fixes #387 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
