### PR TITLE
Pre-release v0.19.0-B2007030

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Unreleased
 
+## v0.19.0-B2007030 (pre-release)
+
 - Bug fixes:
   - Fixed `Assert.In` unable to compare PSObject wrapped array items. [#512](https://github.com/microsoft/PSRule/issues/512)
 


### PR DESCRIPTION
## PR Summary

- Bug fixes:
  - Fixed `Assert.In` unable to compare PSObject wrapped array items. #512

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
