### PR TITLE
Pre-release v0.15.0-B2002012

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.15.0-B2002012 (pre-release)
+
 - Fixed output of warning with `Assert-PSRule`. [#417](https://github.com/Microsoft/PSRule/issues/417)
 - Fixed NUnit report to include a failure element when reason is not specified. [#420](https://github.com/Microsoft/PSRule/issues/420)
 - Added recommendation to failure message of NUnit results. [#421](https://github.com/Microsoft/PSRule/issues/421)


### PR DESCRIPTION
## PR Summary

- Fixed output of warning with `Assert-PSRule`. #417
- Fixed NUnit report to include a failure element when reason is not specified. #420
- Added recommendation to failure message of NUnit results. #421

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
