### PR TITLE
Warn when an obsolete baseline is used #499

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Unreleased
 
+- Engine features:
+  - Baselines can now be flagged as obsolete. [#499](https://github.com/microsoft/PSRule/issues/499)
+    - Set the `metadata.annotations.obsolete` property to `true` to flag a baseline as obsolete.
+    - When an obsolete baseline is used, a warning will be generated.
 - Engineering:
   - Bump YamlDotNet dependency to v8.1.2. [#439](https://github.com/microsoft/PSRule/issues/439)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
@@ -139,36 +139,40 @@ spec: { }
 
 ## EXAMPLES
 
-### Example ps-rule.yaml
+### Example Baseline.Rule.yaml
 
 ```yaml
-#
-# PSRule example configuration
-#
+---
+# Synopsis: This is an example baseline
+kind: Baseline
+metadata:
+  name: TestBaseline1
+spec:
+  binding:
+    targetName:
+    - AlternateName
+    targetType:
+    - kind
+  rule:
+    include:
+    - 'WithBaseline'
+  configuration:
+    key1: value1
 
-# Configures binding
-binding:
-  ignoreCase: false
-  field:
-    id:
-    - ResourceId
-  targetName:
-  - ResourceName
-  - AlternateName
-  targetType:
-  - ResourceType
-  - kind
-
-# Adds rule configuration
-configuration:
-  appServiceMinInstanceCount: 2
-
-# Configure rule filtering
-rule:
-  include:
-  - rule1
-  - rule2
-  exclude:
-  - rule3
-  - rule4
+---
+# Synopsis: This is an example baseline
+kind: Baseline
+metadata:
+  name: TestBaseline2
+spec:
+  binding:
+    targetName:
+    - AlternateName
+    targetType:
+    - kind
+  rule:
+    include:
+    - 'WithBaseline'
+  configuration:
+    key1: value1
 ```

--- a/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
@@ -45,6 +45,7 @@ To define a baseline spec use the following structure:
 kind: Baseline
 metadata:
   name: <name>
+  annotations: { }
 spec:
   # One or more baseline options
   binding: { }
@@ -112,6 +113,29 @@ When baseline options are set, PSRule uses the following order to determine prec
 4. Module - A baseline object included in a `.Rule.yaml` file.
 
 After precedence is determined, baselines are merged and null values are ignored, such that:
+
+### Annotations
+
+Additional baseline annotations can be provided as key/ value pairs.
+Annotations can be used to provide additional information that is available in `Get-PSRuleBaseline` output.
+
+The following reserved annotation exists:
+
+- `obsolete` - Marks the baseline as obsolete when set to `true`.
+PSRule will generate a warning when an obsolete baseline is used.
+
+For example:
+
+```yaml
+---
+# Synopsis: This is an example baseline that is obsolete
+kind: Baseline
+metadata:
+  name: ObsoleteBaseline
+  annotations:
+    obsolete: true
+spec: { }
+```
 
 ## EXAMPLES
 

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -21,6 +21,10 @@
                     "title": "Name",
                     "description": "The name of the resource. This must be unique.",
                     "minLength": 3
+                },
+                "annotations": {
+                    "type": "object",
+                    "title": "Annotations"
                 }
             },
             "required": [

--- a/src/PSRule/Common/DictionaryExtensions.cs
+++ b/src/PSRule/Common/DictionaryExtensions.cs
@@ -14,6 +14,20 @@ namespace PSRule
             return dictionary.TryGetValue(key, out value) && dictionary.Remove(key);
         }
 
+        public static bool TryGetBool(this IDictionary<string, object> dictionary, string key, out bool? value)
+        {
+            value = null;
+            if (!dictionary.TryGetValue(key, out object o))
+                return false;
+
+            if (o is bool bvalue || (o is string svalue && bool.TryParse(svalue, out bvalue)))
+            {
+                value = bvalue;
+                return true;
+            }
+            return false;
+        }
+
         [DebuggerStepThrough]
         public static void AddUnique(this IDictionary<string, object> dictionary, IEnumerable<KeyValuePair<string, object>> values)
         {

--- a/src/PSRule/Definitions/Baseline.cs
+++ b/src/PSRule/Definitions/Baseline.cs
@@ -26,11 +26,13 @@ namespace PSRule.Definitions
     public sealed class Baseline : Resource<BaselineSpec>, IResource
     {
         public Baseline(SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, BaselineSpec spec)
+            : base(metadata)
         {
             Info = info;
             Source = source;
             Spec = spec;
             Name = BaselineId = metadata.Name;
+            Obsolete = ResourceHelper.IsObsolete(metadata);
         }
 
         [YamlIgnore()]
@@ -38,6 +40,9 @@ namespace PSRule.Definitions
 
         [YamlIgnore()]
         public readonly string Name;
+
+        [YamlIgnore()]
+        internal readonly bool Obsolete;
 
         /// <summary>
         /// The script file path where the baseline is defined.

--- a/src/PSRule/Definitions/ISpec.cs
+++ b/src/PSRule/Definitions/ISpec.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Host;
+using System.Collections.Generic;
 
 namespace PSRule.Definitions
 {
@@ -39,9 +40,21 @@ namespace PSRule.Definitions
         internal IResource Block { get; }
     }
 
+    public sealed class ResourceAnnotations : Dictionary<string, object>
+    {
+
+    }
+
     public sealed class ResourceMetadata
     {
+        public ResourceMetadata()
+        {
+            Annotations = new ResourceAnnotations();
+        }
+
         public string Name { get; set; }
+
+        public ResourceAnnotations Annotations { get; set; }
     }
 
     public sealed class ResourceExtent
@@ -63,7 +76,27 @@ namespace PSRule.Definitions
 
     public abstract class Resource<TSpec> where TSpec : Spec, new()
     {
+        protected Resource(ResourceMetadata metadata)
+        {
+            Metadata = metadata;
+        }
+
+        public ResourceMetadata Metadata { get; }
+
         public abstract TSpec Spec { get; }
+    }
+
+    internal static class ResourceHelper
+    {
+        private const string ANNOTATION_OBSOLETE = "obsolete";
+
+        internal static bool IsObsolete(ResourceMetadata metadata)
+        {
+            if (metadata == null || metadata.Annotations == null || !metadata.Annotations.TryGetBool(ANNOTATION_OBSOLETE, out bool? obsolete))
+                return false;
+
+            return obsolete.GetValueOrDefault(false);
+        }
     }
 
     public abstract class Spec

--- a/src/PSRule/Definitions/ModuleConfig.cs
+++ b/src/PSRule/Definitions/ModuleConfig.cs
@@ -15,6 +15,7 @@ namespace PSRule.Definitions
     internal sealed class ModuleConfig : Resource<ModuleConfigSpec>, IResource
     {
         public ModuleConfig(SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ModuleConfigSpec spec)
+            : base(metadata)
         {
             Info = info;
             Source = source;

--- a/src/PSRule/Definitions/SpecFactory.cs
+++ b/src/PSRule/Definitions/SpecFactory.cs
@@ -67,11 +67,6 @@ namespace PSRule.Definitions
             get { return typeof(TSpec); }
         }
 
-        public Type StepType
-        {
-            get { return typeof(T); }
-        }
-
         public bool SupportsFlat { get; private set; }
 
         public IResource CreateInstance(SourceFile source, ResourceMetadata metadata, CommentMetadata comment, object spec)
@@ -100,7 +95,7 @@ namespace PSRule.Definitions
             }
         }
 
-        private void SetDefaultProperty(Action<object, object> set, Type propertyType, Spec option, string value)
+        private static void SetDefaultProperty(Action<object, object> set, Type propertyType, Spec option, string value)
         {
             object v = value;
             if (!propertyType.IsAssignableFrom(typeof(string)))

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -361,7 +361,7 @@ namespace PSRule.Pipeline
             var result = new OptionContext();
 
             // Baseline
-            var baselineScope = new OptionContext.BaselineScope(type: OptionContext.ScopeType.Workspace, moduleName: null, option: Option);
+            var baselineScope = new OptionContext.BaselineScope(type: OptionContext.ScopeType.Workspace, baselineId: null, moduleName: null, option: Option, obsolete: false);
             result.Add(baselineScope);
             baselineScope = new OptionContext.BaselineScope(type: OptionContext.ScopeType.Parameter, include: _Include, tag: _Tag);
             result.Add(baselineScope);

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -128,7 +128,7 @@ namespace PSRule.Pipeline
             if (resource.Kind == ResourceKind.Baseline && resource is Baseline baseline && _Unresolved.TryGetValue(resource.Id, out ResourceRef rr) && rr is BaselineRef baselineRef)
             {
                 _Unresolved.Remove(resource.Id);
-                Baseline.Add(new OptionContext.BaselineScope(baselineRef.Type, resource.Module, baseline.Spec));
+                Baseline.Add(new OptionContext.BaselineScope(baselineRef.Type, baseline.BaselineId, resource.Module, baseline.Spec, baseline.Obsolete));
             }
             else if (TryModuleConfig(resource, out ModuleConfig moduleConfig))
             {

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -5,6 +5,7 @@ using PSRule.Configuration;
 using PSRule.Rules;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Threading;
 
 namespace PSRule.Pipeline
 {
@@ -69,6 +70,17 @@ namespace PSRule.Pipeline
                 return;
 
             _Writer.WriteWarning(message);
+        }
+
+        public void WriteWarning(string message, params object[] args)
+        {
+            if (!ShouldWriteWarning() || string.IsNullOrEmpty(message))
+                return;
+
+            if (args == null || args.Length == 0)
+                WriteWarning(message);
+            else
+                WriteWarning(string.Format(Thread.CurrentThread.CurrentCulture, message, args));
         }
 
         public virtual bool ShouldWriteWarning()

--- a/src/PSRule/Pipeline/RunspaceContext.cs
+++ b/src/PSRule/Pipeline/RunspaceContext.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Text;
+using System.Threading;
 using static PSRule.Pipeline.PipelineContext;
 
 namespace PSRule.Pipeline
@@ -124,13 +125,21 @@ namespace PSRule.Pipeline
             Writer.WriteWarning(PSRuleResources.RuleNotFound);
         }
 
+        public void WarnBaselineObsolete(string baselineId)
+        {
+            if (Writer == null || !Writer.ShouldWriteWarning())
+                return;
+
+            Writer.WriteWarning(PSRuleResources.BaselineObsolete, baselineId);
+        }
+
         public void ErrorInvaildRuleResult()
         {
             if (Writer == null || !Writer.ShouldWriteError())
                 return;
 
             Writer.WriteError(new ErrorRecord(
-                exception: new RuleRuntimeException(message: string.Format(PSRuleResources.InvalidRuleResult, RuleBlock.RuleId)),
+                exception: new RuleRuntimeException(message: string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.InvalidRuleResult, RuleBlock.RuleId)),
                 errorId: ERRORID_INVALIDRULERESULT,
                 errorCategory: ErrorCategory.InvalidResult,
                 targetObject: null
@@ -166,7 +175,7 @@ namespace PSRule.Pipeline
             if (Writer == null || !Writer.ShouldWriteVerbose())
                 return;
 
-            Writer.WriteVerbose(string.Concat(GetLogPrefix(), "[", condition, "] -- ", string.Format(message, args)));
+            Writer.WriteVerbose(string.Concat(GetLogPrefix(), "[", condition, "] -- ", string.Format(Thread.CurrentThread.CurrentCulture, message, args)));
         }
 
         public void VerboseConditionResult(string condition, int pass, int count, bool outcome)
@@ -438,7 +447,7 @@ namespace PSRule.Pipeline
 
         public void Begin()
         {
-            // Do nothing
+            Pipeline.Baseline.Init(this);
         }
 
         public string GetLocalizedPath(string file)

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -61,6 +61,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The baseline &apos;{0}&apos; is obsolete. Consider switching to an alternative baseline..
+        /// </summary>
+        internal static string BaselineObsolete {
+            get {
+                return ResourceManager.GetString("BaselineObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Binding functions are not supported in this language mode..
         /// </summary>
         internal static string ConstrainedTargetBinding {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -117,6 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BaselineObsolete" xml:space="preserve">
+    <value>The baseline '{0}' is obsolete. Consider switching to an alternative baseline.</value>
+    <comment>Occurs when a baseline is used that has been flagged as obsolete.</comment>
+  </data>
   <data name="ConstrainedTargetBinding" xml:space="preserve">
     <value>Binding functions are not supported in this language mode.</value>
   </data>

--- a/tests/PSRule.Tests/Baseline.Rule.yaml
+++ b/tests/PSRule.Tests/Baseline.Rule.yaml
@@ -4,6 +4,8 @@
 kind: Baseline
 metadata:
   name: TestBaseline1
+  annotations:
+    key: value
 spec:
   binding:
     field:
@@ -70,6 +72,15 @@ spec:
       severity:
       - 'high'
       - 'low'
+
+---
+# Synopsis: This is an example obsolete baseline
+kind: Baseline
+metadata:
+  name: TestBaseline5
+  annotations:
+    obsolete: true
+spec: { }
 
 ---
 kind: ObjectSelector

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -20,7 +20,16 @@ namespace PSRule
             var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, new OptionContext(), null), null);
             var baseline = HostHelper.GetBaseline(GetSource(), context).ToArray();
             Assert.NotNull(baseline);
+            Assert.Equal(5, baseline.Length);
+
+            // TestBaseline1
             Assert.Equal("TestBaseline1", baseline[0].Name);
+            Assert.Equal("value", baseline[0].Metadata.Annotations["key"]);
+            Assert.False(baseline[0].Obsolete);
+
+            // TestBaseline5
+            Assert.Equal("TestBaseline5", baseline[4].Name);
+            Assert.True(baseline[4].Obsolete);
         }
 
         private PSRuleOption GetOption()

--- a/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
@@ -37,7 +37,7 @@ Describe 'Get-PSRuleBaseline' -Tag 'Baseline','Get-PSRuleBaseline' {
         It 'With defaults' {
             $result = @(Get-PSRuleBaseline -Path $baselineFilePath);
             $result | Should -Not -BeNullOrEmpty;
-            $result.Length | Should -Be 4;
+            $result.Length | Should -Be 5;
             $result[0].Name | Should -Be 'TestBaseline1';
             $result[3].Name | Should -Be 'TestBaseline4';;
         }
@@ -67,9 +67,9 @@ Describe 'Baseline' -Tag 'Baseline' {
                 Id = '1'
             }
         )
-        $result = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline1');
 
         It 'With -Baseline' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline1');
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 1;
             $result[0].RuleName | Should -Be 'WithBaseline';
@@ -77,6 +77,19 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result[0].TargetName | Should -Be 'TestObject1';
             $result[0].TargetType | Should -Be 'TestObjectType';
             $result[0].Field.kind | Should -Be 'TestObjectType';
+        }
+
+        It 'With obsolete' {
+            # Not obsolete
+            $Null = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline1' -WarningVariable outWarn -WarningAction SilentlyContinue);
+            $warnings = @($outWarn);
+            $warnings.Length | Should -Be 0;
+
+            # Obsolete
+            $Null = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline5' -WarningVariable outWarn -WarningAction SilentlyContinue);
+            $warnings = @($outWarn);
+            $warnings.Length | Should -Be 1;
+            $warnings[0] | Should -BeLike "*'TestBaseline5'*";
         }
 
         It 'With -Module' {


### PR DESCRIPTION
## PR Summary

- Baselines can now be flagged as obsolete. #499
  - Set the `metadata.annotations.obsolete` property to `true` to flag a baseline as obsolete.
  - When an obsolete baseline is used, a warning will be generated.

Fixes #499 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
