### PR TITLE
Pre-release v0.14.0-B2002003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.14.0-B2002003 (pre-release)
+
 - Fixed wide formatting of rules with `Get-PSRule`. [#407](https://github.com/Microsoft/PSRule/issues/407)
 - Fixed TargetName hash serialization for base types. [#406](https://github.com/Microsoft/PSRule/issues/406)
 - Fixed output not generated with Assert-PSRule and Stop. [#405](https://github.com/Microsoft/PSRule/issues/405)


### PR DESCRIPTION
## PR Summary

- Fixed wide formatting of rules with `Get-PSRule`. #407
- Fixed TargetName hash serialization for base types. #406
- Fixed output not generated with Assert-PSRule and Stop. #405
- Fixed NUnit results incorrectly reporting that the test had not executed. #403
- Improved NUnit results to include a failure message based on reported reasons. #404
- Improved reporting on runtime errors in rule blocks. #239

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
