### PR TITLE
Fixed empty markdown out of bounds #516

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed out of bounds exception when empty markdown documentation is used. [#516](https://github.com/microsoft/PSRule/issues/516)
+
 ## v0.20.0-B2008010 (pre-release)
 
 What's changed since pre-release v0.20.0-B2008002:

--- a/src/PSRule/Parser/MarkdownReader.cs
+++ b/src/PSRule/Parser/MarkdownReader.cs
@@ -59,6 +59,9 @@ namespace PSRule.Parser
 
         public TokenStream Read(string markdown, string path)
         {
+            if (string.IsNullOrEmpty(markdown))
+                return _Output;
+
             _Context = MarkdownReaderMode.None;
             _Stream = new MarkdownStream(markdown);
 
@@ -246,7 +249,7 @@ namespace PSRule.Parser
                 _Context = MarkdownReaderMode.None;
         }
 
-        private string UnwrapStyleMarkers(MarkdownStream stream, out MarkdownTokens flag)
+        private static string UnwrapStyleMarkers(MarkdownStream stream, out MarkdownTokens flag)
         {
             flag = MarkdownTokens.None;
 
@@ -308,12 +311,12 @@ namespace PSRule.Parser
             return text;
         }
 
-        private string Pad(string text, char c, int left = 0, int right = 0)
+        private static string Pad(string text, char c, int left = 0, int right = 0)
         {
             return text.PadLeft(text.Length + left, c).PadRight(text.Length + left + right, c);
         }
 
-        private bool IsList(string text)
+        private static bool IsList(string text)
         {
             var clean = text.Trim();
 
@@ -328,7 +331,7 @@ namespace PSRule.Parser
             return false;
         }
 
-        private MarkdownTokens GetEnding(int lineEndings)
+        private static MarkdownTokens GetEnding(int lineEndings)
         {
             if (lineEndings == 0)
                 return MarkdownTokens.None;

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1325,6 +1325,12 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
                 $result | Should -Not -BeNullOrEmpty;
                 $result.RuleName | Should -Be 'WithNoSynopsis';
                 $result.Synopsis | Should -BeNullOrEmpty;
+
+                # Empty markdown
+                $result = Get-PSRule -Path $ruleFilePath -Name 'WithNoSynopsis' -Culture 'en-YY';
+                $result | Should -Not -BeNullOrEmpty;
+                $result.RuleName | Should -Be 'WithNoSynopsis';
+                $result.Synopsis | Should -BeNullOrEmpty;
             }
             finally {
                 [PSRule.Configuration.PSRuleOption]::UseCurrentCulture();


### PR DESCRIPTION
## PR Summary

- Fixed out of bounds exception when empty markdown documentation is used. #516

Fixes #516 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
