### PR TITLE
Pre-release v0.13.0-B2001013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.13.0-B2001013 (pre-release)
+
 - Fixed JSON de-serialization fails with single object. [#379](https://github.com/Microsoft/PSRule/issues/379)
 - Fixed stack overflow when parsing malformed JSON. [#380](https://github.com/Microsoft/PSRule/issues/380)
 - Added rule documentation links and notes to help. [#382](https://github.com/Microsoft/PSRule/issues/382)


### PR DESCRIPTION
## PR Summary

- Fixed JSON de-serialization fails with single object. #379
- Fixed stack overflow when parsing malformed JSON. #380
- Added rule documentation links and notes to help. #382
  - Added `-Full` switch to `Get-PSRuleHelp` to display links and notes sections.
- Added aliases for `-OutputFormat` (`-o`) and `-Module` (`-m`) parameters. #384
- Improved numeric comparison assertion helpers to support strings. #387
  - Methods `Greater`, `GreaterOrEqual`, `Less` and `LessOrEqual` now also check string length.
- Added support for assertion methods to be used within script pre-conditions. #386

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
