### PR TITLE
Add -ResultVariable to Assert-PSRule #412

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `-ResultVariable` to store results from Assert-PSRule into a variable. [#412](https://github.com/Microsoft/PSRule/issues/412)
+
 ## v0.15.0-B2002012 (pre-release)
 
 - Fixed output of warning with `Assert-PSRule`. [#417](https://github.com/Microsoft/PSRule/issues/417)
@@ -10,7 +12,7 @@
 
 ## v0.15.0-B2002005 (pre-release)
 
-- Fix parent culture unwind with POSIX. [#414](https://github.com/Microsoft/PSRule/issues/414)
+- Fixed parent culture unwind with POSIX. [#414](https://github.com/Microsoft/PSRule/issues/414)
 
 ## v0.14.0
 

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -19,7 +19,8 @@ Evaluate objects against matching rules and assert any failures.
 Assert-PSRule [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>] [-Style <OutputStyle>]
  [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-OutputPath <String>]
  [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
- [-Culture <String[]>] -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Culture <String[]>] -InputObject <PSObject> [-ResultVariable <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### InputPath
@@ -28,7 +29,7 @@ Assert-PSRule [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineO
 Assert-PSRule -InputPath <String[]> [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>]
  [-Style <OutputStyle>] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-OutputPath <String>]
  [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
- [-Culture <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Culture <String[]>] [-ResultVariable <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -66,11 +67,11 @@ $items | Assert-PSRule -Path .\docs\scenarios\fruit\
 ```text
 -> Fridge : System.Management.Automation.PSCustomObject
 
-    [FAIL] isFruit
+   [FAIL] isFruit
 
 -> Apple : System.Management.Automation.PSCustomObject
 
-    [PASS] isFruit
+   [PASS] isFruit
 
 Assert-PSRule : One or more rules reported failure.
 At line:1 char:10
@@ -81,6 +82,23 @@ At line:1 char:10
 ```
 
 Evaluate an array of objects on the pipeline against rules loaded a specified relative path.
+
+### Example 3
+
+```powershell
+$items | Assert-PSRule -Module PSRule.Rules.Azure -o NUnit3 -OutputPath .\reports\results.xml
+```
+
+Evaluate items from a pre-installed rules module PSRule.Rules.Azure.
+Additionally save the results as a NUnit report.
+
+### Example 4
+
+```powershell
+$items | Assert-PSRule -Path .\docs\scenarios\fruit\ -ResultVariable resultRecords;
+```
+
+Evaluate items and additionally save the results into a variable `resultRecords`.
 
 ## PARAMETERS
 
@@ -421,6 +439,22 @@ Prompts you for confirmation before running the cmdlet.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResultVariable
+
+Stores output result objects in the specified variable.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -13,10 +13,6 @@ Set-StrictMode -Version latest;
 # Localization
 #
 
-# $LocalizedHelp = data {
-
-# }
-
 Import-LocalizedData -BindingVariable LocalizedHelp -FileName 'PSRule.Resources.psd1' -ErrorAction SilentlyContinue;
 
 #
@@ -167,7 +163,7 @@ function Invoke-PSRule {
             $builder.InputPath($inputPaths);
         }
 
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
@@ -320,7 +316,7 @@ function Test-PSRuleTarget {
             $builder.InputPath($inputPaths);
         }
 
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
@@ -357,6 +353,7 @@ function Test-PSRuleTarget {
     }
 }
 
+# .ExternalHelp PSRule-Help.xml
 function Assert-PSRule {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSShouldProcess', '', Justification = 'ShouldProcess is used within CSharp code.')]
     [CmdletBinding(DefaultParameterSetName = 'Input', SupportsShouldProcess = $True)]
@@ -416,7 +413,10 @@ function Assert-PSRule {
 
         [Parameter(Mandatory = $True, ValueFromPipeline = $True, ParameterSetName = 'Input')]
         [Alias('TargetObject')]
-        [PSObject]$InputObject
+        [PSObject]$InputObject,
+
+        [Parameter(Mandatory = $False)]
+        [String]$ResultVariable
     )
     begin {
         Write-Verbose -Message '[Assert-PSRule] BEGIN::';
@@ -487,13 +487,14 @@ function Assert-PSRule {
         $builder.Name($Name);
         $builder.Tag($Tag);
         $builder.UseBaseline($Baseline);
+        $builder.ResultVariable($ResultVariable);
 
         if ($PSBoundParameters.ContainsKey('InputPath')) {
             $inputPaths = GetFilePath -Path $InputPath -Verbose:$VerbosePreference;
             $builder.InputPath($inputPaths);
         }
 
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
@@ -634,7 +635,7 @@ function Get-PSRule {
             $builder.IncludeDependencies();
         }
 
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
@@ -730,7 +731,7 @@ function Get-PSRuleBaseline {
 
         $builder = [PSRule.Pipeline.PipelineBuilder]::GetBaseline($sourceFiles, $Option);
         $builder.Name($Name);
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
@@ -855,7 +856,7 @@ function Get-PSRuleHelp {
             $builder.Full();
         }
 
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
         $pipeline = $builder.Build();
     }
@@ -1541,7 +1542,7 @@ function GetSource {
     )
     process {
         $builder = [PSRule.Pipeline.PipelineBuilder]::RuleSource().Configure($Option);
-        $builder.UseCommandRuntime($PSCmdlet.CommandRuntime);
+        $builder.UseCommandRuntime($PSCmdlet);
         $builder.UseExecutionContext($ExecutionContext);
 
         if ($PSBoundParameters.ContainsKey('Path')) {

--- a/src/PSRule/Pipeline/HostContext.cs
+++ b/src/PSRule/Pipeline/HostContext.cs
@@ -3,7 +3,7 @@
 
 namespace PSRule.Pipeline
 {
-    internal class HostContext
+    internal sealed class HostContext
     {
         /// <summary>
         /// Determine if running is remote session.

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -17,12 +17,15 @@ namespace PSRule.Pipeline
         void Limit(RuleOutcome outcome);
 
         void InputPath(string[] path);
+
+        void ResultVariable(string variableName);
     }
 
     internal abstract class InvokePipelineBuilderBase : PipelineBuilderBase, IInvokePipelineBuilder
     {
         protected RuleOutcome Outcome;
         protected string[] _InputPath;
+        protected string _ResultVariableName;
         private VisitTargetObject _VisitTargetObject;
 
         protected BindTargetMethod _BindTargetNameHook;
@@ -48,6 +51,11 @@ namespace PSRule.Pipeline
         public void InputPath(string[] path)
         {
             _InputPath = path;
+        }
+
+        public void ResultVariable(string variableName)
+        {
+            _ResultVariableName = variableName;
         }
 
         public override IPipelineBuilder Configure(PSRuleOption option)
@@ -182,7 +190,6 @@ namespace PSRule.Pipeline
                     return PipelineReceiverActions.DetectInputFormat(sourceObject, next);
                 });
             }
-
             return new PipelineReader(_VisitTargetObject, _InputPath);
         }
     }
@@ -331,7 +338,6 @@ namespace PSRule.Pipeline
                     tag: ruleBlock.Tag,
                     info: ruleBlock.Info
                 );
-
                 _Summary.Add(ruleBlock.RuleId, s);
             }
 

--- a/src/PSRule/Pipeline/Output/CsvOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/CsvOutputWriter.cs
@@ -22,9 +22,9 @@ namespace PSRule.Pipeline.Output
             _Builder = new StringBuilder();
         }
 
-        public override void WriteObject(object o, bool enumerate)
+        public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
-            if (!(o is InvokeResult result))
+            if (!(sendToPipeline is InvokeResult result))
                 return;
 
             Add(result);

--- a/src/PSRule/Pipeline/Output/FileOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/FileOutputWriter.cs
@@ -25,9 +25,9 @@ namespace PSRule.Pipeline.Output
             _ShouldProcess = shouldProcess;
         }
 
-        public override void WriteObject(object o, bool enumerate)
+        public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
-            WriteToFile(o);
+            WriteToFile(sendToPipeline);
         }
 
         private void WriteToFile(object o)

--- a/src/PSRule/Pipeline/Output/NUnit3OutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/NUnit3OutputWriter.cs
@@ -19,9 +19,9 @@ namespace PSRule.Pipeline.Output
             _Builder = new StringBuilder();
         }
 
-        public override void WriteObject(object o, bool enumerate)
+        public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
-            if (!(o is InvokeResult result))
+            if (!(sendToPipeline is InvokeResult result))
                 return;
 
             Add(result);

--- a/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
+++ b/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
@@ -53,7 +53,7 @@ namespace PSRule.Pipeline.Output
                 _DebugFilter = new HashSet<string>(Option.Logging.LimitDebug);
         }
 
-        internal void UseCommandRuntime(ICommandRuntime2 commandRuntime)
+        internal void UseCommandRuntime(PSCmdlet commandRuntime)
         {
             OnWriteVerbose = commandRuntime.WriteVerbose;
             OnWriteWarning = commandRuntime.WriteWarning;
@@ -141,15 +141,15 @@ namespace PSRule.Pipeline.Output
             OnWriteDebug(debugRecord.Message);
         }
 
-        public override void WriteObject(object sendToPipeline, bool enumerate)
+        public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
             if (OnWriteObject == null)
                 return;
 
             if (sendToPipeline is InvokeResult result)
-                ExpandRuleRecord(result.AsRecord());
+                ProcessRecord(result.AsRecord());
             else
-                OnWriteObject(sendToPipeline, enumerate);
+                OnWriteObject(sendToPipeline, enumerateCollection);
         }
 
         public override void WriteHost(HostInformationMessage info)
@@ -199,7 +199,7 @@ namespace PSRule.Pipeline.Output
 
         #endregion Internal logging methods
 
-        private void ExpandRuleRecord(RuleRecord[] records)
+        private void ProcessRecord(RuleRecord[] records)
         {
             if (records == null || records.Length == 0)
                 return;

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -3,13 +3,11 @@
 
 using PSRule.Configuration;
 using PSRule.Pipeline.Output;
-using PSRule.Resources;
 using PSRule.Rules;
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
 using System.Management.Automation;
 using System.Text;
 using System.Threading;
@@ -68,7 +66,7 @@ namespace PSRule.Pipeline
 
     public interface IPipelineBuilder
     {
-        void UseCommandRuntime(ICommandRuntime2 commandRuntime);
+        void UseCommandRuntime(PSCmdlet commandRuntime);
 
         void UseExecutionContext(EngineIntrinsics executionContext);
 
@@ -91,6 +89,7 @@ namespace PSRule.Pipeline
         protected readonly PSRuleOption Option;
         protected readonly Source[] Source;
         protected readonly HostContext HostContext;
+        protected PSCmdlet CmdletContext;
 
         private string[] _Include;
         private Hashtable _Tag;
@@ -123,8 +122,9 @@ namespace PSRule.Pipeline
             _Tag = tag;
         }
 
-        public virtual void UseCommandRuntime(ICommandRuntime2 commandRuntime)
+        public virtual void UseCommandRuntime(PSCmdlet commandRuntime)
         {
+            CmdletContext = commandRuntime;
             _ShouldProcess = commandRuntime.ShouldProcess;
             _Output.UseCommandRuntime(commandRuntime);
         }

--- a/src/PSRule/Pipeline/PipelineLogger.cs
+++ b/src/PSRule/Pipeline/PipelineLogger.cs
@@ -143,7 +143,7 @@ namespace PSRule.Pipeline
         private bool _LogInformation;
         private bool _LogDebug;
 
-        internal void UseCommandRuntime(ICommandRuntime2 commandRuntime)
+        internal void UseCommandRuntime(PSCmdlet commandRuntime)
         {
             OnWriteVerbose = commandRuntime.WriteVerbose;
             OnWriteWarning = commandRuntime.WriteWarning;

--- a/src/PSRule/Pipeline/TestPipeline.cs
+++ b/src/PSRule/Pipeline/TestPipeline.cs
@@ -20,9 +20,9 @@ namespace PSRule.Pipeline
                 _Outcome = outcome;
             }
 
-            public override void WriteObject(object o, bool enumerate)
+            public override void WriteObject(object sendToPipeline, bool enumerateCollection)
             {
-                if (!(o is InvokeResult result) || !ShouldOutput(result.Outcome))
+                if (!(sendToPipeline is InvokeResult result) || !ShouldOutput(result.Outcome))
                     return;
 
                 base.WriteObject(result.IsSuccess(), false);

--- a/src/PSRule/Rules/RuleSource.cs
+++ b/src/PSRule/Rules/RuleSource.cs
@@ -112,7 +112,7 @@ namespace PSRule.Rules
             return this;
         }
 
-        public void UseCommandRuntime(ICommandRuntime2 commandRuntime)
+        public void UseCommandRuntime(PSCmdlet commandRuntime)
         {
             _Logger.UseCommandRuntime(commandRuntime);
         }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1092,6 +1092,27 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
         }
     }
 
+    Context 'With -ResultVariable' {
+        $testObject = [PSCustomObject]@{
+            Name = 'TestObject1'
+        }
+        It 'Returns output' {
+            $assertParams = @{
+                Path = $ruleFilePath
+                Name = 'FromFile1', 'FromFile2', 'FromFile3'
+                ErrorAction = 'SilentlyContinue'
+                WarningAction = 'SilentlyContinue'
+            }
+            $Null = $testObject | Assert-PSRule @assertParams -ResultVariable 'recordsOut' 6>&1 | Out-String;
+            $recordsOut | Should -Not -BeNullOrEmpty;
+            $recordsOut | Should -BeOfType 'PSRule.Rules.RuleRecord';
+            $recordsOut.Length | Should -Be 3;
+            $recordsOut[0].IsSuccess() | Should -Be $True;
+            $recordsOut[1].IsSuccess() | Should -Be $False;
+            $recordsOut[2].IsSuccess() | Should -Be $False;
+        }
+    }
+
     Context 'With constrained language' {
         $testObject = [PSCustomObject]@{
             Name = 'TestObject1'


### PR DESCRIPTION
## PR Summary

- Added `-ResultVariable` to store results from Assert-PSRule into a variable. #412

Fixes #412 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
