### PR TITLE
Fixed handling of warning in Assert-PSRule #428

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed handling of `v` in field value with `$Assert.Version`. [#429](https://github.com/Microsoft/PSRule/issues/429)
+- Fixed handling of warning action preference with `Assert-PSRule`. [#428](https://github.com/Microsoft/PSRule/issues/428)
 
 ## v0.15.0-B2002019 (pre-release)
 

--- a/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
+++ b/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
@@ -17,12 +17,6 @@ namespace PSRule.Pipeline.Output
         private const string Source = "PSRule";
         private const string HostTag = "PSHOST";
 
-        private const string ErrorPreference = "ErrorActionPreference";
-        private const string WarningPreference = "WarningPreference";
-        private const string VerbosePreference = "VerbosePreference";
-        private const string InformationPreference = "InformationPreference";
-        private const string DebugPreference = "DebugPreference";
-
         private Action<string> OnWriteWarning;
         private Action<string> OnWriteVerbose;
         private Action<ErrorRecord> OnWriteError;
@@ -74,11 +68,14 @@ namespace PSRule.Pipeline.Output
 
         private static bool GetPreferenceVariable(EngineIntrinsics executionContext, string variableName)
         {
-            var preference = (ActionPreference)executionContext.SessionState.PSVariable.GetValue(variableName);
+            var preference = GetPreferenceVariable(executionContext.SessionState, variableName);
             if (preference == ActionPreference.Ignore)
                 return false;
 
-            return !(preference == ActionPreference.SilentlyContinue && (variableName == VerbosePreference || variableName == DebugPreference));
+            return !(preference == ActionPreference.SilentlyContinue && (
+                variableName == VerbosePreference ||
+                variableName == DebugPreference)
+            );
         }
 
         #region Internal logging methods
@@ -169,7 +166,7 @@ namespace PSRule.Pipeline.Output
 
         public override bool ShouldWriteInformation()
         {
-            return true;
+            return _LogInformation;
         }
 
         public override bool ShouldWriteDebug()
@@ -179,12 +176,12 @@ namespace PSRule.Pipeline.Output
 
         public override bool ShouldWriteError()
         {
-            return true;
+            return _LogError;
         }
 
         public override bool ShouldWriteWarning()
         {
-            return true;
+            return _LogWarning;
         }
 
         public override void EnterScope(string scopeName)

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -90,6 +90,7 @@ namespace PSRule.Pipeline
         protected readonly Source[] Source;
         protected readonly HostContext HostContext;
         protected PSCmdlet CmdletContext;
+        protected EngineIntrinsics ExecutionContext;
 
         private string[] _Include;
         private Hashtable _Tag;
@@ -131,6 +132,7 @@ namespace PSRule.Pipeline
 
         public void UseExecutionContext(EngineIntrinsics executionContext)
         {
+            ExecutionContext = executionContext;
             HostContext.InSession = executionContext.SessionState.PSVariable.GetValue("PSSenderInfo") != null;
             _Output.UseExecutionContext(executionContext);
         }

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -11,6 +11,12 @@ namespace PSRule.Pipeline
 {
     internal abstract class PipelineWriter : ILogger
     {
+        protected const string ErrorPreference = "ErrorActionPreference";
+        protected const string WarningPreference = "WarningPreference";
+        protected const string VerbosePreference = "VerbosePreference";
+        protected const string InformationPreference = "InformationPreference";
+        protected const string DebugPreference = "DebugPreference";
+
         private readonly PipelineWriter _Writer;
 
         protected readonly PSRuleOption Option;
@@ -145,6 +151,11 @@ namespace PSRule.Pipeline
                 record.Error.Category,
                 record.TargetName
             ));
+        }
+
+        protected static ActionPreference GetPreferenceVariable(SessionState sessionState, string variableName)
+        {
+            return (ActionPreference)sessionState.PSVariable.GetValue(variableName);
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1029,6 +1029,23 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             Test-Path -Path $testOutputPath | Should -Be $True;
         }
 
+        It 'With -WarningAction' {
+            $assertParams = @{
+                Path = $ruleFilePath
+                Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain' }
+                Name = 'WithWarning'
+            }
+            $result = $testObject | Assert-PSRule @assertParams 6>&1 | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeOfType System.String;
+            $result | Should -Match "\[WARN\] This is a warning";
+
+            $result = $testObject | Assert-PSRule @assertParams -WarningAction SilentlyContinue 6>&1 | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeOfType System.String;
+            $result | Should -Not -Match "\[WARN\] This is a warning";
+        }
+
         It 'Writes output to file' {
             $testOutputPath = (Join-Path -Path $outputPath -ChildPath 'newPath/assert.results2.json');
             $assertParams = @{
@@ -1061,7 +1078,6 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
                 Option = @{ 'Output.Style' = 'GitHubActions' }
                 Name = 'FromFile1', 'FromFile2', 'FromFile3', 'WithWarning'
                 ErrorVariable = 'errorOut'
-                WarningAction = 'SilentlyContinue'
             }
             $result = $testObject | Assert-PSRule @assertParams -ErrorAction SilentlyContinue 6>&1 | Out-String;
             $result | Should -Not -BeNullOrEmpty;
@@ -1079,7 +1095,6 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
                 Option = @{ 'Output.Style' = 'AzurePipelines' }
                 Name = 'FromFile1', 'FromFile2', 'FromFile3', 'WithWarning'
                 ErrorVariable = 'errorOut'
-                WarningAction = 'SilentlyContinue'
             }
             $result = $testObject | Assert-PSRule @assertParams -ErrorAction SilentlyContinue 6>&1 | Out-String;
             $result | Should -Not -BeNullOrEmpty;


### PR DESCRIPTION
## PR Summary

- Fixed handling of warning action preference with `Assert-PSRule`. #428

Fixes #428 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
