### PR TITLE
Warn on deprecated $Rule properties #536

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Added file assertion helpers `FileHeader`, and `FilePath`. [#534](https://github.com/microsoft/PSRule/issues/534)
     - `FileHeader` checks for a comment header in the file.
     - `FilePath` checks that a file path, optionally with suffixes exist.
+- Engineering:
+  - Warn when deprecated `$Rule` properties are used. [#536](https://github.com/microsoft/PSRule/issues/536)
 - Bug fixes:
   - Fixed out of bounds exception when empty markdown documentation is used. [#516](https://github.com/microsoft/PSRule/issues/516)
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Rule 'isFruit' {
     Recommend 'Fruit is only Apple, Orange and Pear'
 
     # An failure reason to display for non-fruit
-    Reason "$($Rule.TargetName) is not fruit."
+    Reason "$($PSRule.TargetName) is not fruit."
 
     # Condition to determine if the object is fruit
     $TargetObject.Name -in 'Apple', 'Orange', 'Pear'

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -224,7 +224,7 @@ Examples:
 ```powershell
 # Synopsis: This rule determines if the target object matches the naming convention
 Rule 'resource.NamingConvention' {
-    $Rule.TargetName.ToLower() -ceq $Rule.TargetName
+    $PSRule.TargetName.ToLower() -ceq $PSRule.TargetName
 }
 ```
 

--- a/docs/scenarios/fruit/isFruit.Rule.ps1
+++ b/docs/scenarios/fruit/isFruit.Rule.ps1
@@ -7,7 +7,7 @@ Rule 'isFruit' {
     Recommend 'Fruit is only Apple, Orange and Pear'
 
     # An failure reason to display for non-fruit
-    Reason "$($Rule.TargetName) is not fruit."
+    Reason "$($PSRule.TargetName) is not fruit."
 
     # Condition to determine if the object is fruit
     $TargetObject.Name -in 'Apple', 'Orange', 'Pear'

--- a/docs/scenarios/index.md
+++ b/docs/scenarios/index.md
@@ -105,7 +105,7 @@ Rule 'isFruit' {
     Recommend 'Fruit is only Apple, Orange and Pear'
 
     # An failure reason to display for non-fruit
-    Reason "$($Rule.TargetName) is not fruit."
+    Reason "$($PSRule.TargetName) is not fruit."
 
     # Condition to determine if the object is fruit
     $TargetObject.Name -in 'Apple', 'Orange', 'Pear'

--- a/src/PSRule/Pipeline/RunspaceContext.cs
+++ b/src/PSRule/Pipeline/RunspaceContext.cs
@@ -133,6 +133,14 @@ namespace PSRule.Pipeline
             Writer.WriteWarning(PSRuleResources.BaselineObsolete, baselineId);
         }
 
+        public void WarnPropertyObsolete(string variableName, string propertyName)
+        {
+            if (Writer == null || !Writer.ShouldWriteWarning())
+                return;
+
+            Writer.WriteWarning(PSRuleResources.PropertyObsolete, variableName, propertyName);
+        }
+
         public void ErrorInvaildRuleResult()
         {
             if (Writer == null || !Writer.ShouldWriteError())

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -268,6 +268,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The property &apos;${0}.{1}&apos; is obsolete and will be removed in the next major version..
+        /// </summary>
+        internal static string PropertyObsolete {
+            get {
+                return ResourceManager.GetString("PropertyObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
         internal static string ReadJsonFailed {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -192,6 +192,9 @@
   <data name="OutcomeRulePass" xml:space="preserve">
     <value>[PASS] -- {0}:: Reported for '{1}'</value>
   </data>
+  <data name="PropertyObsolete" xml:space="preserve">
+    <value>The property '${0}.{1}' is obsolete and will be removed in the next major version.</value>
+  </data>
   <data name="ReadJsonFailed" xml:space="preserve">
     <value>Read JSON failed.</value>
   </data>

--- a/src/PSRule/Runtime/Rule.cs
+++ b/src/PSRule/Runtime/Rule.cs
@@ -14,6 +14,7 @@ namespace PSRule.Runtime
     /// </summary>
     public sealed class Rule
     {
+        private const string VariableName = "Rule";
 
         public string RuleName
         {
@@ -36,6 +37,7 @@ namespace PSRule.Runtime
         {
             get
             {
+                RunspaceContext.CurrentThread.WarnPropertyObsolete(VariableName, nameof(TargetObject));
                 return RunspaceContext.CurrentThread.RuleRecord.TargetObject;
             }
         }
@@ -45,6 +47,7 @@ namespace PSRule.Runtime
         {
             get
             {
+                RunspaceContext.CurrentThread.WarnPropertyObsolete(VariableName, nameof(TargetName));
                 return RunspaceContext.CurrentThread.RuleRecord.TargetName;
             }
         }
@@ -54,6 +57,7 @@ namespace PSRule.Runtime
         {
             get
             {
+                RunspaceContext.CurrentThread.WarnPropertyObsolete(VariableName, nameof(TargetType));
                 return RunspaceContext.CurrentThread.RuleRecord.TargetType;
             }
         }

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -188,8 +188,8 @@ Rule 'VariableContextVariable' {
 # Synopsis: Test $Rule automatic variables
 Rule 'WithRuleVariable' {
     $TargetObject.RuleTest -eq $Rule.RuleName;
-    $TargetObject.Name -eq $Rule.TargetName;
-    $TargetObject.Type -eq $Rule.TargetType;
+    $TargetObject.Name -eq $PSRule.TargetName;
+    $TargetObject.Type -eq $PSRule.TargetType;
 }
 
 # Synopsis: Test $Configuration automatic variables

--- a/tests/PSRule.Tests/FromFileBaseline.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileBaseline.Rule.ps1
@@ -7,8 +7,8 @@
 
 # Synopsis: Test for baseline
 Rule 'WithBaseline' -Tag @{ category = 'group2'; severity = 'high' } {
-    $Rule.TargetName -eq 'TestObject1'
-    $Rule.TargetType -eq 'TestObjectType'
+    $PSRule.TargetName -eq 'TestObject1'
+    $PSRule.TargetType -eq 'TestObjectType'
     $PSRule.Field.kind -eq 'TestObjectType'
 }
 

--- a/tests/PSRule.Tests/TestModule4/rules/Module4.Rule.ps1
+++ b/tests/PSRule.Tests/TestModule4/rules/Module4.Rule.ps1
@@ -7,8 +7,8 @@
 
 # Synopsis: Test rule in TestModule4
 Rule 'M4.Rule1' {
-    $Rule.TargetName -eq 'TestObject1'
-    $Rule.TargetType -eq 'TestObjectType'
+    $PSRule.TargetName -eq 'TestObject1'
+    $PSRule.TargetType -eq 'TestObjectType'
     $Configuration.ruleConfig1 -eq 'Test'
 }
 


### PR DESCRIPTION
## PR Summary

- Warn when deprecated `$Rule` properties are used. #536

Fixes #536 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
