### PR TITLE
Improved Assert-PSRule output formatting #472

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- General improvements:
+  - Improved `Assert-PSRule` output formatting. [#472](https://github.com/Microsoft/PSRule/issues/472)
+    - Added recommendation and reasons for `AzurePipelines` and `GitHubActions` styles.
+    - Summary line is has been updated to include synopsis instead of reasons.
 - Bug fixes:
   - Fixed binding with ModuleConfig. [#468](https://github.com/Microsoft/PSRule/issues/468)
   - Fixed recommendation output with client style. [#467](https://github.com/Microsoft/PSRule/issues/467)

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -339,6 +339,13 @@ task TagBuild {
     }
 }
 
+# Synopsis: Attach a change log to the output
+task AttachChangeLog {
+    if ($AssertStyle -eq 'AzurePipelines') {
+        Write-Host "`#`#vso[task.addattachment type=Distributedtask.Core.Summary;name=Change Log;]$(Join-Path -Path $PWD -ChildPath 'CHANGELOG.md')";
+    }
+}
+
 # Synopsis: Run script analyzer
 task Analyze Build, PSScriptAnalyzer, {
     Invoke-ScriptAnalyzer -Path out/modules/PSRule;
@@ -374,7 +381,7 @@ task PublishSite CleanSite, {
 }
 
 # Synopsis: Build and test.
-task . Build, Rules, TestDotNet, Benchmark
+task . Build, Rules, TestDotNet, Benchmark, AttachChangeLog
 
 # Synopsis: Build the project
 task Build Clean, BuildModule, BuildHelp, VersionModule, PackageModule

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -447,8 +447,8 @@ namespace PSRule.Pipeline
 
                 protected override void FailDetail(RuleRecord record)
                 {
-                    LineBreak();
-                    Error(string.Format(FormatterStrings.AzurePipelines_Fail, record.TargetName, record.RuleName, GetReason(record)));
+                    base.FailDetail(record);
+                    Error(string.Format(FormatterStrings.AzurePipelines_Fail, record.TargetName, record.RuleName, record.Info.Synopsis));
                     LineBreak();
                 }
 
@@ -514,8 +514,8 @@ namespace PSRule.Pipeline
 
                 protected override void FailDetail(RuleRecord record)
                 {
-                    LineBreak();
-                    Error(string.Format(FormatterStrings.GitHubActions_Fail, record.TargetName, record.RuleName, GetReason(record)));
+                    base.FailDetail(record);
+                    Error(string.Format(FormatterStrings.GitHubActions_Fail, record.TargetName, record.RuleName, record.Info.Synopsis));
                     LineBreak();
                 }
             }


### PR DESCRIPTION
## PR Summary

- Improved `Assert-PSRule` output formatting. #472
  - Added recommendation and reasons for `AzurePipelines` and `GitHubActions` styles.
  - Summary line is has been updated to include synopsis instead of reasons.

Fixes #472 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
