### PR TITLE
Added HasJsonSchema method #398 #399

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - Added support for qualified target names. [#395](https://github.com/Microsoft/PSRule/issues/395)
   - Added options `Binding.UseQualifiedName` and `Binding.NameSeparator`.
   - See `about_PSRule_Options` for details.
+- Added assertion method `HasJsonSchema` to check if a JSON schema is referenced. [#398](https://github.com/Microsoft/PSRule/issues/398)
+  - See `about_PSRule_Assert` for usage details.
+- Added file content helper for reading objects from files. [#399](https://github.com/Microsoft/PSRule/issues/399)
+  - The method `GetContent` of `$PSRule` can be used to read files as objects.
+  - See `about_PSRule_Variables` for usage details.
 
 ## v0.13.0
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ isFruit                             Pass       Fruit is only Apple, Orange and P
 
 ### Additional options
 
-To filter results to only non-fruit results, use `Invoke-PSRule -Outcome Fail`. Passed, failed and error results are shown by default.
+To filter results to only non-fruit results, use `Invoke-PSRule -Outcome Fail`.
+Passed, failed and error results are shown by default.
 
 ```powershell
 # Only show non-fruit results
@@ -235,6 +236,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [HasDefaultValue](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasdefaultvalue)
   - [HasField](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfield)
   - [HasFieldValue](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfieldvalue)
+  - [HasJsonSchema](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasjsonschema)
   - [JsonSchema](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#jsonschema)
   - [Less](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#less)
   - [LessOrEqual](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#lessorequal)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -22,6 +22,7 @@ The following built-in assertion methods are provided:
 - [HasDefaultValue](#hasdefaultvalue) - The object should not have the field or the field value is set to the default value.
 - [HasField](#hasfield) - The object must have the specified field.
 - [HasFieldValue](#hasfieldvalue) - The object must have the specified field and that field is not empty.
+- [HasJsonSchema](#hasjsonschema) - The object must reference a JSON schema with the `$schema` field.
 - [JsonSchema](#jsonschema) - The object must validate successfully against a JSON schema.
 - [Less](#less) - The field value must be less.
 - [LessOrEqual](#lessorequal) - The field value must be less or equal to.
@@ -42,7 +43,8 @@ Assertion methods use the following standard pattern:
   - Assertion methods must a `$Null` input object.
 - Assertion methods return the `AssertResult` object that is interpreted by the rule pipeline.
 
-Some assertion methods may overlap or provide similar functionality to built-in keywords. Where you have the choice, use built-in keywords.
+Some assertion methods may overlap or provide similar functionality to built-in keywords.
+Where you have the choice, use built-in keywords.
 Use assertion methods for advanced cases or increased flexibility.
 
 In the following example, `Assert.HasFieldValue` asserts that `$TargetObject` should have a field named `Type` with a non-empty value.
@@ -275,6 +277,32 @@ Rule 'HasFieldValue' {
 }
 ```
 
+### HasJsonSchema
+
+The `HasJsonSchema` assertion method determines if the input object has a `$schema` property defined.
+If the `$schema` property is defined, it must match one of the supplied schemas.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being compared.
+- `uri` - Optional. When specified, the object being compared must have a `$schema` property set to one of the specified schemas.
+
+Reasons include:
+
+- _The parameter 'inputObject' is null._
+- _The field '$schema' does not exist._
+- _The field value '$schema' is not a string._
+- _None of the specified schemas match '{0}'._
+
+Examples:
+
+```powershell
+Rule 'HasFieldValue' {
+    $Assert.HasJsonSchema($TargetObject)
+    $Assert.HasJsonSchema($TargetObject, "http://json-schema.org/draft-07/schema`#")
+}
+```
+
 ### JsonSchema
 
 The `JsonSchema` assertion method compares the input object against a defined JSON schema.
@@ -282,7 +310,8 @@ The `JsonSchema` assertion method compares the input object against a defined JS
 The following parameters are accepted:
 
 - `inputObject` - The object being compared against the JSON schema.
-- `uri` - A URL or file path to a JSON schema file formatted as UTF-8. Either a file path or URL can be used to specify the location of the schema file.
+- `uri` - A URL or file path to a JSON schema file formatted as UTF-8.
+Either a file path or URL can be used to specify the location of the schema file.
 
 Reasons include:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -146,15 +146,25 @@ The following properties are available for read access:
 
 - `Field` - A hashtable of custom bound fields. See option `Binding.Field` for more information.
 - `TargetObject` - The object currently being processed on the pipeline.
-- `TargetName` - The name of the object currently being processed on the pipeline. This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
-- `TargetType` - The type of the object currently being processed on the pipeline. This property will automatically bind to `PSObject.TypeNames[0]` by default.
+- `TargetName` - The name of the object currently being processed on the pipeline.
+This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
+- `TargetType` - The type of the object currently being processed on the pipeline.
+This property will automatically bind to `PSObject.TypeNames[0]` by default.
 
 The following properties are available for read/ write access:
 
-- `Data` - A hashtable of custom data. This property can be populated during rule execution. Custom data is not used by PSRule directly, and is intended to be used by downstream processes that need to interpret PSRule results.
+- `Data` - A hashtable of custom data. This property can be populated during rule execution.
+Custom data is not used by PSRule directly, and is intended to be used by downstream processes that need to interpret PSRule results.
 
 To bind fields that already exist on the target object use custom binding and `Binding.Field`.
 Use custom data to store data that must be calculated during rule execution.
+
+The following helper methods are available:
+
+- `GetContent(PSObject sourceObject)` - Returns the content of a file as one or more objects.
+The parameter `sourceObject` should be a `FileInfo` or a `Uri` object.
+The file format is detected based on the same file formats as the option `Input.Format`.
+i.e. Yaml, Json, Markdown and PowerShell Data.
 
 Syntax:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,7 +33,7 @@ To install the extension:
 code --install-extension bewhite.psrule-vscode-preview
 ```
 
-For additional installation options see [install instructions](scenarios/install-instructions.md).
+For additional installation options, see [install instructions](scenarios/install-instructions.md).
 
 ## Reusable
 

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -21,7 +21,7 @@ namespace PSRule.Host
         public PSRuleVariable()
             : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
-            _Value = new Runtime.PSRule();
+            _Value = new Runtime.PSRule(PipelineContext.CurrentThread);
         }
 
         public override object Value

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -68,8 +68,9 @@ namespace PSRule.Pipeline
 
         internal ExecutionScope ExecutionScope;
 
-        internal readonly Dictionary<string, Hashtable> DataCache;
+        internal readonly Dictionary<string, Hashtable> LocalizedDataCache;
         internal readonly Dictionary<string, object> ExpressionCache;
+        internal readonly Dictionary<string, PSObject[]> ContentCache;
         internal readonly string[] Culture;
         internal readonly BaselineContext Baseline;
         internal readonly HostContext HostContext;
@@ -108,8 +109,9 @@ namespace PSRule.Pipeline
             _PassStream = option.Logging.RulePass ?? LoggingOption.Default.RulePass.Value;
 
             _NameTokenCache = new Dictionary<string, NameToken>();
-            DataCache = new Dictionary<string, Hashtable>();
+            LocalizedDataCache = new Dictionary<string, Hashtable>();
             ExpressionCache = new Dictionary<string, object>();
+            ContentCache = new Dictionary<string, PSObject[]>();
 
             _Reason = new List<string>();
             _Binder = binder;
@@ -422,6 +424,8 @@ namespace PSRule.Pipeline
             _ObjectNumber++;
             TargetObject = targetObject;
             _Binder.Bind(Baseline, targetObject);
+            if (ContentCache.Count > 0)
+                ContentCache.Clear();
         }
 
         /// <summary>
@@ -530,7 +534,6 @@ namespace PSRule.Pipeline
                     {
                         _Hash.Dispose();
                     }
-
                     if (_Runspace != null)
                     {
                         _Runspace.Dispose();
@@ -538,10 +541,10 @@ namespace PSRule.Pipeline
 
                     _RuleTimer.Stop();
                     _NameTokenCache.Clear();
-                    DataCache.Clear();
+                    LocalizedDataCache.Clear();
                     ExpressionCache.Clear();
+                    ContentCache.Clear();
                 }
-
                 _Disposed = true;
             }
         }

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -151,6 +151,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to None of the specified schemas match &apos;{0}&apos;..
+        /// </summary>
+        internal static string HasJsonSchema {
+            get {
+                return ResourceManager.GetString("HasJsonSchema", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed schema validation on {0}. {1}.
         /// </summary>
         internal static string JsonSchemaInvalid {

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -149,6 +149,9 @@
   <data name="HasFieldValue" xml:space="preserve">
     <value>The value of '{0}' is null or empty.</value>
   </data>
+  <data name="HasJsonSchema" xml:space="preserve">
+    <value>None of the specified schemas match '{0}'.</value>
+  </data>
   <data name="JsonSchemaInvalid" xml:space="preserve">
     <value>Failed schema validation on {0}. {1}</value>
   </data>

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -99,6 +99,27 @@ namespace PSRule.Runtime
         }
 
         /// <summary>
+        /// The object should have the $schema property defined with the URI.
+        /// </summary>
+        public AssertResult HasJsonSchema(PSObject inputObject, string[] uri = null)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardField(inputObject, "$schema", false, out object fieldValue, out result) ||
+                GuardString(fieldValue, out string value, out result))
+                return result;
+
+            if (uri == null || uri.Length == 0)
+                return Pass();
+
+            for (var i = 0; i < uri.Length; i++)
+                if (StringComparer.OrdinalIgnoreCase.Equals(value, uri[i]))
+                    return Pass();
+
+            return Fail(ReasonStrings.HasJsonSchema, value);
+        }
+
+        /// <summary>
         /// The object should have a specific field.
         /// </summary>
         public AssertResult HasField(PSObject inputObject, string field, bool caseSensitive = false)

--- a/src/PSRule/Runtime/LocalizedData.cs
+++ b/src/PSRule/Runtime/LocalizedData.cs
@@ -31,15 +31,15 @@ namespace PSRule.Runtime
             if (path == null)
                 return Empty;
 
-            if (PipelineContext.CurrentThread.DataCache.ContainsKey(path))
-                return PipelineContext.CurrentThread.DataCache[path];
+            if (PipelineContext.CurrentThread.LocalizedDataCache.ContainsKey(path))
+                return PipelineContext.CurrentThread.LocalizedDataCache[path];
 
             var ast = System.Management.Automation.Language.Parser.ParseFile(path, out Token[] tokens, out ParseError[] errors);
             var data = ast.Find(a => a is HashtableAst, false);
             if (data != null)
             {
                 var result = (Hashtable)data.SafeGetValue();
-                PipelineContext.CurrentThread.DataCache[path] = result;
+                PipelineContext.CurrentThread.LocalizedDataCache[path] = result;
                 return result;
             }
             return Empty;

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -32,6 +32,21 @@ namespace PSRule
         }
 
         [Fact]
+        public void HasJsonSchema()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+
+            var actual1 = GetObject((name: "$schema", value: "abc"));
+            var actual2 = GetObject((name: "schema", value: "abc"));
+
+            Assert.True(assert.HasJsonSchema(actual1, null).Result);
+            Assert.True(assert.HasJsonSchema(actual1, new string[] { "abc" }).Result);
+            Assert.False(assert.HasJsonSchema(actual2, new string[] { "abc" }).Result);
+            Assert.True(assert.HasJsonSchema(actual1, new string[] { "efg", "abc" }).Result);
+        }
+
+        [Fact]
         public void StartsWith()
         {
             SetContext();

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -137,6 +137,9 @@ Rule 'VariableContextVariable' {
     $PSRule.Data['property2'] = 'value2';
     $PSRule.Data.Add('property3', 'value3');
     $PSRule.Data.Count -eq 3;
+
+    # Get content
+    $PSRule.GetContent((Get-Item -Path (Join-Path -Path $PSScriptRoot -ChildPath 'ObjectFromFile.json'))).Length -eq 2;
 }
 
 # Synopsis: Test $Rule automatic variables

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -79,6 +79,17 @@ Rule 'Assert.HasDefaultValue' {
     $Assert.HasDefaultValue($TargetObject, 'OtherInt', 1)
 }
 
+# Synopsis: Test for $Assert.HasJsonSchema
+Rule 'Assert.HasJsonSchema' {
+    $schemas = @(
+        "http://json-schema.org/draft-04/schema`#"
+        "http://json-schema.org/draft-07/schema`#"
+    )
+    $Assert.HasJsonSchema($TargetObject)
+    $Assert.HasJsonSchema($TargetObject, $schemas[1])
+    $Assert.HasJsonSchema($TargetObject, $schemas)
+}
+
 # Synopsis: Test for $Assert.JsonSchema
 Rule 'Assert.JsonSchema' {
     $Assert.JsonSchema($TargetObject, 'tests/PSRule.Tests/FromFile.Json.schema.json')

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -46,6 +46,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 CompareString = 'abc'
             }
             [PSCustomObject]@{
+                '$schema' = "http://json-schema.org/draft-07/schema`#"
                 Name = 'TestObject2'
                 NotType = 'TestType'
                 Value = $Null
@@ -204,6 +205,22 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[1].TargetName | Should -Be 'TestObject2';
             $result[1].Reason.Length | Should -Be 3;
             $result[1].Reason[0..2] | Should -BeLike "The field '*' is set to '*'.";
+        }
+
+        It 'HasJsonSchema' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.HasJsonSchema');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $False;
+            $result[0].TargetName | Should -Be 'TestObject1';
+            $result[0].Reason.Length | Should -Be 3;
+            $result[0].Reason | Should -BeIn 'The field ''$schema'' does not exist.';
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $True;
+            $result[1].TargetName | Should -Be 'TestObject2';
         }
 
         It 'JsonSchema' {


### PR DESCRIPTION
## PR Summary

- Added assertion method `HasJsonSchema` to check if a JSON schema is referenced. #398
  - See `about_PSRule_Assert` for usage details.
- Added file content helper for reading objects from files. #399
  - The method `GetContent` of `$PSRule` can be used to read files as objects.
  - See `about_PSRule_Variables` for usage details.

Fixes #398 
Fixes #399 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
