### PR TITLE
Add PS 7.0 style for client and plain styles #456

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- General improvements:
+  - Improved `Assert-PSRule` output formatting.
+    - Added recommendation and reasons for `Client` and `Plain` styles. [#456](https://github.com/Microsoft/PSRule/issues/456)
 - Engine features:
   - Added support for configuration of default module options. [#459](https://github.com/Microsoft/PSRule/issues/459)
     - `binding` and `configuration` options can be set to a default value.

--- a/src/PSRule/Resources/FormatterStrings.Designer.cs
+++ b/src/PSRule/Resources/FormatterStrings.Designer.cs
@@ -187,6 +187,42 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to     | REASON:.
+        /// </summary>
+        internal static string Reason {
+            get {
+                return ResourceManager.GetString("Reason", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     | - .
+        /// </summary>
+        internal static string ReasonPrefix {
+            get {
+                return ResourceManager.GetString("ReasonPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     | RECOMMEND:.
+        /// </summary>
+        internal static string Recommend {
+            get {
+                return ResourceManager.GetString("Recommend", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     | .
+        /// </summary>
+        internal static string RecommendPrefix {
+            get {
+                return ResourceManager.GetString("RecommendPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rules processed: {0}, failed: {1}, errors: {2}.
         /// </summary>
         internal static string Summary {

--- a/src/PSRule/Resources/FormatterStrings.resx
+++ b/src/PSRule/Resources/FormatterStrings.resx
@@ -159,6 +159,20 @@
   <data name="PSRuleVersion" xml:space="preserve">
     <value>Using PSRule v{0}</value>
   </data>
+  <data name="Reason" xml:space="preserve">
+    <value>    | REASON:</value>
+    <comment>Reason output header</comment>
+  </data>
+  <data name="ReasonPrefix" xml:space="preserve">
+    <value>    | - </value>
+  </data>
+  <data name="Recommend" xml:space="preserve">
+    <value>    | RECOMMEND:</value>
+    <comment>Recommendation output header</comment>
+  </data>
+  <data name="RecommendPrefix" xml:space="preserve">
+    <value>    | </value>
+  </data>
   <data name="Summary" xml:space="preserve">
     <value>Rules processed: {0}, failed: {1}, errors: {2}</value>
   </data>


### PR DESCRIPTION
## PR Summary

- Improved `Assert-PSRule` output formatting.
- Added recommendation and reasons for `Client` and `Plain` styles. #456

Fixes #456 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
