### PR TITLE
Fixed git ref line break #538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Warn when deprecated `$Rule` properties are used. [#536](https://github.com/microsoft/PSRule/issues/536)
 - Bug fixes:
   - Fixed out of bounds exception when empty markdown documentation is used. [#516](https://github.com/microsoft/PSRule/issues/516)
+  - Fixed lines breaks in `RepositoryInfo` target name with git ref. [#538](https://github.com/microsoft/PSRule/issues/538)
 
 ## v0.20.0-B2008010 (pre-release)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -546,7 +546,7 @@ Files within `.git` sub-directories are ignored.
 Path specs specified in `.gitignore` directly in the current working path are ignored.
 A `RepositoryInfo` object is generated if the current working path if a `.git` sub-directory is present.
 
-Detect uses matches the following file extensions:
+Detect uses the following file extensions:
 
 - Yaml - `.yaml` or `.yml`
 - Json - `.json`

--- a/src/PSRule/Common/GitHelper.cs
+++ b/src/PSRule/Common/GitHelper.cs
@@ -35,9 +35,14 @@ namespace PSRule
             if (!File.Exists(headFilePath))
                 return false;
 
-            value = File.ReadAllText(headFilePath);
-            if (value.StartsWith("ref: ", System.StringComparison.OrdinalIgnoreCase))
-                value = value.Substring(5);
+            var lines = File.ReadAllLines(headFilePath);
+            if (lines == null || lines.Length == 0)
+                return false;
+
+            if (lines[0].StartsWith("ref: ", System.StringComparison.OrdinalIgnoreCase))
+                value = lines[0].Substring(5);
+            else
+                value = lines[0];
 
             return true;
         }


### PR DESCRIPTION
## PR Summary

- Fixed lines breaks in `RepositoryInfo` target name with git ref. #538

Fixes #538 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
