### PR TITLE
Fixed Assert.In compare of array items #512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed `Assert.In` unable to compare PSObject wrapped array items. [#512](https://github.com/microsoft/PSRule/issues/512)
+
 ## v0.19.0-B2007023 (pre-release)
 
 - Engine features:

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -438,20 +438,21 @@ namespace PSRule.Runtime
             return o is PSObject pso ? pso.BaseObject : o;
         }
 
-        private static bool IsValue(object fieldValue, object expectedValue, bool caseSensitive)
+        private static bool IsValue(object actualValue, object expectedValue, bool caseSensitive)
         {
             var expectedBase = GetBaseObject(expectedValue);
-            if (fieldValue is string && expectedBase is string)
-                return caseSensitive ? StringComparer.Ordinal.Equals(fieldValue, expectedBase) : StringComparer.OrdinalIgnoreCase.Equals(fieldValue, expectedBase);
+            var actualBase = GetBaseObject(actualValue);
+            if (actualBase is string && expectedBase is string)
+                return caseSensitive ? StringComparer.Ordinal.Equals(actualBase, expectedBase) : StringComparer.OrdinalIgnoreCase.Equals(actualBase, expectedBase);
 
-            return expectedBase.Equals(fieldValue);
+            return expectedBase.Equals(actualBase) || expectedValue.Equals(actualValue);
         }
 
-        private static bool AnyValue(object fieldValue, object expectedValue, bool caseSensitive, out object foundValue)
+        private static bool AnyValue(object actualValue, object expectedValue, bool caseSensitive, out object foundValue)
         {
-            foundValue = fieldValue;
+            foundValue = actualValue;
             var expectedBase = GetBaseObject(expectedValue);
-            if (fieldValue is IEnumerable items)
+            if (actualValue is IEnumerable items)
             {
                 foreach (var item in items)
                 {
@@ -460,9 +461,9 @@ namespace PSRule.Runtime
                         return true;
                 }
             }
-            if (IsValue(fieldValue, expectedBase, caseSensitive))
+            if (IsValue(actualValue, expectedBase, caseSensitive))
             {
-                foundValue = fieldValue;
+                foundValue = actualValue;
                 return true;
             }
             return false;

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -113,7 +113,9 @@ Rule 'Assert.JsonSchema' {
 Rule 'Assert.In' {
     $Assert.In($TargetObject, 'Name', @('TestObject2', 'TestObject3'))
     $Assert.In($TargetObject, 'Int', @(2, 3))
-    # $Assert.In($TargetObject, 'Name', 'TestObject2')
+    $Assert.In($TargetObject, 'InArray', @('Item2'))
+    $Assert.In($TargetObject, 'InArray', @('item1'), $True)
+    $Assert.In($TargetObject, 'InArrayPSObject', @('item2'), $True)
 }
 
 # Synopsis: Test for $Assert.Less

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -44,6 +44,11 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 CompareNumeric = 3
                 CompareArray = 1, 2, 3
                 CompareString = 'abc'
+                InArray = @(
+                    'Item1'
+                    'Item3'
+                    'Item4'
+                )
             }
             [PSCustomObject]@{
                 '$schema' = "http://json-schema.org/draft-07/schema`#"
@@ -60,6 +65,16 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 CompareNumeric = 0
                 CompareArray = @()
                 CompareString = ''
+                InArray = @(
+                    'item1'
+                    'item2'
+                    'item3'
+                )
+                InArrayPSObject = [PSObject[]]@(
+                    'item1'
+                    'item2'
+                    'item3'
+                )
             }
         )
 
@@ -269,7 +284,7 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             # Negative case
             $result[0].IsSuccess() | Should -Be $False;
             $result[0].TargetName | Should -Be 'TestObject1';
-            $result[0].Reason.Length | Should -Be 2;
+            $result[0].Reason.Length | Should -Be 5;
             $result[0].Reason[0] | Should -Be "The field value 'TestObject1' was not included in the set.";
 
             # Positive case


### PR DESCRIPTION
## PR Summary

- Fixed `Assert.In` unable to compare PSObject wrapped array items. #512

Fixes #512 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
