### PR TITLE
Support input of self reference #437

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - General improvements:
   - Added configuration option `Output.Culture` for setting culture. [#442](https://github.com/Microsoft/PSRule/issues/442)
+  - Improved handling of fields to allow the input object to be referenced with `.`. [#437](https://github.com/Microsoft/PSRule/issues/437)
 
 ## v0.15.0
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -40,7 +40,7 @@ Assertion methods use the following standard pattern:
 
 - The first parameter is _always_ the input object of type `PSObject`, additional parameters can be included based on the functionality required by the method.
   - In many cases the input object will be `$TargetObject`, however assertion methods must not assume that `$TargetObject` will be used.
-  - Assertion methods must a `$Null` input object.
+  - Assertion methods must accept a `$Null` input object.
 - Assertion methods return the `AssertResult` object that is interpreted by the rule pipeline.
 
 Some assertion methods may overlap or provide similar functionality to built-in keywords.
@@ -64,6 +64,25 @@ Rule 'Assert.HasRequiredFields' {
     $Assert.HasFieldValue($TargetObject, 'Value')
 }
 ```
+
+### Field names
+
+Many of the built-in assertion methods accept a field name.
+The field name is an expression that traverses object properties, keys or indexes of the _input object_.
+
+The field name can contain:
+
+- Property names for PSObjects or .NET objects.
+- Keys for hash table or dictionaries.
+- Indexes for arrays or collections.
+
+For example:
+
+- `.` refers to _input object_ itself.
+- `Name` or `.Name` refers to the name property/ key of the _input object_.
+- `Properties.enabled` refers to the enabled property under the Properties property.
+- `Tags.env` refers to the env key under a hash table property of the _input object_.
+- `Properties.securityRules[0].name` references to the name property of the first security rule.
 
 ### Contains
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -127,7 +127,7 @@ namespace PSRule.Runtime
             // Guard parameters
             if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
                 GuardNullOrEmptyParam(field, nameof(field), out result) ||
-                GuardField(inputObject, field, caseSensitive, out object fieldValue, out result))
+                GuardField(inputObject, field, caseSensitive, out _, out result))
                 return result;
 
             // Assert

--- a/src/PSRule/Runtime/NameToken.cs
+++ b/src/PSRule/Runtime/NameToken.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
+
 namespace PSRule.Runtime
 {
     /// <summary>
@@ -16,12 +18,18 @@ namespace PSRule.Runtime
         /// <summary>
         /// The token is an index in an object.
         /// </summary>
-        Index = 1
+        Index = 1,
+
+        /// <summary>
+        /// The token is a reference to the parent object. Can only be the first token.
+        /// </summary>
+        Self = 2
     }
 
     /// <summary>
     /// A token for expressing a path through a tree of fields.
     /// </summary>
+    [DebuggerDisplay("{Type}, Name = {Name}, Index = {Index}")]
     internal sealed class NameToken
     {
         /// <summary>

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -224,6 +224,9 @@ namespace PSRule
             Assert.False(assert.Greater(value, "value", 4).Result);
             Assert.True(assert.Greater(value, "value", 0).Result);
             Assert.True(assert.Greater(value, "value", -1).Result);
+
+            // Self
+            Assert.True(assert.Greater(3, ".", 2).Result);
         }
 
         [Fact]
@@ -255,6 +258,9 @@ namespace PSRule
             Assert.False(assert.GreaterOrEqual(value, "value", 4).Result);
             Assert.True(assert.GreaterOrEqual(value, "value", 0).Result);
             Assert.True(assert.GreaterOrEqual(value, "value", -1).Result);
+
+            // Self
+            Assert.True(assert.GreaterOrEqual(2, ".", 2).Result);
         }
 
         [Fact]
@@ -286,6 +292,9 @@ namespace PSRule
             Assert.True(assert.Less(value, "value", 4).Result);
             Assert.False(assert.Less(value, "value", 0).Result);
             Assert.False(assert.Less(value, "value", -1).Result);
+
+            // Self
+            Assert.True(assert.Less(1, ".", 2).Result);
         }
 
         [Fact]
@@ -317,6 +326,9 @@ namespace PSRule
             Assert.True(assert.LessOrEqual(value, "value", 4).Result);
             Assert.False(assert.LessOrEqual(value, "value", 0).Result);
             Assert.False(assert.LessOrEqual(value, "value", -1).Result);
+
+            // Self
+            Assert.True(assert.LessOrEqual(1, ".", 1).Result);
         }
 
         private static void SetContext()

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -21,6 +21,13 @@ Rule 'Assert.Precondition' -If { $Assert.StartsWith($TargetObject, 'Name', 'Test
     $True;
 }
 
+# Synopsis: Test for $Assert with self field
+Rule 'Assert.Self' {
+    $Assert.HasFieldValue($TargetObject.Name, '.', 'TestObject1')
+    $Assert.Greater(3, '.', 2)
+    $Assert.EndsWith('Name', '.', 'ame')
+}
+
 # Synopsis: Test for $Assert.Complete
 Rule 'Assert.Complete' {
     $Assert.HasField($TargetObject, 'Name').Complete() -and

--- a/tests/PSRule.Tests/ObjectHelperTests.cs
+++ b/tests/PSRule.Tests/ObjectHelperTests.cs
@@ -17,18 +17,21 @@ namespace PSRule
             Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: "Value.Value1", caseSensitive: false, value: out object actual2);
             Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: "Metadata.'app.kubernetes.io/name'", caseSensitive: false, value: out object actual3);
             Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: "Value2[1]", caseSensitive: false, value: out object actual4);
+            Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".", caseSensitive: true, value: out object actual5);
+            Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".Value2[1]", caseSensitive: false, value: out object actual6);
 
             Assert.Equal(expected: testObject.Name, actual: actual1);
             Assert.Equal(expected: testObject.Value.Value1, actual: actual2);
             Assert.Equal(expected: testObject.Metadata["app.kubernetes.io/name"], actual: actual3);
             Assert.Equal(expected: testObject.Value2[1], actual: actual4);
+            Assert.Equal(expected: testObject, actual: actual5);
+            Assert.Equal(expected: testObject.Value2[1], actual: actual6);
         }
 
-        private TestObject1 GetTestObject()
+        private static TestObject1 GetTestObject()
         {
             var result = new TestObject1 { Name = "TestObject1", Value = new TestObject2 { Value1 = "Value1" }, Value2 = new string[] { "1", "2" }, Metadata = new Hashtable() };
             result.Metadata.Add("app.kubernetes.io/name", "KubeName");
-
             return result;
         }
 
@@ -47,6 +50,5 @@ namespace PSRule
         {
             public string Value1;
         }
-
     }
 }

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -77,6 +77,20 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[1].TargetName | Should -Be 'TestObject2';
         }
 
+        It 'With self field' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Self' -Outcome All -WarningAction SilentlyContinue -Verbose);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Positive case
+            $result[0].Outcome | Should -Be 'Pass';
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            # Negative case
+            $result[1].Outcome | Should -Be 'Fail';
+            $result[1].TargetName | Should -Be 'TestObject2';
+        }
+
         It 'Complete' {
             $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.Complete');
             $result | Should -Not -BeNullOrEmpty;


### PR DESCRIPTION
## PR Summary

- Improved handling of fields to allow the input object to be referenced with `.`. #437

Fixes #437 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
