### PR TITLE
Fixed actual value in for numeric assertion #505

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     - The module versions that PSRule uses can be constrained.
 - Bug fixes:
   - Fixed styling for no rule files warning with `Assert-PSRule`. [#484](https://github.com/microsoft/PSRule/issues/484)
+  - Fixed actual value in reason for numeric comparison assertion method. [#505](https://github.com/microsoft/PSRule/issues/505)
 
 ## v0.18.1
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -290,8 +290,8 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (CompareNumeric(fieldValue, value, out int actual))
-                return actual > 0 ? Pass() : Fail(ReasonStrings.Greater, actual, value);
+            if (CompareNumeric(fieldValue, value, out int compare, out object actual))
+                return compare > 0 ? Pass() : Fail(ReasonStrings.Greater, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
         }
@@ -304,8 +304,8 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (CompareNumeric(fieldValue, value, out int actual))
-                return actual >= 0 ? Pass() : Fail(ReasonStrings.GreaterOrEqual, actual, value);
+            if (CompareNumeric(fieldValue, value, out int compare, out object actual))
+                return compare >= 0 ? Pass() : Fail(ReasonStrings.GreaterOrEqual, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
         }
@@ -318,8 +318,8 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (CompareNumeric(fieldValue, value, out int actual))
-                return actual < 0 ? Pass() : Fail(ReasonStrings.Less, actual, value);
+            if (CompareNumeric(fieldValue, value, out int compare, out object actual))
+                return compare < 0 ? Pass() : Fail(ReasonStrings.Less, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
         }
@@ -332,8 +332,8 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out object fieldValue, out result))
                 return result;
 
-            if (CompareNumeric(fieldValue, value, out int actual))
-                return actual <= 0 ? Pass() : Fail(ReasonStrings.LessOrEqual, actual, value);
+            if (CompareNumeric(fieldValue, value, out int compare, out object actual))
+                return compare <= 0 ? Pass() : Fail(ReasonStrings.LessOrEqual, actual, value);
 
             return Fail(ReasonStrings.Compare, fieldValue, value);
         }
@@ -533,23 +533,27 @@ namespace PSRule.Runtime
             return false;
         }
 
-        private static bool CompareNumeric(object obj, int value, out int actual)
+        private static bool CompareNumeric(object obj, int value, out int compare, out object actual)
         {
-            if (TryInt(obj, out int ivalue) || TryStringLength(obj, out ivalue) || TryArrayLength(obj, out ivalue))
+            if (TryInt(obj, out int iactual) || TryStringLength(obj, out iactual) || TryArrayLength(obj, out iactual))
             {
-                actual = ivalue.CompareTo(value);
+                compare = iactual.CompareTo(value);
+                actual = iactual;
                 return true;
             }
-            if (TryLong(obj, out long lvalue))
+            if (TryLong(obj, out long lactual))
             {
-                actual = lvalue.CompareTo(value);
+                compare = lactual.CompareTo(value);
+                actual = lactual;
                 return true;
             }
-            if (TryFloat(obj, out float fvalue))
+            if (TryFloat(obj, out float factual))
             {
-                actual = fvalue.CompareTo(value);
+                compare = factual.CompareTo(value);
+                actual = factual;
                 return true;
             }
+            compare = 0;
             actual = 0;
             return false;
         }

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -176,7 +176,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[1].IsSuccess() | Should -Be $False;
             $result[1].TargetName | Should -Be 'TestObject2';
             $result[1].Reason.Length | Should -Be 3;
-            $result[1].Reason | Should -BeLike "The value '*' was not >= '*'.";
+            $result[1].Reason | Should -BeLike "The value '0' was not >= '*'.";
         }
 
         It 'HasField' {


### PR DESCRIPTION
## PR Summary

- Fixed actual value in reason for numeric comparison assertion method. #505

Fixes #505 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/master/CHANGELOG.md) has been updated with change under unreleased section
