### PR TITLE
Fixed Csv output format with summary #486

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed `Csv` output format with summary for `Invoke-PSRule`. [#486](https://github.com/Microsoft/PSRule/issues/486)
+
 ## v0.18.0
 
 What's changed since v0.17.0:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -916,14 +916,10 @@ The following format options are available:
 - Json - Output is serialized as JSON.
 - NUnit3 - Output is serialized as NUnit3 (XML).
 - Csv - Output is serialized as a comma separated values (CSV).
-  - The following columns are included:
-    - RuleName
-    - TargetName
-    - TargetType
-    - Outcome
-    - OutcomeReason
-    - Synopsis
-    - Recommendation
+  - The following columns are included for `Detail` output:
+RuleName, TargetName, TargetType, Outcome, OutcomeReason, Synopsis, Recommendation
+  - The following columns are included for `Summary` output:
+RuleName, Pass, Fail, Outcome, Synopsis, Recommendation
 - Wide -  Output is presented using the wide table format, which includes reason and wraps columns.
 
 The Wide format is ignored by `Assert-PSRule`. `Get-PSRule` only accepts `Wide` or `None`.

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -252,7 +252,7 @@ namespace PSRule.Pipeline
         public override void End()
         {
             if (_ResultFormat == ResultFormat.Summary)
-                Writer.WriteObject(_Summary.Values.Where(r => _Outcome == RuleOutcome.All || (r.Outcome & _Outcome) > 0), true);
+                Writer.WriteObject(_Summary.Values.Where(r => _Outcome == RuleOutcome.All || (r.Outcome & _Outcome) > 0).ToArray(), true);
 
             Writer.End();
         }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -485,6 +485,8 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 WarningAction = 'SilentlyContinue'
                 Culture = 'en-ZZ'
             }
+
+            # Detail
             $result = $testObject | Invoke-PSRule @option | Out-String;
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.String;
@@ -494,6 +496,23 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $resultCsv[0].Outcome | Should -Be 'Pass';
             $resultCsv[1].Outcome | Should -Be 'Fail';
             $resultCsv[1].Synopsis | Should -Be 'Test rule 3';
+            $resultCsv[2].RuleName | Should -Be 'WithCsv';
+            $resultCsv[2].Synopsis | Should -Be 'This is "a" synopsis.';
+            ($resultCsv[2].Recommendation -replace "`r`n", "`n") | Should -Be "This is an extended recommendation.`n`n- That includes line breaks`n- And lists";
+
+            # Summary
+            $result = $testObject | Invoke-PSRule @option -As Summary | Out-String;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeOfType System.String;
+            $resultCsv = @($result | ConvertFrom-Csv);
+            $resultCsv.Length | Should -Be 3;
+            $resultCsv.RuleName | Should -BeIn 'FromFile1', 'FromFile3', 'WithCsv';
+            $resultCsv[0].Outcome | Should -Be 'Pass';
+            $resultCsv[0].Pass | Should -Be '1';
+            $resultCsv[0].Fail | Should -Be '0';
+            $resultCsv[1].Outcome | Should -Be 'Fail';
+            $resultCsv[1].Pass | Should -Be '0';
+            $resultCsv[1].Fail | Should -Be '1';
             $resultCsv[2].RuleName | Should -Be 'WithCsv';
             $resultCsv[2].Synopsis | Should -Be 'This is "a" synopsis.';
             ($resultCsv[2].Recommendation -replace "`r`n", "`n") | Should -Be "This is an extended recommendation.`n`n- That includes line breaks`n- And lists";


### PR DESCRIPTION
## PR Summary

- Bug fixes:
  - Fixed `Csv` output format with summary for `Invoke-PSRule`. #486

Fixes #486 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
