### PR TITLE
Pre-release v0.15.0-B2002031

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.15.0-B2002031 (pre-release)
+
 - Fixed handling of `v` in field value with `$Assert.Version`. [#429](https://github.com/Microsoft/PSRule/issues/429)
 - Fixed handling of warning action preference with `Assert-PSRule`. [#428](https://github.com/Microsoft/PSRule/issues/428)
 


### PR DESCRIPTION
## PR Summary

- Fixed handling of `v` in field value with `$Assert.Version`. #429
- Fixed handling of warning action preference with `Assert-PSRule`. #428

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
