### PR TITLE
Fixed excessive obsolete property warnings #545

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed excessive obsolete property warnings. [#545](https://github.com/microsoft/PSRule/issues/545)
+
 ## v0.20.0-B2009013 (pre-release)
 
 What's changed since pre-release v0.20.0-B2009007:

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -72,17 +72,6 @@ namespace PSRule.Pipeline
             _Writer.WriteWarning(message);
         }
 
-        public void WriteWarning(string message, params object[] args)
-        {
-            if (!ShouldWriteWarning() || string.IsNullOrEmpty(message))
-                return;
-
-            if (args == null || args.Length == 0)
-                WriteWarning(message);
-            else
-                WriteWarning(string.Format(Thread.CurrentThread.CurrentCulture, message, args));
-        }
-
         public virtual bool ShouldWriteWarning()
         {
             return _Writer != null && _Writer.ShouldWriteWarning();

--- a/src/PSRule/Pipeline/PipelineWriterExtensions.cs
+++ b/src/PSRule/Pipeline/PipelineWriterExtensions.cs
@@ -25,6 +25,14 @@ namespace PSRule.Pipeline
             writer.WriteWarning(PSRuleResources.RulePathNotFound);
         }
 
+        internal static void WriteWarning(this PipelineWriter writer, string message, params object[] args)
+        {
+            if (!writer.ShouldWriteWarning() || string.IsNullOrEmpty(message))
+                return;
+
+            writer.WriteWarning(Format(message, args));
+        }
+
         internal static void ErrorRequiredVersionMismatch(this PipelineWriter writer, string moduleName, string moduleVersion, string requiredVersion)
         {
             if (!writer.ShouldWriteError())
@@ -40,6 +48,22 @@ namespace PSRule.Pipeline
         internal static void WriteError(this PipelineWriter writer, PipelineException exception, string errorId, ErrorCategory errorCategory)
         {
             writer.WriteError(new ErrorRecord(exception, errorId, errorCategory, null));
+        }
+
+        internal static void WriteDebug(this PipelineWriter writer, string message, params object[] args)
+        {
+            if (!writer.ShouldWriteDebug() || string.IsNullOrEmpty(message))
+                return;
+
+            writer.WriteDebug(new DebugRecord
+            (
+                message: Format(message, args)
+            ));
+        }
+
+        private static string Format(string message, params object[] args)
+        {
+            return args == null || args.Length == 0 ? message : string.Format(Thread.CurrentThread.CurrentCulture, message, args);
         }
     }
 }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -79,6 +79,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}: The property &apos;${1}.{2}&apos; is obsolete and will be removed in the next major version..
+        /// </summary>
+        internal static string DebugPropertyObsolete {
+            get {
+                return ResourceManager.GetString("DebugPropertyObsolete", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Target failed If precondition.
         /// </summary>
         internal static string DebugTargetIfMismatch {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -124,6 +124,9 @@
   <data name="ConstrainedTargetBinding" xml:space="preserve">
     <value>Binding functions are not supported in this language mode.</value>
   </data>
+  <data name="DebugPropertyObsolete" xml:space="preserve">
+    <value>{0}: The property '${1}.{2}' is obsolete and will be removed in the next major version.</value>
+  </data>
   <data name="DebugTargetIfMismatch" xml:space="preserve">
     <value>Target failed If precondition</value>
   </data>


### PR DESCRIPTION
## PR Summary

- Fixed excessive obsolete property warnings. #545

Fixes #545 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
