### PR TITLE
Fixed handling of v in version field value #429

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed handling of `v` in field value with `$Assert.Version`. [#429](https://github.com/Microsoft/PSRule/issues/429)
+
 ## v0.15.0-B2002019 (pre-release)
 
 - Added `-ResultVariable` to store results from Assert-PSRule into a variable. [#412](https://github.com/Microsoft/PSRule/issues/412)

--- a/src/PSRule/Runtime/SemanticVersion.cs
+++ b/src/PSRule/Runtime/SemanticVersion.cs
@@ -250,7 +250,6 @@ namespace PSRule.Runtime
 
             internal void GetConstraint(out CompareFlag flag)
             {
-                SkipLeading();
                 flag = CompareFlag.None;
                 while (!EOF && IsConstraint(_Current))
                 {
@@ -271,7 +270,7 @@ namespace PSRule.Runtime
 
             private void SkipLeading()
             {
-                if (!EOF && _Position == 0 && (_Current == EQUAL || _Current == VUPPER || _Current == VLOWER))
+                if (!EOF && (_Current == VUPPER || _Current == VLOWER))
                     Next();
             }
 
@@ -292,6 +291,7 @@ namespace PSRule.Runtime
             {
                 segments = new int[] { -1, -1, -1, -1 };
                 var segmentIndex = 0;
+                SkipLeading();
                 while (!EOF)
                 {
                     if (!IsAllowedChar(_Current))
@@ -437,7 +437,6 @@ namespace PSRule.Runtime
 
             stream.TryPrerelease(out string prerelease);
             stream.TryBuild(out string build);
-
             version = new Version(segments[0], segments[1], segments[2], prerelease, build);
             return true;
         }

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/PSRule.Tests/SemanticVersionTests.cs
+++ b/tests/PSRule.Tests/SemanticVersionTests.cs
@@ -16,6 +16,13 @@ namespace PSRule
             Assert.Equal(3, actual1.Patch);
             Assert.Equal("alpha.3", actual1.PreRelease);
             Assert.Equal("7223b39", actual1.Build);
+
+            Assert.True(Runtime.SemanticVersion.TryParseVersion("v1.2.3-alpha.3+7223b39", out Runtime.SemanticVersion.Version actual2));
+            Assert.Equal(1, actual2.Major);
+            Assert.Equal(2, actual2.Minor);
+            Assert.Equal(3, actual2.Patch);
+            Assert.Equal("alpha.3", actual2.PreRelease);
+            Assert.Equal("7223b39", actual2.Build);
         }
 
         [Fact]
@@ -33,6 +40,8 @@ namespace PSRule
             Assert.True(Runtime.SemanticVersion.TryParseConstraint("<1.2.3-beta", out Runtime.SemanticVersion.Constraint actual5));
             Assert.True(Runtime.SemanticVersion.TryParseConstraint("^1.2.3-alpha", out Runtime.SemanticVersion.Constraint actual6));
             Assert.True(Runtime.SemanticVersion.TryParseConstraint("<3.4.6", out Runtime.SemanticVersion.Constraint actual7));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("=v1.2.3", out Runtime.SemanticVersion.Constraint actual8));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint(">=v1.2.3", out Runtime.SemanticVersion.Constraint actual9));
 
             Assert.True(actual1.Equals(version1));
             Assert.False(actual2.Equals(version1));
@@ -41,6 +50,8 @@ namespace PSRule
             Assert.False(actual5.Equals(version1));
             Assert.True(actual6.Equals(version1));
             Assert.True(actual7.Equals(version1));
+            Assert.True(actual8.Equals(version1));
+            Assert.True(actual9.Equals(version1));
 
             Assert.False(actual1.Equals(version2));
             Assert.True(actual2.Equals(version2));
@@ -49,6 +60,8 @@ namespace PSRule
             Assert.True(actual5.Equals(version2));
             Assert.True(actual6.Equals(version2));
             Assert.False(actual7.Equals(version2));
+            Assert.False(actual8.Equals(version2));
+            Assert.False(actual9.Equals(version2));
 
             Assert.False(actual1.Equals(version3));
             Assert.False(actual2.Equals(version3));
@@ -57,6 +70,8 @@ namespace PSRule
             Assert.False(actual5.Equals(version3));
             Assert.False(actual6.Equals(version3));
             Assert.False(actual7.Equals(version3));
+            Assert.False(actual8.Equals(version3));
+            Assert.False(actual9.Equals(version3));
 
             Assert.False(actual1.Equals(version4));
             Assert.False(actual2.Equals(version4));
@@ -65,6 +80,8 @@ namespace PSRule
             Assert.False(actual5.Equals(version4));
             Assert.False(actual6.Equals(version4));
             Assert.True(actual7.Equals(version4));
+            Assert.False(actual8.Equals(version4));
+            Assert.True(actual9.Equals(version4));
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed handling of `v` in field value with `$Assert.Version`. #429

Fixes #429 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
