### PR TITLE
Pre-release v0.20.0-B2008010

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## Unreleased
 
+## v0.20.0-B2008010 (pre-release)
+
+What's changed since pre-release v0.20.0-B2008002:
+
 - Engine features:
   - Baselines can now be flagged as obsolete. [#499](https://github.com/microsoft/PSRule/issues/499)
     - Set the `metadata.annotations.obsolete` property to `true` to flag a baseline as obsolete.


### PR DESCRIPTION
## PR Summary


What's changed since pre-release v0.20.0-B2008002:

- Engine features:
  - Baselines can now be flagged as obsolete. #499
    - Set the `metadata.annotations.obsolete` property to `true` to flag a baseline as obsolete.
    - When an obsolete baseline is used, a warning will be generated.
- Engineering:
  - Bump YamlDotNet dependency to v8.1.2. #439

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
