### PR TITLE
Fix automatic binding properties #541 #542

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 - General improvements:
   - Added automatic binding for Rule object. [#542](https://github.com/microsoft/PSRule/issues/542)
-- Big fixes:
+- Bug fixes:
   - Fixed `InputFileInfo` `Type` property causes downstream binding issues. [#541](https://github.com/microsoft/PSRule/issues/541)
 
 ## v0.20.0-B2009007 (pre-release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## Unreleased
 
+- General improvements:
+  - Added automatic binding for Rule object. [#542](https://github.com/microsoft/PSRule/issues/542)
+- Big fixes:
+  - Fixed `InputFileInfo` `Type` property causes downstream binding issues. [#541](https://github.com/microsoft/PSRule/issues/541)
+
 ## v0.20.0-B2009007 (pre-release)
 
 What's changed since pre-release v0.20.0-B2008010:

--- a/src/PSRule/Data/InputFileInfo.cs
+++ b/src/PSRule/Data/InputFileInfo.cs
@@ -25,7 +25,6 @@ namespace PSRule.Data
             Extension = Path.GetExtension(path);
             DirectoryName = Path.GetDirectoryName(path);
             DisplayName = FullName.Substring(basePath.Length).Replace(Backslash, Slash);
-            Type = typeof(InputFileInfo).FullName;
         }
 
         public string FullName { get; }
@@ -39,8 +38,6 @@ namespace PSRule.Data
         public string DirectoryName { get; }
 
         public string DisplayName { get; }
-
-        public string Type { get; }
 
         string ITargetInfo.TargetName => DisplayName;
 

--- a/src/PSRule/Data/RepositoryInfo.cs
+++ b/src/PSRule/Data/RepositoryInfo.cs
@@ -10,7 +10,6 @@ namespace PSRule.Data
             FullName = basePath;
             BasePath = basePath;
             DisplayName = headRef;
-            Type = typeof(RepositoryInfo).FullName;
         }
 
         public string FullName { get; }
@@ -19,10 +18,8 @@ namespace PSRule.Data
 
         public string DisplayName { get; }
 
-        public string Type { get; }
-
         string ITargetInfo.TargetName => DisplayName;
 
-        string ITargetInfo.TargetType => Type;
+        string ITargetInfo.TargetType => typeof(RepositoryInfo).FullName;
     }
 }

--- a/src/PSRule/Rules/Rule.cs
+++ b/src/PSRule/Rules/Rule.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json;
+using PSRule.Data;
 using PSRule.Definitions;
 using PSRule.Host;
 using System.ComponentModel;
@@ -13,7 +14,7 @@ namespace PSRule.Rules
     /// Define a single rule.
     /// </summary>
     [JsonObject]
-    public sealed class Rule : IDependencyTarget
+    public sealed class Rule : IDependencyTarget, ITargetInfo
     {
         /// <summary>
         /// A unique identifier for the rule.
@@ -73,5 +74,9 @@ namespace PSRule.Rules
         /// </summary>
         [JsonProperty(PropertyName = "dependsOn")]
         public string[] DependsOn { get; set; }
+
+        string ITargetInfo.TargetName => RuleName;
+
+        string ITargetInfo.TargetType => typeof(Rule).FullName;
     }
 }


### PR DESCRIPTION
## PR Summary

- General improvements:
  - Added automatic binding for Rule object. #542
- Bug fixes:
  - Fixed `InputFileInfo` `Type` property causes downstream binding issues. #541

Fixes #541 
Fixes #542 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
