### PR TITLE
Update CI pipeline for PS 7.0 as default

### DIFF
--- a/.azure-pipelines/azure-pipelines.yaml
+++ b/.azure-pipelines/azure-pipelines.yaml
@@ -128,15 +128,16 @@ stages:
 
   - template: jobs/test.yaml
     parameters:
-      name: ps_6_ubuntu_18_04
+      name: ubuntu_18_04_coverage
       imageName: 'ubuntu-18.04'
-      displayName: 'PowerShell 6.2.4 - ubuntu-18.04'
+      displayName: 'PowerShell coverage'
       coverage: 'true'
+      publishResults: 'false'
 
   - template: jobs/test.yaml
     parameters:
       name: macOS_10_15
-      displayName: 'PowerShell 6.2.4 - macOS-10.15'
+      displayName: 'PowerShell 7.0 - macOS-10.15'
       imageName: 'macOS-10.15'
 
   - template: jobs/test.yaml
@@ -145,6 +146,7 @@ stages:
       displayName: 'PowerShell 5.1 - win2016'
       imageName: 'vs2017-win2016'
 
+  # Currently can't use alpine because addtional tools for Azure DevOps are required
   # - template: jobs/testContainer.yaml
   #   parameters:
   #     name: alpine_3_10
@@ -158,6 +160,13 @@ stages:
       displayName: 'PowerShell 7.0 - ubuntu-18.04'
       imageName: mcr.microsoft.com/powershell
       imageTag: 7.0.0-ubuntu-18.04
+
+  - template: jobs/testContainer.yaml
+    parameters:
+      name: ps_6_ubuntu_18_04
+      displayName: 'PowerShell 6.2.4 - ubuntu-18.04'
+      imageName: mcr.microsoft.com/powershell
+      imageTag: 6.2.4-ubuntu-18.04
 
 # Release pipeline
 - stage: Release

--- a/.azure-pipelines/jobs/test.yaml
+++ b/.azure-pipelines/jobs/test.yaml
@@ -7,6 +7,7 @@ parameters:
   buildConfiguration: 'Release'
   imageName: ''
   coverage: 'false'
+  publishResults: 'true'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -15,6 +16,7 @@ jobs:
     vmImage: ${{ parameters.imageName }}
   variables:
     COVERAGE: ${{ parameters.coverage }}
+    PUBLISHRESULTS: ${{ parameters.publishResults }}
     skipComponentGovernanceDetection: true
   steps:
 
@@ -46,7 +48,7 @@ jobs:
       platform: ${{ parameters.name }}
       configuration: ${{ parameters.buildConfiguration }}
       publishRunAttachments: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['PUBLISHRESULTS'], 'true'))
 
   # Generate Code Coverage report
   - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4

--- a/.azure-pipelines/jobs/testContainer.yaml
+++ b/.azure-pipelines/jobs/testContainer.yaml
@@ -9,6 +9,7 @@ parameters:
   imageName: ''
   imageTag: ''
   coverage: 'false'
+  publishResults: 'true'
 
 jobs:
 - job: ${{ parameters.name }}
@@ -19,8 +20,10 @@ jobs:
     image: '${{ parameters.imageName }}:${{ parameters.imageTag }}'
     env:
       COVERAGE: ${{ parameters.coverage }}
+      PUBLISHRESULTS: ${{ parameters.publishResults }}
   variables:
     COVERAGE: ${{ parameters.coverage }}
+    PUBLISHRESULTS: ${{ parameters.publishResults }}
     skipComponentGovernanceDetection: true
   steps:
 
@@ -50,7 +53,7 @@ jobs:
       platform: ${{ parameters.imageTag }}
       configuration: ${{ parameters.buildConfiguration }}
       publishRunAttachments: true
-    condition: succeededOrFailed()
+    condition: and(succeededOrFailed(), eq(variables['PUBLISHRESULTS'], 'true'))
 
   # Generate Code Coverage report
   - task: Palmmedia.reportgenerator.reportgenerator-build-release-task.reportgenerator@4


### PR DESCRIPTION
## PR Summary

- Azure Pipelines is not using PS 7.0 as default. Update CI process to check PS 6.2.4.
- Fix CI issue with YamlDotNet being used between PSRule and PlatyPS.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
