### PR TITLE
Fix output of warning with Assert-PSRule #417

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix output of warning with `Assert-PSRule`. [#417](https://github.com/Microsoft/PSRule/issues/417)
+
 ## v0.15.0-B2002005 (pre-release)
 
 - Fix parent culture unwind with POSIX. [#414](https://github.com/Microsoft/PSRule/issues/414)

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -413,6 +413,11 @@ namespace PSRule.Pipeline
                     _InnerWriter.WriteObject(sendToPipeline, enumerateCollection);
             }
 
+            public override void WriteWarning(string message)
+            {
+                _Formatter.Warning(new WarningRecord(message));
+            }
+
             public override void End()
             {
                 _Formatter.End(_TotalCount, _FailCount, _ErrorCount);

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -50,6 +50,12 @@ Rule 'WithFunctionError' {
     FunctionError
 }
 
+# Synopsis: A rule writing a warning
+Rule 'WithWarning' {
+    Write-Warning 'This is a warning';
+    $True;
+}
+
 function global:FunctionError {
     param ()
     process {

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1036,7 +1036,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $assertParams = @{
                 Path = $ruleFilePath
                 Option = @{ 'Output.Style' = 'GitHubActions' }
-                Name = 'FromFile1', 'FromFile2', 'FromFile3'
+                Name = 'FromFile1', 'FromFile2', 'FromFile3', 'WithWarning'
                 ErrorVariable = 'errorOut'
                 WarningAction = 'SilentlyContinue'
             }
@@ -1046,6 +1046,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $result | Should -Match '\[\+\] FromFile1';
             $result | Should -Match '::error::\[FAIL\] TestObject1 failed FromFile2';
             $result | Should -Match '::error::\[FAIL\] TestObject1 failed FromFile3';
+            $result | Should -Match '::warning::This is a warning';
             $errorOut | Should -Not -BeNullOrEmpty;
         }
 
@@ -1053,7 +1054,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $assertParams = @{
                 Path = $ruleFilePath
                 Option = @{ 'Output.Style' = 'AzurePipelines' }
-                Name = 'FromFile1', 'FromFile2', 'FromFile3'
+                Name = 'FromFile1', 'FromFile2', 'FromFile3', 'WithWarning'
                 ErrorVariable = 'errorOut'
                 WarningAction = 'SilentlyContinue'
             }
@@ -1063,6 +1064,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $result | Should -Match '\[\+\] FromFile1';
             $result | Should -Match "`#`#vso\[task\.logissue type=error\]TestObject1 failed FromFile2";
             $result | Should -Match "`#`#vso\[task\.logissue type=error\]TestObject1 failed FromFile3";
+            $result | Should -Match "`#`#vso\[task\.logissue type=warning\]This is a warning";
             $errorOut | Should -Not -BeNullOrEmpty;
         }
     }


### PR DESCRIPTION
## PR Summary

- Fix output of warning with `Assert-PSRule`. #417

Fixes #417 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
