### PR TITLE
Added support for repository scanning #524 #525

### DIFF
--- a/.ps-rule/OpenSource.Rule.ps1
+++ b/.ps-rule/OpenSource.Rule.ps1
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # Synopsis: Check for recommended community files
-Rule 'OpenSource.Community' -Type 'System.IO.DirectoryInfo' {
+Rule 'OpenSource.Community' -Type 'System.IO.DirectoryInfo', 'PSRule.Data.RepositoryInfo' {
     $requiredFiles = @(
         'CHANGELOG.md'
         'LICENSE.txt'
@@ -21,7 +21,7 @@ Rule 'OpenSource.Community' -Type 'System.IO.DirectoryInfo' {
 }
 
 # Synopsis: Check for license in code files
-Rule 'OpenSource.License' -Type 'System.IO.FileInfo' -If { $TargetObject.Extension -in '.cs', '.ps1', '.psd1', '.psm1' } {
+Rule 'OpenSource.License' -Type 'System.IO.FileInfo', 'PSRule.Data.InputFileInfo', '.cs', '.ps1', '.psd1', '.psm1' -If { $TargetObject.Extension -in '.cs', '.ps1', '.psd1', '.psm1' } {
     $commentPrefix = "`# ";
     if ($TargetObject.Extension -eq '.cs') {
         $commentPrefix = '// '

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 ## Unreleased
 
+- Engine features:
+  - Added support for scanning repository files. [#524](https://github.com/microsoft/PSRule/issues/524)
+    - Added `File` input type (`-InputType File`) to scan for files without deserializing them.
+    - Added `Input.PathIgnore` option to ignore files.
+    - When using the `File` input type path specs in `.gitignore` are ignored.
+  - Added `Get-PSRuleTarget` cmdlet to read input files and return raw objects. [#525](https://github.com/microsoft/PSRule/issues/525)
+    - This cmdlet can be used to troubleshoot PSRule input issues.
+
 ## v0.19.0
 
 What's changed since v0.18.1:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The following commands exist in the `PSRule` module:
 - [Get-PSRule](docs/commands/PSRule/en-US/Get-PSRule.md) - Get a list of rule definitions.
 - [Get-PSRuleBaseline](docs/commands/PSRule/en-US/Get-PSRuleBaseline.md) - Get a list of baselines.
 - [Get-PSRuleHelp](docs/commands/PSRule/en-US/Get-PSRuleHelp.md) - Get documentation for a rule.
+- [Get-PSRuleTarget](docs/commands/PSRule/en-US/Get-PSRuleTarget.md) - Get a list of target objects.
 - [Invoke-PSRule](docs/commands/PSRule/en-US/Invoke-PSRule.md) - Evaluate objects against matching rules and output the results.
 - [New-PSRuleOption](docs/commands/PSRule/en-US/New-PSRuleOption.md) - Create options to configure PSRule execution.
 - [Set-PSRuleOption](docs/commands/PSRule/en-US/Set-PSRuleOption.md) - Sets options that configure PSRule execution.
@@ -270,6 +271,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionnotprocessedwarning)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)
+  - [Input.PathIgnore](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputpathignore)
   - [Input.TargetType](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputtargettype)
   - [Logging.LimitDebug](docs/concepts/PSRule/en-US/about_PSRule_Options.md#logginglimitdebug)
   - [Logging.LimitVerbose](docs/concepts/PSRule/en-US/about_PSRule_Options.md#logginglimitverbose)

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -137,7 +137,7 @@ This parameter takes precedence over the `Input.Format` option if set.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, File, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Get-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleTarget.md
@@ -1,0 +1,188 @@
+---
+external help file: PSRule-help.xml
+Module Name: PSRule
+online version: https://microsoft.github.io/PSRule/commands/PSRule/en-US/Get-PSRuleTarget.html
+schema: 2.0.0
+---
+
+# Get-PSRuleTarget
+
+## SYNOPSIS
+
+Get a list of target objects.
+
+## SYNTAX
+
+### Input (Default)
+
+```text
+Get-PSRuleTarget [-Format <InputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>]
+ -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+### InputPath
+
+```text
+Get-PSRuleTarget -InputPath <String[]> [-Format <InputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>]
+ [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+Get a list of target objects from input.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Get-PSRuleTarget -InputPath .\resources.json;
+```
+
+Get target objects from `resources.json`.
+
+## PARAMETERS
+
+### -InputPath
+
+Instead of processing objects from the pipeline, import objects file the specified file paths.
+
+```yaml
+Type: String[]
+Parameter Sets: InputPath
+Aliases: f
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Format
+
+Configures the input format for when a string is passed in as a target object.
+
+When the `-InputObject` parameter or pipeline input is used, strings are treated as plain text by default.
+Set this option to either `Yaml`, `Json`, `Markdown`, `PowerShellData` to have PSRule deserialize the object.
+
+When the `-InputPath` parameter is used with a file path or URL.
+If the `Detect` format is used, the file extension will be used to automatically detect the format.
+When `-InputPath` is not used, `Detect` is the same as `None`.
+
+See `about_PSRule_Options` for details.
+
+This parameter takes precedence over the `Input.Format` option if set.
+
+```yaml
+Type: InputFormat
+Parameter Sets: (All)
+Aliases:
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, File, Detect
+
+Required: False
+Position: Named
+Default value: Detect
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Option
+
+Additional options that configure execution.
+A `PSRuleOption` can be created by using the `New-PSRuleOption` cmdlet.
+Alternatively, a hashtable or path to YAML file can be specified with options.
+
+For more information on PSRule options see about_PSRule_Options.
+
+```yaml
+Type: PSRuleOption
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ObjectPath
+
+The name of a property to use instead of the pipeline object.
+If the property specified by `ObjectPath` is a collection or an array, then each item in evaluated separately.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+
+The pipeline object to process rules for.
+
+```yaml
+Type: PSObject
+Parameter Sets: Input
+Aliases: TargetObject
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Confirm
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Management.Automation.PSObject
+
+## NOTES
+
+## RELATED LINKS

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -279,7 +279,7 @@ This parameter takes precedence over the `Input.Format` option if set.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, File, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -388,7 +388,7 @@ See about_PSRule_Options for more information.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases: InputFormat
-Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, File, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/PSRule.md
+++ b/docs/commands/PSRule/en-US/PSRule.md
@@ -30,6 +30,10 @@ Get a list of matching baselines within the search path.
 
 Get documentation for a rule.
 
+### [Get-PSRuleTarget](Get-PSRuleTarget.md)
+
+Get a list of target object.
+
 ### [Invoke-PSRule](Invoke-PSRule.md)
 
 Evaluate objects against matching rules and output the results.

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -294,7 +294,7 @@ Sets the `Input.Format` option to configure the input format for when a string i
 Type: InputFormat
 Parameter Sets: (All)
 Aliases: InputFormat
-Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, File, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -189,7 +189,7 @@ This parameter takes precedence over the `Input.Format` option if set.
 Type: InputFormat
 Parameter Sets: (All)
 Aliases:
-Accepted values: None, Yaml, Json, Markdown, PowerShellData, Detect
+Accepted values: None, Yaml, Json, Markdown, PowerShellData, Repository, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/toc.yml
+++ b/docs/commands/PSRule/en-US/toc.yml
@@ -15,6 +15,9 @@
     - name: Get-PSRuleHelp
       href: Get-PSRuleHelp.md
       topicHref: Get-PSRuleHelp.md
+    - name: Get-PSRuleTarget
+      href: Get-PSRuleTarget.md
+      topicHref: Get-PSRuleTarget.md
     - name: Invoke-PSRule
       href: Invoke-PSRule.md
       topicHref: Invoke-PSRule.md

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -95,44 +95,6 @@ function CopyModuleFiles {
     }
 }
 
-function Get-RepoRuleData {
-    [CmdletBinding()]
-    param (
-        [Parameter(Position = 0, Mandatory = $False)]
-        [String]$Path = $PWD
-    )
-    process {
-        GetPathInfo -Path $Path -Verbose:$VerbosePreference;
-    }
-}
-
-function GetPathInfo {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $True)]
-        [String]$Path
-    )
-    begin {
-        $items = New-Object -TypeName System.Collections.ArrayList;
-    }
-    process {
-        $Null = $items.Add((Get-Item -Path $Path));
-        $files = @(Get-ChildItem -Path $Path -File -Recurse -Include *.ps1,*.psm1,*.psd1,*.cs | Where-Object {
-            !($_.FullName -like "*.Designer.cs") -and
-            !($_.FullName -like "*/bin/*") -and
-            !($_.FullName -like "*/obj/*") -and
-            !($_.FullName -like "*\obj\*") -and
-            !($_.FullName -like "*\bin\*") -and
-            !($_.FullName -like "*\out\*") -and
-            !($_.FullName -like "*/out/*")
-        });
-        $Null = $items.AddRange($files);
-    }
-    end {
-        $items;
-    }
-}
-
 task BuildDotNet {
     exec {
         dotnet restore
@@ -324,11 +286,10 @@ task Rules {
     $assertParams = @{
         Path = './.ps-rule/'
         Style = $AssertStyle
-        OutputFormat = 'NUnit3';
+        OutputFormat = 'NUnit3'
     }
     Import-Module (Join-Path -Path $PWD -ChildPath out/modules/PSRule) -Force;
-    Get-RepoRuleData -Path $PWD |
-        Assert-PSRule @assertParams -OutputPath reports/ps-rule-file.xml -Option @{ 'Binding.TargetName' = 'FullName' };
+    Assert-PSRule @assertParams -OutputPath reports/ps-rule-file.xml -InputPath $PWD -Format File -ErrorAction Stop;
 }
 
 task Benchmark {

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -2,3 +2,7 @@
 output:
   culture:
   - 'en-US'
+
+input:
+  pathIgnore:
+  - '*.Designer.cs'

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -121,6 +121,15 @@
                     "title": "Object path",
                     "description": "The object path to a property to use instead of the pipeline object."
                 },
+                "pathIgnore": {
+                    "type": "array",
+                    "title": "Path ignore",
+                    "description": "Ignores input files that match the path spec.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
                 "targetType": {
                     "type": "array",
                     "title": "Target type",

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -111,6 +111,7 @@
                         "Json",
                         "Markdown",
                         "PowerShellData",
+                        "File",
                         "Detect"
                     ],
                     "default": "Detect"

--- a/src/PSRule.Benchmark/PSRule.cs
+++ b/src/PSRule.Benchmark/PSRule.cs
@@ -66,7 +66,7 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "Benchmark" };
-            var builder = PipelineBuilder.Get(GetSource(), option);
+            var builder = PipelineBuilder.Get(GetSource(), option, null, null);
             _GetPipeline = builder.Build();
         }
 
@@ -75,7 +75,7 @@ namespace PSRule.Benchmark
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "BenchmarkHelp" };
             option.Output.Culture = new string[] { "en-ZZ" };
-            var builder = PipelineBuilder.GetHelp(GetSource(), option);
+            var builder = PipelineBuilder.GetHelp(GetSource(), option, null, null);
             _GetHelpPipeline = builder.Build();
         }
 
@@ -83,7 +83,7 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "Benchmark" };
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             _InvokePipeline = builder.Build();
         }
 
@@ -91,7 +91,7 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "BenchmarkIf" };
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             _InvokeIfPipeline = builder.Build();
         }
 
@@ -99,7 +99,7 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "BenchmarkType" };
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             _InvokeTypePipeline = builder.Build();
         }
 
@@ -108,7 +108,7 @@ namespace PSRule.Benchmark
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "Benchmark" };
             option.Output.As = ResultFormat.Summary;
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             _InvokeSummaryPipeline = builder.Build();
         }
 
@@ -116,7 +116,7 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "BenchmarkWithin" };
-            var builder = PipelineBuilder.Invoke(GetWithinSource(), option);
+            var builder = PipelineBuilder.Invoke(GetWithinSource(), option, null, null);
             _InvokeWithinPipeline = builder.Build();
         }
 
@@ -124,7 +124,7 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "BenchmarkWithinBulk" };
-            var builder = PipelineBuilder.Invoke(GetWithinSource(), option);
+            var builder = PipelineBuilder.Invoke(GetWithinSource(), option, null, null);
             _InvokeWithinBulkPipeline = builder.Build();
         }
 
@@ -132,20 +132,20 @@ namespace PSRule.Benchmark
         {
             var option = new PSRuleOption();
             option.Rule.Include = new string[] { "BenchmarkWithinLike" };
-            var builder = PipelineBuilder.Invoke(GetWithinSource(), option);
+            var builder = PipelineBuilder.Invoke(GetWithinSource(), option, null, null);
             _InvokeWithinLikePipeline = builder.Build();
         }
 
         private Source[] GetSource()
         {
-            var builder = new RuleSourceBuilder();
+            var builder = new RuleSourceBuilder(null);
             builder.Directory(GetSourcePath("Benchmark.Rule.ps1"));
             return builder.Build();
         }
 
         private Source[] GetWithinSource()
         {
-            var builder = new RuleSourceBuilder();
+            var builder = new RuleSourceBuilder(null);
             builder.Directory(GetSourcePath("Benchmark.Within.Rule.ps1"));
             return builder.Build();
         }

--- a/src/PSRule/Common/Environment.cs
+++ b/src/PSRule/Common/Environment.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Net;
+using System.Security;
+
+namespace PSRule
+{
+    internal sealed class EnvironmentHelper
+    {
+        private const char UNDERSCORE = '_';
+
+        internal static bool TryString(string key, out string value)
+        {
+            value = null;
+            var variable = System.Environment.GetEnvironmentVariable(key);
+            if (string.IsNullOrEmpty(variable))
+                return false;
+
+            value = variable;
+            return true;
+        }
+
+        internal static bool TrySecureString(string key, out SecureString value)
+        {
+            value = null;
+            if (!TryString(key, out string variable))
+                return false;
+
+            value = new NetworkCredential("na", variable).SecurePassword;
+            return true;
+        }
+
+        internal static bool TryInt(string key, out int value)
+        {
+            var variable = System.Environment.GetEnvironmentVariable(key);
+            if (!int.TryParse(variable, out value))
+                return false;
+
+            return true;
+        }
+
+        internal static bool TryBool(string key, out bool value)
+        {
+            var variable = System.Environment.GetEnvironmentVariable(key);
+            if (!bool.TryParse(variable, out value))
+                return false;
+
+            return true;
+        }
+
+        private static string CombineKey(string prefix, string key)
+        {
+            return string.IsNullOrEmpty(prefix) ? key : string.Concat(prefix, UNDERSCORE, key);
+        }
+    }
+}

--- a/src/PSRule/Common/GitHelper.cs
+++ b/src/PSRule/Common/GitHelper.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+
+namespace PSRule
+{
+    internal static class GitHelper
+    {
+        public static string GetHeadRef(string path)
+        {
+            // Try PSRule
+            if (EnvironmentHelper.TryString("PSRULE_GITREF", out string value))
+                return value;
+
+            // Try Azure Pipelines
+            if (EnvironmentHelper.TryString("BUILD_SOURCEBRANCH", out value))
+                return value;
+
+            // Try GitHub Actions
+            if (EnvironmentHelper.TryString("GITHUB_REF", out value))
+                return value;
+
+            // Try .git/HEAD
+            if (TryReadHead(path, out value))
+                return value;
+
+            return null;
+        }
+
+        private static bool TryReadHead(string path, out string value)
+        {
+            value = null;
+            var headFilePath = Path.Combine(path, "HEAD");
+            if (!File.Exists(headFilePath))
+                return false;
+
+            value = File.ReadAllText(headFilePath);
+            if (value.StartsWith("ref: ", System.StringComparison.OrdinalIgnoreCase))
+                value = value.Substring(5);
+
+            return true;
+        }
+    }
+}

--- a/src/PSRule/Common/StringExtensions.cs
+++ b/src/PSRule/Common/StringExtensions.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+
 namespace PSRule
 {
     internal static class StringExtensions
     {
         public static bool IsUri(this string s)
         {
-            return s.StartsWith("http://") || s.StartsWith("https://");
+            return s.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || s.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/PSRule/Configuration/InputFormat.cs
+++ b/src/PSRule/Configuration/InputFormat.cs
@@ -22,6 +22,8 @@ namespace PSRule.Configuration
 
         PowerShellData = 4,
 
+        File = 5,
+
         Detect = 255
     }
 }

--- a/src/PSRule/Configuration/InputOption.cs
+++ b/src/PSRule/Configuration/InputOption.cs
@@ -13,12 +13,14 @@ namespace PSRule.Configuration
     {
         private const InputFormat DEFAULT_FORMAT = PSRule.Configuration.InputFormat.Detect;
         private const string DEFAULT_OBJECTPATH = null;
+        private const string[] DEFAULT_PATHIGNORE = null;
         private const string[] DEFAULT_TARGETTYPE = null;
 
         internal static readonly InputOption Default = new InputOption
         {
             Format = DEFAULT_FORMAT,
             ObjectPath = DEFAULT_OBJECTPATH,
+            PathIgnore = DEFAULT_PATHIGNORE,
             TargetType = DEFAULT_TARGETTYPE,
         };
 
@@ -26,6 +28,7 @@ namespace PSRule.Configuration
         {
             Format = null;
             ObjectPath = null;
+            PathIgnore = null;
             TargetType = null;
         }
 
@@ -36,6 +39,7 @@ namespace PSRule.Configuration
 
             Format = option.Format;
             ObjectPath = option.ObjectPath;
+            PathIgnore = option.PathIgnore;
             TargetType = option.TargetType;
         }
 
@@ -49,6 +53,7 @@ namespace PSRule.Configuration
             return other != null &&
                 Format == other.Format &&
                 ObjectPath == other.ObjectPath &&
+                PathIgnore == other.PathIgnore &&
                 TargetType == other.TargetType;
         }
 
@@ -59,6 +64,7 @@ namespace PSRule.Configuration
                 int hash = 17;
                 hash = hash * 23 + (Format.HasValue ? Format.Value.GetHashCode() : 0);
                 hash = hash * 23 + (ObjectPath != null ? ObjectPath.GetHashCode() : 0);
+                hash = hash * 23 + (PathIgnore != null ? PathIgnore.GetHashCode() : 0);
                 hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
                 return hash;
             }
@@ -69,6 +75,7 @@ namespace PSRule.Configuration
             var result = new InputOption(o1);
             result.Format = o1.Format ?? o2.Format;
             result.ObjectPath = o1.ObjectPath ?? o2.ObjectPath;
+            result.PathIgnore = o1.PathIgnore ?? o2.PathIgnore;
             result.TargetType = o1.TargetType ?? o2.TargetType;
             return result;
         }
@@ -84,6 +91,12 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public string ObjectPath { get; set; }
+
+        /// <summary>
+        /// Ignores input files that match the path spec.
+        /// </summary>
+        [DefaultValue(null)]
+        public string[] PathIgnore { get; set; }
 
         /// <summary>
         /// Only process objects that match one of the included types.

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -7,6 +7,7 @@ using PSRule.Resources;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -324,6 +325,10 @@ namespace PSRule.Configuration
             {
                 option.Input.ObjectPath = (string)value;
             }
+            if (index.TryPopValue("input.pathignore", out value))
+            {
+                option.Input.PathIgnore = AsStringArray(value);
+            }
             if (index.TryPopValue("input.targettype", out value))
             {
                 option.Input.TargetType = AsStringArray(value);
@@ -455,6 +460,18 @@ namespace PSRule.Configuration
             return Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(GetWorkingPath(), path));
         }
 
+        /// <summary>
+        /// Get a full path instead of a relative path that may be passed from PowerShell.
+        /// </summary>
+        internal static string GetRootedBasePath(string path)
+        {
+            var rootedPath = GetRootedPath(path);
+            if (rootedPath.Length > 0 && IsSeparator(rootedPath[rootedPath.Length - 1]))
+                return rootedPath;
+
+            return string.Concat(rootedPath, Path.DirectorySeparatorChar);
+        }
+
         internal static Dictionary<string, object> BuildIndex(Hashtable hashtable)
         {
             var index = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
@@ -491,6 +508,12 @@ namespace PSRule.Configuration
                 return null;
 
             return value.GetType().IsArray ? ((object[])value).OfType<string>().ToArray() : new string[] { value.ToString() };
+        }
+
+        [DebuggerStepThrough]
+        private static bool IsSeparator(char c)
+        {
+            return c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar;
         }
     }
 }

--- a/src/PSRule/Data/ITargetInfo.cs
+++ b/src/PSRule/Data/ITargetInfo.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Data
+{
+    internal interface ITargetInfo
+    {
+        string TargetName { get; }
+
+        string TargetType { get; }
+    }
+}

--- a/src/PSRule/Data/InputFileInfo.cs
+++ b/src/PSRule/Data/InputFileInfo.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+
+namespace PSRule.Data
+{
+    public sealed class InputFileInfo : ITargetInfo
+    {
+        private const char Backslash = '\\';
+        private const char Slash = '/';
+
+        internal readonly bool IsUrl;
+
+        internal InputFileInfo(string basePath, string path)
+        {
+            FullName = path;
+            if (path.IsUri())
+            {
+                IsUrl = true;
+                return;
+            }
+            BasePath = basePath;
+            Name = Path.GetFileName(path);
+            Extension = Path.GetExtension(path);
+            DirectoryName = Path.GetDirectoryName(path);
+            DisplayName = FullName.Substring(basePath.Length).Replace(Backslash, Slash);
+            Type = typeof(InputFileInfo).FullName;
+        }
+
+        public string FullName { get; }
+
+        public string BasePath { get; }
+
+        public string Name { get; }
+
+        public string Extension { get; }
+
+        public string DirectoryName { get; }
+
+        public string DisplayName { get; }
+
+        public string Type { get; }
+
+        string ITargetInfo.TargetName => DisplayName;
+
+        string ITargetInfo.TargetType => Extension;
+    }
+}

--- a/src/PSRule/Data/RepositoryInfo.cs
+++ b/src/PSRule/Data/RepositoryInfo.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Data
+{
+    public sealed class RepositoryInfo : ITargetInfo
+    {
+        internal RepositoryInfo(string basePath, string headRef)
+        {
+            FullName = basePath;
+            BasePath = basePath;
+            DisplayName = headRef;
+            Type = typeof(RepositoryInfo).FullName;
+        }
+
+        public string FullName { get; }
+
+        public string BasePath { get; }
+
+        public string DisplayName { get; }
+
+        public string Type { get; }
+
+        string ITargetInfo.TargetName => DisplayName;
+
+        string ITargetInfo.TargetType => Type;
+    }
+}

--- a/src/PSRule/PSRule.psd1
+++ b/src/PSRule/PSRule.psd1
@@ -76,6 +76,7 @@ FunctionsToExport = @(
     'Rule'
     'Invoke-PSRule'
     'Test-PSRuleTarget'
+    'Get-PSRuleTarget'
     'Assert-PSRule'
     'Get-PSRule'
     'Get-PSRuleHelp'

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -31,8 +31,8 @@ namespace PSRule.Pipeline
     {
         private AssertWriter _Writer;
 
-        internal AssertPipelineBuilder(Source[] source)
-            : base(source) { }
+        internal AssertPipelineBuilder(Source[] source, HostContext hostContext)
+            : base(source, hostContext) { }
 
         /// <summary>
         /// A writer for outputting assertions.
@@ -601,8 +601,8 @@ namespace PSRule.Pipeline
                     next,
                     Option.Output.Style ?? OutputOption.Default.Style.Value,
                     _ResultVariableName,
-                    CmdletContext,
-                    ExecutionContext
+                    HostContext.CmdletContext,
+                    HostContext.ExecutionContext
                 );
             }
             return _Writer;

--- a/src/PSRule/Pipeline/GetBaselinePipeline.cs
+++ b/src/PSRule/Pipeline/GetBaselinePipeline.cs
@@ -13,8 +13,8 @@ namespace PSRule.Pipeline
     {
         private string[] _Name;
 
-        internal GetBaselinePipelineBuilder(Source[] source)
-            : base(source) { }
+        internal GetBaselinePipelineBuilder(Source[] source, HostContext hostContext)
+            : base(source, hostContext) { }
 
         /// <summary>
         /// Filter returned baselines by name.

--- a/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
+++ b/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
@@ -23,8 +23,8 @@ namespace PSRule.Pipeline
         private bool _Full;
         private bool _Online;
 
-        internal GetRuleHelpPipelineBuilder(Source[] source)
-            : base(source) { }
+        internal GetRuleHelpPipelineBuilder(Source[] source, HostContext hostContext)
+            : base(source, hostContext) { }
 
         public override IPipelineBuilder Configure(PSRuleOption option)
         {

--- a/src/PSRule/Pipeline/GetRulePipeline.cs
+++ b/src/PSRule/Pipeline/GetRulePipeline.cs
@@ -19,8 +19,8 @@ namespace PSRule.Pipeline
     {
         private bool _IncludeDependencies;
 
-        internal GetRulePipelineBuilder(Source[] source)
-            : base(source) { }
+        internal GetRulePipelineBuilder(Source[] source, HostContext hostContext)
+            : base(source, hostContext) { }
 
         public override IPipelineBuilder Configure(PSRuleOption option)
         {
@@ -50,7 +50,7 @@ namespace PSRule.Pipeline
             return new GetRulePipeline(PrepareContext(null, null, null), Source, PrepareReader(), PrepareWriter(), _IncludeDependencies);
         }
 
-        private OutputFormat SuppressFormat(OutputFormat? format)
+        private static OutputFormat SuppressFormat(OutputFormat? format)
         {
             return !format.HasValue ||
                 !(format == OutputFormat.Wide ||

--- a/src/PSRule/Pipeline/GetTargetPipeline.cs
+++ b/src/PSRule/Pipeline/GetTargetPipeline.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Configuration;
+using PSRule.Data;
+using PSRule.Rules;
+using System;
+using System.Management.Automation;
+
+namespace PSRule.Pipeline
+{
+    public interface IGetTargetPipelineBuilder : IPipelineBuilder
+    {
+        void InputPath(string[] path);
+    }
+
+    /// <summary>
+    /// A helper to construct the pipeline for Assert-PSRule.
+    /// </summary>
+    internal sealed class GetTargetPipelineBuilder : PipelineBuilderBase, IGetTargetPipelineBuilder
+    {
+        private InputFileInfo[] _InputPath;
+
+        internal GetTargetPipelineBuilder(Source[] source, HostContext hostContext)
+            : base(source, hostContext)
+        {
+            _InputPath = null;
+        }
+
+        public override IPipelineBuilder Configure(PSRuleOption option)
+        {
+            if (option == null)
+                return this;
+
+            base.Configure(option);
+
+            Option.Output = new OutputOption();
+            Option.Output.Culture = GetCulture(option.Output.Culture);
+
+            ConfigureBinding(option);
+            Option.Requires = new RequiresOption(option.Requires);
+
+            return this;
+        }
+
+        public void InputPath(string[] path)
+        {
+            if (path == null || path.Length == 0)
+                return;
+
+            var basePath = PSRuleOption.GetWorkingPath();
+            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore);
+            if (Option.Input.Format == InputFormat.File)
+                filter.UseGitIgnore();
+
+            var builder = new InputPathBuilder(GetOutput(), basePath, "*", filter.Build());
+            builder.Add(path);
+            _InputPath = builder.Build();
+        }
+
+        public override IPipeline Build()
+        {
+            return new GetTargetPipeline(PrepareContext(null, null, null), PrepareReader(), PrepareWriter());
+        }
+
+        protected override PipelineReader PrepareReader()
+        {
+            if (!string.IsNullOrEmpty(Option.Input.ObjectPath))
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ReadObjectPath(sourceObject, next, Option.Input.ObjectPath, true);
+                });
+            }
+
+            if (Option.Input.Format == InputFormat.Yaml)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromYaml(sourceObject, next);
+                });
+            }
+            else if (Option.Input.Format == InputFormat.Json)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromJson(sourceObject, next);
+                });
+            }
+            else if (Option.Input.Format == InputFormat.Markdown)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromMarkdown(sourceObject, next);
+                });
+            }
+            else if (Option.Input.Format == InputFormat.PowerShellData)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromPowerShellData(sourceObject, next);
+                });
+            }
+            else if (Option.Input.Format == InputFormat.File)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.ConvertFromGitHead(sourceObject, next);
+                });
+            }
+            else if (Option.Input.Format == InputFormat.Detect && _InputPath != null)
+            {
+                AddVisitTargetObjectAction((sourceObject, next) =>
+                {
+                    return PipelineReceiverActions.DetectInputFormat(sourceObject, next);
+                });
+            }
+            return new PipelineReader(VisitTargetObject, _InputPath);
+        }
+    }
+
+    /// <summary>
+    /// A pipeline that gets target objects through the pipeline.
+    /// </summary>
+    internal sealed class GetTargetPipeline : RulePipeline
+    {
+        internal GetTargetPipeline(PipelineContext context, PipelineReader reader, PipelineWriter writer)
+            : base(context, null, reader, writer) { }
+
+        public override void Process(PSObject targetObject)
+        {
+            try
+            {
+                Reader.Enqueue(targetObject);
+                while (Reader.TryDequeue(out PSObject next))
+                {
+                    Writer.WriteObject(next, false);
+                }
+            }
+            catch (Exception)
+            {
+                End();
+                throw;
+            }
+        }
+    }
+}

--- a/src/PSRule/Pipeline/HostContext.cs
+++ b/src/PSRule/Pipeline/HostContext.cs
@@ -1,18 +1,33 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Management.Automation;
+
 namespace PSRule.Pipeline
 {
     internal sealed class HostContext
     {
+        internal readonly PSCmdlet CmdletContext;
+        internal readonly EngineIntrinsics ExecutionContext;
+        internal readonly ShouldProcess ShouldProcess;
+
         /// <summary>
         /// Determine if running is remote session.
         /// </summary>
         internal bool InSession;
 
-        public HostContext()
+        public HostContext(PSCmdlet commandRuntime, EngineIntrinsics executionContext)
         {
             InSession = false;
+            CmdletContext = commandRuntime;
+            ExecutionContext = executionContext;
+            ShouldProcess = (target, action) => true;
+            if (commandRuntime != null)
+                ShouldProcess = commandRuntime.ShouldProcess;
+
+            InSession = executionContext == null ? false : executionContext.SessionState.PSVariable.GetValue("PSSenderInfo") != null;
         }
+
+        
     }
 }

--- a/src/PSRule/Pipeline/InputPathBuilder.cs
+++ b/src/PSRule/Pipeline/InputPathBuilder.cs
@@ -1,65 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Management.Automation;
-
 namespace PSRule.Pipeline
 {
-    public sealed class InputPathBuilder
+    internal sealed class InputPathBuilder : PathBuilder
     {
-        private readonly HashSet<string> _Items;
-
-        public InputPathBuilder()
-        {
-            _Items = new HashSet<string>();
-        }
-
-        public void Add(string path)
-        {
-            if (string.IsNullOrEmpty(path) || _Items.Contains(path))
-            {
-                return;
-            }
-            _Items.Add(path);
-        }
-
-        public void Add(System.IO.FileInfo[] fileInfo)
-        {
-            if (fileInfo == null || fileInfo.Length == 0)
-            {
-                return;
-            }
-
-            for (var i = 0; i < fileInfo.Length; i++)
-            {
-                if (!_Items.Contains(fileInfo[i].FullName))
-                {
-                    _Items.Add(fileInfo[i].FullName);
-                }
-            }
-        }
-
-        public void Add(PathInfo[] pathInfo)
-        {
-            if (pathInfo == null || pathInfo.Length == 0)
-            {
-                return;
-            }
-
-            for (var i = 0; i < pathInfo.Length; i++)
-            {
-                if (!_Items.Contains(pathInfo[i].Path))
-                {
-                    _Items.Add(pathInfo[i].Path);
-                }
-            }
-        }
-
-        public IEnumerable<string> Build()
-        {
-            return _Items.ToArray();
-        }
+        public InputPathBuilder(ILogger logger, string basePath, string searchPattern, PathFilter filter)
+            : base(logger, basePath, searchPattern, filter) { }
     }
 }

--- a/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
+++ b/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
@@ -35,8 +35,12 @@ namespace PSRule.Pipeline.Output
 
         private string _ScopeName;
 
-        internal PSPipelineWriter(PSRuleOption option)
-            : base(null, option) { }
+        internal PSPipelineWriter(HostContext hostContext, PSRuleOption option)
+            : base(null, option)
+        {
+            UseCommandRuntime(hostContext.CmdletContext);
+            UseExecutionContext(hostContext.ExecutionContext);
+        }
 
         public override void Begin()
         {
@@ -47,8 +51,11 @@ namespace PSRule.Pipeline.Output
                 _DebugFilter = new HashSet<string>(Option.Logging.LimitDebug);
         }
 
-        internal void UseCommandRuntime(PSCmdlet commandRuntime)
+        private void UseCommandRuntime(PSCmdlet commandRuntime)
         {
+            if (commandRuntime == null)
+                return;
+
             OnWriteVerbose = commandRuntime.WriteVerbose;
             OnWriteWarning = commandRuntime.WriteWarning;
             OnWriteError = commandRuntime.WriteError;
@@ -57,8 +64,11 @@ namespace PSRule.Pipeline.Output
             OnWriteObject = commandRuntime.WriteObject;
         }
 
-        internal void UseExecutionContext(EngineIntrinsics executionContext)
+        private void UseExecutionContext(EngineIntrinsics executionContext)
         {
+            if (executionContext == null)
+                return;
+
             _LogError = GetPreferenceVariable(executionContext, ErrorPreference);
             _LogWarning = GetPreferenceVariable(executionContext, WarningPreference);
             _LogVerbose = GetPreferenceVariable(executionContext, VerbosePreference);

--- a/src/PSRule/Pipeline/PathBuilder.cs
+++ b/src/PSRule/Pipeline/PathBuilder.cs
@@ -88,8 +88,6 @@ namespace PSRule.Pipeline
 
             var pathLiteral = GetSearchParameters(path, out string searchPattern, out SearchOption searchOption, out PathFilter filter);
             var files = Directory.EnumerateFiles(pathLiteral, searchPattern, searchOption);
-            //var isLiteral = IsLiteralFile(path);
-
             foreach (var file in files)
                 if (ShouldInclude(file, filter))
                     AddFile(file);
@@ -111,7 +109,7 @@ namespace PSRule.Pipeline
                 return false;
 
             var rootedPath = GetRootedPath(path);
-            if (Directory.Exists(rootedPath))
+            if (Directory.Exists(rootedPath) || path == CurrentPath)
             {
                 if (IsBasePath(rootedPath))
                     normalPath = CurrentPath;
@@ -135,6 +133,9 @@ namespace PSRule.Pipeline
 
         private void ErrorNotFound(string path)
         {
+            if (_Logger == null)
+                return;
+
             _Logger.WriteError(new ErrorRecord(new FileNotFoundException(), "PSRule.PathBuilder.ErrorNotFound", ErrorCategory.ObjectNotFound, path));
         }
 

--- a/src/PSRule/Pipeline/PathBuilder.cs
+++ b/src/PSRule/Pipeline/PathBuilder.cs
@@ -1,0 +1,249 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Configuration;
+using PSRule.Data;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Management.Automation;
+
+namespace PSRule.Pipeline
+{
+    public interface IPathBuilder
+    {
+        void Add(string path);
+
+        void Add(System.IO.FileInfo[] fileInfo);
+
+        void Add(PathInfo[] pathInfo);
+
+        InputFileInfo[] Build();
+    }
+
+    internal abstract class PathBuilder
+    {
+        // Path separators
+        private const char Slash = '/';
+        private const char BackSlash = '\\';
+
+        private const char Dot = '.';
+        private const string CurrentPath = ".";
+        private const string RecursiveSearchOperator = "**";
+
+        private static readonly char[] PathLiteralStopCharacters = new char[] { '*', '[', '?' };
+        private static readonly char[] PathSeparatorCharacters = new char[] { '\\', '/' };
+
+        private readonly ILogger _Logger;
+        private readonly List<InputFileInfo> _Files;
+        private readonly HashSet<string> _Paths;
+        private readonly string _BasePath;
+        private readonly string _DefaultSearchPattern;
+        private readonly PathFilter _GlobalFilter;
+
+        internal PathBuilder(ILogger logger, string basePath, string searchPattern, PathFilter filter)
+        {
+            _Logger = logger;
+            _Files = new List<InputFileInfo>();
+            _Paths = new HashSet<string>();
+            _BasePath = NormalizePath(PSRuleOption.GetRootedBasePath(basePath));
+            _DefaultSearchPattern = searchPattern;
+            _GlobalFilter = filter;
+        }
+
+        public void Add(string[] path)
+        {
+            if (path == null || path.Length == 0)
+                return;
+
+            for (var i = 0; i < path.Length; i++)
+                Add(path[i]);
+        }
+
+        public void Add(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return;
+
+            FindFiles(path);
+        }
+
+        public InputFileInfo[] Build()
+        {
+            try
+            {
+                return _Files.ToArray();
+            }
+            finally
+            {
+                _Files.Clear();
+                _Paths.Clear();
+            }
+        }
+
+        private void FindFiles(string path)
+        {
+            if (TryUrl(path) || TryPath(path, out path))
+                return;
+
+            var pathLiteral = GetSearchParameters(path, out string searchPattern, out SearchOption searchOption, out PathFilter filter);
+            var files = Directory.EnumerateFiles(pathLiteral, searchPattern, searchOption);
+            //var isLiteral = IsLiteralFile(path);
+
+            foreach (var file in files)
+                if (ShouldInclude(file, filter))
+                    AddFile(file);
+        }
+
+        private bool TryUrl(string path)
+        {
+            if (!path.IsUri())
+                return false;
+
+            AddFile(path);
+            return true;
+        }
+
+        private bool TryPath(string path, out string normalPath)
+        {
+            normalPath = path;
+            if (path.IndexOfAny(PathLiteralStopCharacters) > -1)
+                return false;
+
+            var rootedPath = GetRootedPath(path);
+            if (Directory.Exists(rootedPath))
+            {
+                if (IsBasePath(rootedPath))
+                    normalPath = CurrentPath;
+
+                return false;
+            }
+            if (!File.Exists(rootedPath))
+            {
+                ErrorNotFound(path);
+                return false;
+            }
+            AddFile(rootedPath);
+            return true;
+        }
+
+        private bool IsBasePath(string path)
+        {
+            path = IsSeparator(path[path.Length - 1]) ? path : string.Concat(path, Path.DirectorySeparatorChar);
+            return NormalizePath(path) == _BasePath;
+        }
+
+        private void ErrorNotFound(string path)
+        {
+            _Logger.WriteError(new ErrorRecord(new FileNotFoundException(), "PSRule.PathBuilder.ErrorNotFound", ErrorCategory.ObjectNotFound, path));
+        }
+
+        private void AddFile(string path)
+        {
+            if (_Paths.Contains(path))
+                return;
+
+            _Files.Add(new InputFileInfo(_BasePath, path));
+            _Paths.Add(path);
+        }
+
+        private string GetRootedPath(string path)
+        {
+            return Path.IsPathRooted(path) ? path : Path.GetFullPath(Path.Combine(_BasePath, path));
+        }
+
+        /// <summary>
+        /// Split a search path into components based on wildcards.
+        /// </summary>
+        private string GetSearchParameters(string path, out string searchPattern, out SearchOption searchOption, out PathFilter filter)
+        {
+            searchOption = SearchOption.AllDirectories;
+            var pathLiteral = TrimPath(path, out bool relativeAnchor);
+
+            if (TryFilter(pathLiteral, out searchPattern, out filter))
+                return _BasePath;
+
+            pathLiteral = SplitSearchPath(pathLiteral, out searchPattern);
+            if ((relativeAnchor || !string.IsNullOrEmpty(pathLiteral)) && !string.IsNullOrEmpty(searchPattern))
+                searchOption = SearchOption.TopDirectoryOnly;
+
+            if (string.IsNullOrEmpty(searchPattern))
+                searchPattern = _DefaultSearchPattern;
+
+            // If a path separator is within the pattern use a resursive search
+            //if (relativeAnchor || !string.IsNullOrEmpty(pathLiteral))
+            //if (relativeAnchor && string.IsNullOrEmpty(searchPattern))
+            //    searchOption = SearchOption.TopDirectoryOnly;
+
+            return GetRootedPath(pathLiteral);
+        }
+
+        private static string SplitSearchPath(string path, out string searchPattern)
+        {
+            // Find the index of the first expression character i.e. out/modules/**/file
+            var stopIndex = path.IndexOfAny(PathLiteralStopCharacters);
+
+            // Track back to the separator before any expression characters
+            var literalSeparator = stopIndex > -1 ? path.LastIndexOfAny(PathSeparatorCharacters, stopIndex) + 1 : path.LastIndexOfAny(PathSeparatorCharacters) + 1;
+            searchPattern = path.Substring(literalSeparator, path.Length - literalSeparator);
+            return path.Substring(0, literalSeparator);
+        }
+
+        private bool TryFilter(string path, out string searchPattern, out PathFilter filter)
+        {
+            searchPattern = null;
+            filter = null;
+            if (UseSimpleSearch(path))
+                return false;
+
+            filter = PathFilter.Create(_BasePath, path);
+            var patternSeparator = path.LastIndexOfAny(PathSeparatorCharacters) + 1;
+            searchPattern = path.Substring(patternSeparator, path.Length - patternSeparator);
+            return true;
+        }
+
+        /// <summary>
+        /// Remove leading ./ or .\ characters indicating a relative path anchor.
+        /// </summary>
+        /// <param name="path">The path to trim.</param>
+        /// <param name="relativeAnchor">Returns true when a relative path anchor was present.</param>
+        /// <returns>Return a clean path without the relative path anchor.</returns>
+        private static string TrimPath(string path, out bool relativeAnchor)
+        {
+            relativeAnchor = false;
+            if (path.Length >= 2 && path[0] == Dot && IsSeparator(path[1]))
+            {
+                relativeAnchor = true;
+                return path.Remove(0, 2);
+            }
+            return path;
+        }
+
+        private bool ShouldInclude(string file, PathFilter filter)
+        {
+            return (filter == null || filter.Match(file)) &&
+                (_GlobalFilter == null || _GlobalFilter.Match(file));
+        }
+
+        [DebuggerStepThrough]
+        private static bool IsSeparator(char c)
+        {
+            return c == Slash || c == BackSlash;
+        }
+
+        /// <summary>
+        /// Determines if a simple search can be used.
+        /// </summary>
+        [DebuggerStepThrough]
+        private static bool UseSimpleSearch(string s)
+        {
+            return s.IndexOf(RecursiveSearchOperator, System.StringComparison.OrdinalIgnoreCase) == -1;
+        }
+
+        [DebuggerStepThrough]
+        private static string NormalizePath(string path)
+        {
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+    }
+}

--- a/src/PSRule/Pipeline/PathFilter.cs
+++ b/src/PSRule/Pipeline/PathFilter.cs
@@ -1,0 +1,465 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace PSRule.Pipeline
+{
+    internal sealed class PathFilterBuilder
+    {
+        private const string GitIgnoreFileName = ".gitignore";
+
+        private readonly string _BasePath;
+        private readonly List<string> _Expressions;
+        private readonly bool _MatchResult;
+
+        private PathFilterBuilder(string basePath, string[] expressions, bool matchResult)
+        {
+            _BasePath = basePath;
+            _Expressions = expressions == null || expressions.Length == 0 ? new List<string>() : new List<string>(expressions);
+            _MatchResult = matchResult;
+        }
+
+        internal static PathFilterBuilder Create(string basePath, string[] expressions, bool matchResult = false)
+        {
+            return new PathFilterBuilder(basePath, expressions, matchResult);
+        }
+
+        internal void UseGitIgnore(string basePath = null)
+        {
+            _Expressions.Add(".git/");
+            _Expressions.Add("!.git/HEAD");
+            ReadFile(Path.Combine(basePath ?? _BasePath, GitIgnoreFileName));
+        }
+
+        internal PathFilter Build()
+        {
+            return PathFilter.Create(_BasePath, _Expressions.ToArray(), _MatchResult);
+        }
+
+        private void ReadFile(string filePath)
+        {
+            if (File.Exists(filePath))
+                _Expressions.AddRange(File.ReadAllLines(filePath));
+        }
+    }
+
+    /// <summary>
+    /// Filters paths based on predefined rules.
+    /// </summary>
+    internal sealed class PathFilter
+    {
+        // Path separators
+        private const char Slash = '/';
+        private const char BackSlash = '\\';
+        
+        // Operators
+        private const char Asterix = '*'; // Match multiple characters except '/'
+        private const char Question = '?'; // Match any character except '/'
+        private const char Hash = '#'; // Comment
+        private const char Exclamation = '!'; // Include a previously excluded path
+        
+        private const string GitIgnoreFileName = ".gitignore";
+
+        private readonly string _BasePath;
+        private readonly PathFilterExpression[] _Expression;
+
+        private bool _MatchResult;
+
+        private PathFilter(string basePath, PathFilterExpression[] expression, bool matchResult)
+        {
+            _BasePath = NormalDirectoryPath(basePath);
+            _Expression = expression ?? Array.Empty<PathFilterExpression>();
+            _MatchResult = matchResult;
+        }
+
+        #region PathStream
+
+        [DebuggerDisplay("Path = '{_Path}', Position = {_Position}, Current = '{_Current}'")]
+        private sealed class PathStream
+        {
+            private readonly string _Path;
+            private int _Position;
+            private char _Current;
+
+            public PathStream(string path)
+            {
+                _Path = path;
+                Reset();
+            }
+
+            /// <summary>
+            /// Resets the cursor to the start of the path stream.
+            /// </summary>
+            public void Reset()
+            {
+                _Position = -1;
+                _Current = char.MinValue;
+                if (_Path[0] == Exclamation)
+                    Next();
+            }
+
+            /// <summary>
+            /// Move to the next character.
+            /// </summary>
+            public bool Next()
+            {
+                _Position++;
+                if (_Position >= _Path.Length)
+                {
+                    _Current = char.MinValue;
+                    return false;
+                }
+                _Current = _Path[_Position];
+                return true;
+            }
+
+            public bool TryMatch(PathStream other, int offset)
+            {
+                return other.Peak(offset, out char c) && IsMatch(c);
+            }
+
+            public bool IsUnmatchedSingle(PathStream other, int offset)
+            {
+                return other.Peak(offset, out char c) && IsWilcardQ(c) && other.Peak(offset + 1, out char cnext) && IsMatch(cnext);
+            }
+
+            private bool IsMatch(char c)
+            {
+                return _Current == c ||
+                    (IsSeparator(_Current) && IsSeparator(c)) ||
+                    (!IsSeparator(_Current) && IsWilcardQ(c));
+            }
+
+            /// <summary>
+            /// Determine if the current character sequence is ** or **/.
+            /// </summary>
+            public bool IsAnyMatchEnding(int offset = 0)
+            {
+                if (!IsWildcardAA(offset))
+                    return false;
+
+                var pos = _Position + offset;
+
+                // Ends in **
+                if (pos + 1 == _Path.Length - 1)
+                    return true;
+
+                // Ends in **/
+                if (pos + 2 == _Path.Length - 1 && IsSeparator(_Path[pos + 2]))
+                    return true;
+
+                return false;
+            }
+
+            public bool SkipMatchAA()
+            {
+                if (!IsWildcardAA())
+                    return false;
+
+                
+                Skip(2); // Skip **
+                SkipSeparator(); // Skip **/
+                SkipMatchAA(); // Skip **/**/
+                return true;
+            }
+
+            public bool SkipMatchA()
+            {
+                if (!IsWildardA())
+                    return false;
+
+                Skip(1);
+                return true;
+            }
+
+            private bool Skip(int count)
+            {
+                if (count > 1)
+                    _Position += count - 1;
+
+                return Next();
+            }
+
+            [DebuggerStepThrough]
+            private void SkipSeparator()
+            {
+                if (IsSeparator(_Current))
+                    Next();
+            }
+
+            /// <summary>
+            /// Determine if the current character sequence is **.
+            /// </summary>
+            [DebuggerStepThrough]
+            private bool IsWildcardAA(int offset = 0)
+            {
+                var pos = _Position + offset;
+                return pos + 1 < _Path.Length && _Path[pos] == Asterix && _Path[pos + 1] == Asterix;
+            }
+
+            [DebuggerStepThrough]
+            private bool IsWildardA(int offset = 0)
+            {
+                var pos = _Position + offset;
+                return pos < _Path.Length && _Path[pos] == Asterix;
+            }
+
+            [DebuggerStepThrough]
+            private static bool IsWilcardQ(char c)
+            {
+                return c == Question;
+            }
+
+            [DebuggerStepThrough]
+            private static bool IsSeparator(char c)
+            {
+                return c == Slash || c == BackSlash;
+            }
+
+            /// <summary>
+            /// Match **
+            /// </summary>
+            public bool TryMatchAA(PathStream other, int start)
+            {
+                var offset = start;
+                do
+                {
+                    if (IsUnmatchedSingle(other, offset))
+                        offset++;
+
+                    // Determine if fully matched to end or the next any match
+                    if (other.IsWildcardAA(offset))
+                    {
+                        other.Skip(offset);
+                        return true;
+                    }
+                    else if (other.IsWildardA(offset) && TryMatchA(other, offset + 1))
+                    {
+                        return true;
+                    }
+
+                    //(IsSingleWildcard(c) && other.Peak(offset + 1, out char cnext) && IsMatch(cnext))
+                    //if (TryMatchCharacter(other, offset))
+                    //{
+
+                    //}
+                    // Try to match the remaining
+                    if (TryMatch(other, offset))
+                    {
+                        offset++;
+                    }
+                    else
+                    {
+                        offset = start;
+                    }
+
+                    if (offset + other._Position >= other._Path.Length)
+                    {
+                        other.Skip(offset);
+                        return true;
+                    }
+                } while (Next());
+                return false;
+            }
+
+            /// <summary>
+            /// Match *
+            /// </summary>
+            public bool TryMatchA(PathStream other, int start)
+            {
+                var offset = start;
+                do
+                {
+                    // Determine if fully matched to end or the next any match
+                    if (other.IsWildcardAA(offset))
+                    {
+                        other.Skip(offset);
+                        return true;
+                    }
+                    //if (other.IsCharacterMatch(offset))
+
+                    // Try to match the remaining
+                    if (TryMatch(other, offset))
+                    {
+                        offset++;
+                    }
+                    else
+                    {
+                        offset = start;
+                    }
+
+                    if (offset + other._Position >= other._Path.Length)
+                    {
+                        Next();
+                        other.Skip(offset);
+                        return true;
+                    }
+                } while (Next());
+                return false;
+            }
+
+            private bool Peak(int offset, out char c)
+            {
+                if (offset + _Position >= _Path.Length)
+                {
+                    c = char.MinValue;
+                    return false;
+                }
+                c = _Path[offset + _Position];
+                return true;
+            }
+        }
+
+        #endregion PathStream
+
+        #region PathFilterExpression
+
+        [DebuggerDisplay("{_Expression}")]
+        private sealed class PathFilterExpression
+        {
+            private readonly PathStream _Expression;
+            private readonly bool _Include;
+
+            private PathFilterExpression(string expression, bool include)
+            {
+                _Expression = new PathStream(expression);
+                _Include = include;
+            }
+
+            public static PathFilterExpression Create(string expression)
+            {
+                if (string.IsNullOrEmpty(expression))
+                    throw new ArgumentNullException(nameof(expression));
+
+                var actualInclude = true;
+                if (expression[0] == Exclamation)
+                    actualInclude = false;
+
+                return new PathFilterExpression(expression, actualInclude);
+            }
+
+            /// <summary>
+            /// Determine if the path matches the expression.
+            /// </summary>
+            public void Match(string path, ref bool include)
+            {
+                // Only process if the result would change
+                if (_Include == include || !Match(path))
+                    return;
+
+                include = !include;
+            }
+
+            /// <summary>
+            /// Determines if the path matches the expression.
+            /// </summary>
+            private bool Match(string path)
+            {
+                _Expression.Reset();
+                var stream = new PathStream(path);
+                while (stream.Next() && _Expression.Next())
+                {
+                    // Match characters
+                    if (stream.TryMatch(_Expression, 0))
+                        continue;
+
+                    // Skip ? when zero characters are being matched
+                    else if (stream.IsUnmatchedSingle(_Expression, 0))
+                        _Expression.Next();
+
+                    // Match ending wildcards e.g. src/** or src/**/
+                    else if (_Expression.IsAnyMatchEnding())
+                        break;
+
+                    // Match ending with depth e.g. src/**/bin/
+                    else if (_Expression.SkipMatchAA())
+                    {
+                        if (!stream.TryMatchAA(_Expression, 0))
+                            return false;
+                    }
+
+                    // Match wildcard *
+                    else if (_Expression.SkipMatchA())
+                    {
+                        if (!stream.TryMatchA(_Expression, 0))
+                            return false;
+                    }
+
+                    else return false;
+                }
+                return true;
+            }
+        }
+
+        #endregion PathFilterExpression
+
+        #region Public methods
+
+        public static PathFilter Create(string basePath, string expression, bool matchResult = true)
+        {
+            if (!ShouldSkipExpression(expression))
+                return new PathFilter(basePath, new PathFilterExpression[] { PathFilterExpression.Create(expression) }, matchResult);
+
+            return new PathFilter(basePath, null, matchResult);
+        }
+
+        public static PathFilter Create(string basePath, string[] expression, bool matchResult = true)
+        {
+            var result = new List<PathFilterExpression>(expression.Length);
+            for (var i = 0; i < expression.Length; i++)
+                if (!ShouldSkipExpression(expression[i]))
+                    result.Add(PathFilterExpression.Create(expression[i]));
+
+            return result.Count == 0 ? new PathFilter(basePath, null, matchResult) : new PathFilter(basePath, result.ToArray(), matchResult);
+        }
+
+        /// <summary>
+        /// Determine if the specific path is matched.
+        /// </summary>
+        /// <param name="path">The path to evaluate.</param>
+        public bool Match(string path)
+        {
+            var start = 0;
+
+            // Check if path is within base path
+            if (Path.IsPathRooted(path))
+            {
+                if (!path.StartsWith(_BasePath))
+                    return !_MatchResult;
+
+                start = _BasePath.Length;
+            }
+            var cleanPath = start > 0 ? path.Remove(0, start) : path;
+
+            // Include unless excluded
+            bool result = false;
+
+            // Compare expressions
+            for (var i = 0; i < _Expression.Length; i++)
+                _Expression[i].Match(cleanPath, ref result);
+
+            // Flip the result if a match should return false
+            return _MatchResult ? result : !result;
+        }
+
+        #endregion Public methods
+
+        private static bool ShouldSkipExpression(string expression)
+        {
+            return string.IsNullOrEmpty(expression) || expression[0] == Hash;
+        }
+
+        private static string NormalDirectoryPath(string path)
+        {
+            var c = path[path.Length - 1];
+            if (c == Path.DirectorySeparatorChar || c == Path.AltDirectorySeparatorChar)
+                return path;
+
+            return string.Concat(path, Path.DirectorySeparatorChar);
+        }
+    }
+}

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using PSRule.Configuration;
+using PSRule.Data;
 using PSRule.Runtime;
 using System.Globalization;
 using System.Linq;
@@ -58,9 +59,11 @@ namespace PSRule.Pipeline
         /// <returns>The TargetName of the object.</returns>
         private static string DefaultTargetNameBinding(PSObject targetObject)
         {
-            if (TryGetTargetName(targetObject: targetObject, propertyName: Property_TargetName, targetName: out string targetName) ||
-                TryGetTargetName(targetObject: targetObject, propertyName: Property_Name, targetName: out targetName))
+            if (TryGetInfoTargetName(targetObject, out string targetName) ||
+                TryGetTargetName(targetObject, propertyName: Property_TargetName, targetName: out targetName) ||
+                TryGetTargetName(targetObject, propertyName: Property_Name, targetName: out targetName))
                 return targetName;
+
             return GetUnboundObjectTargetName(targetObject);
         }
 
@@ -135,12 +138,35 @@ namespace PSRule.Pipeline
         /// <returns>The TargetObject of the object.</returns>
         private static string DefaultTargetTypeBinding(PSObject targetObject)
         {
+            if (TryGetInfoTargetType(targetObject, out string targetType))
+                return targetType;
+
             return targetObject.TypeNames[0];
         }
 
         private static string DefaultFieldBinding(PSObject targetObject)
         {
             return null;
+        }
+
+        private static bool TryGetInfoTargetName(PSObject targetObject, out string targetName)
+        {
+            targetName = null;
+            if (!(targetObject.BaseObject is ITargetInfo info))
+                return false;
+
+            targetName = info.TargetName;
+            return true;
+        }
+
+        private static bool TryGetInfoTargetType(PSObject targetObject, out string targetType)
+        {
+            targetType = null;
+            if (!(targetObject.BaseObject is ITargetInfo info))
+                return false;
+
+            targetType = info.TargetType;
+            return true;
         }
     }
 }

--- a/src/PSRule/Pipeline/TestPipeline.cs
+++ b/src/PSRule/Pipeline/TestPipeline.cs
@@ -7,8 +7,8 @@ namespace PSRule.Pipeline
 {
     internal sealed class TestPipelineBuilder : InvokePipelineBuilderBase
     {
-        internal TestPipelineBuilder(Source[] source)
-            : base(source) { }
+        internal TestPipelineBuilder(Source[] source, HostContext hostContext)
+            : base(source, hostContext) { }
 
         private sealed class BooleanWriter : PipelineWriter
         {

--- a/src/PSRule/Rules/RuleSource.cs
+++ b/src/PSRule/Rules/RuleSource.cs
@@ -99,10 +99,15 @@ namespace PSRule.Rules
         private readonly List<Source> _Source;
         private readonly PipelineLogger _Logger;
 
-        internal RuleSourceBuilder()
+        internal RuleSourceBuilder(HostContext hostContext)
         {
             _Source = new List<Source>();
             _Logger = new PipelineLogger();
+            if (hostContext != null)
+            {
+                _Logger.UseCommandRuntime(hostContext.CmdletContext);
+                _Logger.UseExecutionContext(hostContext.ExecutionContext);
+            }
         }
 
         public RuleSourceBuilder Configure(PSRuleOption option)
@@ -110,16 +115,6 @@ namespace PSRule.Rules
             _Logger.Configure(option);
             _Logger.EnterScope("[Discovery.Source]");
             return this;
-        }
-
-        public void UseCommandRuntime(PSCmdlet commandRuntime)
-        {
-            _Logger.UseCommandRuntime(commandRuntime);
-        }
-
-        public void UseExecutionContext(EngineIntrinsics executionContext)
-        {
-            _Logger.UseExecutionContext(executionContext);
         }
 
         public void VerboseScanSource(string path)

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -30,7 +30,7 @@ namespace PSRule
 
         private Source[] GetSource()
         {
-            var builder = new RuleSourceBuilder();
+            var builder = new RuleSourceBuilder(null);
             builder.Directory(GetSourcePath("Baseline.Rule.yaml"));
             return builder.Build();
         }

--- a/tests/PSRule.Tests/ConfigTests.cs
+++ b/tests/PSRule.Tests/ConfigTests.cs
@@ -30,7 +30,7 @@ namespace PSRule
 
         private Source[] GetSource()
         {
-            var builder = new RuleSourceBuilder();
+            var builder = new RuleSourceBuilder(null);
             builder.Directory(GetSourcePath("ModuleConfig.Rule.yaml"));
             return builder.Build();
         }

--- a/tests/PSRule.Tests/ConfigurationTests.cs
+++ b/tests/PSRule.Tests/ConfigurationTests.cs
@@ -44,7 +44,7 @@ namespace PSRule
 
         private static void BuildPipeline(PSRuleOption option)
         {
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             builder.Build();
         }
 
@@ -55,7 +55,7 @@ namespace PSRule
 
         private static Source[] GetSource()
         {
-            var builder = new RuleSourceBuilder();
+            var builder = new RuleSourceBuilder(null);
             builder.Directory(GetSourcePath("FromFile.Rule.ps1"));
             return builder.Build();
         }

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -154,6 +154,21 @@ Rule 'ConstrainedTest3' -If { $Null = [Console]::WriteLine('Should fail'); retur
     $True;
 }
 
+# Synopsis: Test for using -InputFormat
+Rule 'WithFormat' {
+    $TargetObject.spec.properties.kind -eq 'Test'
+    ($TargetObject.spec.properties.array.id | Measure-Object).Count -eq 2
+    ($TargetObject.spec.properties.array2 | Measure-Object).Count -eq 3
+}
+
+# Synopsis: Test for using -InputFormat File
+Rule 'WithFileFormat' {
+    $Assert.HasFieldValue($TargetObject, 'FullName');
+    $Assert.HasFieldValue($TargetObject, 'DisplayName');
+    $PSRule.Data['FullName'] = $TargetObject.FullName;
+    $PSRule.Data['DisplayName'] = $TargetObject.DisplayName;
+}
+
 # Synopsis: Test $PSRule automatic variables
 Rule 'VariableContextVariable' {
     $TargetObject.Name -eq $PSRule.TargetName;
@@ -182,12 +197,6 @@ Rule 'WithConfiguration' {
     $Configuration.Value1 -eq 1
     $Configuration.Value2 -eq 2
 } -Configure @{ Value1 = 2; Value2 = 2; }
-
-Rule 'WithFormat' {
-    $TargetObject.spec.properties.kind -eq 'Test'
-    ($TargetObject.spec.properties.array.id | Measure-Object).Count -eq 2
-    ($TargetObject.spec.properties.array2 | Measure-Object).Count -eq 3
-}
 
 # Synopsis: Test $LocalizedData automatic variable
 Rule 'WithLocalizedData' {

--- a/tests/PSRule.Tests/InputPathBuilderTests.cs
+++ b/tests/PSRule.Tests/InputPathBuilderTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Pipeline;
+using System;
+using System.IO;
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class InputPathBuilderTests
+    {
+        [Fact]
+        public void GetPath()
+        {
+            var builder = new InputPathBuilder(null, GetWorkingPath(), "*", null);
+            builder.Add(".");
+            var actual = builder.Build();
+            Assert.True(actual.Length > 100);
+
+            builder.Add(GetWorkingPath());
+            actual = builder.Build();
+            Assert.True(actual.Length > 100);
+
+            builder.Add("./src");
+            actual = builder.Build();
+            Assert.True(actual.Length == 0);
+
+            builder.Add("./src/");
+            actual = builder.Build();
+            Assert.True(actual.Length > 100);
+
+            builder.Add("./");
+            actual = builder.Build();
+            Assert.True(actual.Length > 100);
+
+            builder.Add("./.azure-pipelines/*.yaml");
+            actual = builder.Build();
+            Assert.True(actual.Length == 1);
+
+            builder.Add("./.azure-pipelines/**/*.yaml");
+            actual = builder.Build();
+            Assert.True(actual.Length == 3);
+
+            builder.Add("./.azure-pipelines/");
+            actual = builder.Build();
+            Assert.True(actual.Length == 4);
+
+            builder.Add(".azure-pipelines/");
+            actual = builder.Build();
+            Assert.True(actual.Length == 4);
+
+            builder.Add("./*.json");
+            actual = builder.Build();
+            Assert.True(actual.Length == 1);
+
+            builder.Add("src/");
+            actual = builder.Build();
+            Assert.True(actual.Length > 100);
+        }
+
+        private static string GetWorkingPath()
+        {
+            return Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..\\..\\..\\..\\.."));
+        }
+    }
+}

--- a/tests/PSRule.Tests/InputPathBuilderTests.cs
+++ b/tests/PSRule.Tests/InputPathBuilderTests.cs
@@ -61,7 +61,7 @@ namespace PSRule
 
         private static string GetWorkingPath()
         {
-            return Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..\\..\\..\\..\\.."));
+            return Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "../../../../.."));
         }
     }
 }

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -434,6 +434,28 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Input.PathIgnore' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Input.PathIgnore | Should -Be $Null;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Input.PathIgnore' = 'ignore.cs' };
+            $option.Input.PathIgnore | Should -Be 'ignore.cs';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Input.PathIgnore | Should -Be '*.Designer.cs';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InputPathIgnore 'ignore.cs' -Path $emptyOptionsFilePath;
+            $option.Input.PathIgnore | Should -Be 'ignore.cs';
+        }
+    }
+
     Context 'Read Input.TargetType' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -880,6 +902,13 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -ObjectPath 'items' @optionParams;
             $option.Input.ObjectPath | Should -Be 'items';
+        }
+    }
+
+    Context 'Read Input.PathIgnore' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -InputPathIgnore 'ignore.cs' @optionParams;
+            $option.Input.PathIgnore | Should -Be 'ignore.cs';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -38,6 +38,8 @@ execution:
 input:
   format: Yaml
   objectPath: items
+  pathIgnore:
+  - '*.Designer.cs'
   targetType:
   - virtualMachine
 

--- a/tests/PSRule.Tests/PathFilterTests.cs
+++ b/tests/PSRule.Tests/PathFilterTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Pipeline;
+using System;
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class PathFilterTests
+    {
+        [Fact]
+        public void Match()
+        {
+            // Single expression match
+            var filter = PathFilter.Create(GetWorkingPath(), "**/Resources.Parameters*.json");
+            Assert.True(filter.Match("tests/example/Resources.Parameters.json"));
+            Assert.True(filter.Match("tests/example2/Resources.Parameters2.json"));
+            Assert.False(filter.Match("tests/example2/Resources.Parameters2.txt"));
+            filter = PathFilter.Create(GetWorkingPath(), "**/example2/Resources.Parameters*.json");
+            Assert.False(filter.Match("tests/example/Resources.Parameters.json"));
+            Assert.True(filter.Match("tests/example2/Resources.Parameters2.json"));
+            filter = PathFilter.Create(GetWorkingPath(), "**/example?/Resources.Parameters*.json");
+            Assert.True(filter.Match("tests/example/Resources.Parameters.json"));
+            Assert.True(filter.Match("tests/example2/Resources.Parameters2.json"));
+            Assert.False(filter.Match("tests/example2/Resources.Parameters2.txt"));
+            filter = PathFilter.Create(GetWorkingPath(), "tests/example?/Resources.Parameters.json");
+            Assert.True(filter.Match("tests/example/Resources.Parameters.json"));
+            Assert.True(filter.Match("tests/example2/Resources.Parameters.json"));
+            filter = PathFilter.Create(GetWorkingPath(), "tests/example/Resources.Parameters*.json");
+            Assert.True(filter.Match("tests/example/Resources.Parameters.json"));
+            Assert.True(filter.Match("tests/example/Resources.Parameters2.json"));
+
+            // Multi-expression match
+            var expressions = new string[]
+            {
+                "out/",
+                "**/bin/",
+                "**/obj/",
+                "",
+                "# Add reports/bin",
+                "!reports/bin/"
+            };
+            filter = PathFilter.Create(GetWorkingPath(), expressions, true);
+            Assert.True(filter.Match("out/example.parameters.json"));
+            Assert.False(filter.Match("outer/example.parameters.json"));
+            Assert.False(filter.Match("reports/out/example.parameters.json"));
+            Assert.True(filter.Match("src/bin/pwsh.exe"));
+            Assert.True(filter.Match("src/obj/example.parameters.json"));
+            Assert.False(filter.Match("reports/bin/other.json"));
+
+            // Exclude
+            filter = PathFilter.Create(GetWorkingPath(), expressions, false);
+            Assert.False(filter.Match("out/example.parameters.json"));
+            Assert.True(filter.Match("outer/example.parameters.json"));
+            Assert.True(filter.Match("reports/out/example.parameters.json"));
+            Assert.False(filter.Match("src/bin/pwsh.exe"));
+            Assert.False(filter.Match("src/obj/example.parameters.json"));
+            Assert.True(filter.Match("reports/bin/other.json"));
+        }
+
+        private static string GetWorkingPath()
+        {
+            return AppDomain.CurrentDomain.BaseDirectory;
+        }
+    }
+}

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -25,7 +25,7 @@ namespace PSRule
         public void BuildInvokePipeline()
         {
             var option = GetOption();
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             Assert.NotNull(builder.Build());
         }
 
@@ -35,7 +35,7 @@ namespace PSRule
             var testObject1 = new TestObject { Name = "TestObject1" };
             var option = GetOption();
             option.Rule.Include = new string[] { "FromFile1" };
-            var builder = PipelineBuilder.Invoke(GetSource(), option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             var pipeline = builder.Build();
             pipeline.Begin();
 
@@ -49,7 +49,7 @@ namespace PSRule
         [Fact]
         public void BuildGetPipeline()
         {
-            var builder = PipelineBuilder.Get(GetSource(), GetOption());
+            var builder = PipelineBuilder.Get(GetSource(), GetOption(), null, null);
             Assert.NotNull(builder.Build());
         }
 
@@ -77,13 +77,13 @@ namespace PSRule
         public void PipelineWithRequires()
         {
             var option = GetOption(GetSourcePath("PSRule.Tests6.yml"));
-            var builder = PipelineBuilder.Get(GetSource(), option);
+            var builder = PipelineBuilder.Get(GetSource(), option, null, null);
             Assert.Null(builder.Build());
         }
 
         private static Source[] GetSource()
         {
-            var builder = new RuleSourceBuilder();
+            var builder = new RuleSourceBuilder(null);
             builder.Directory(GetSourcePath("FromFile.Rule.ps1"));
             return builder.Build();
         }


### PR DESCRIPTION
## PR Summary

- Engine features:
  - Added support for scanning repository files. #524
    - Added `File` input type (`-InputType File`) to scan for files without deserializing them.
    - Added `Input.PathIgnore` option to ignore files.
    - When using the `File` input type path specs in `.gitignore` are ignored.
  - Added `Get-PSRuleTarget` cmdlet to read input files and return raw objects. #525
    - This cmdlet can be used to troubleshoot PSRule input issues.

Fixes #524 
Fixes #525 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
