### PR TITLE
Pre-release v0.14.0-B2001020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.14.0-B2001020 (pre-release)
+
 - Added support for qualified target names. [#395](https://github.com/Microsoft/PSRule/issues/395)
   - Added options `Binding.UseQualifiedName` and `Binding.NameSeparator`.
   - See `about_PSRule_Options` for details.


### PR DESCRIPTION
## PR Summary

- Added support for qualified target names. #395
  - Added options `Binding.UseQualifiedName` and `Binding.NameSeparator`.
  - See `about_PSRule_Options` for details.
- Added assertion method `HasJsonSchema` to check if a JSON schema is referenced. #398
  - See `about_PSRule_Assert` for usage details.
- Added file content helper for reading objects from files. #399
  - The method `GetContent` of `$PSRule` can be used to read files as objects.
  - See `about_PSRule_Variables` for usage details.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
