### PR TITLE
Added markdown output format #474 #552

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 
 ## Unreleased
 
+- Engine features:
+  - Added support for formatting results as markdown. [#474](https://github.com/microsoft/PSRule/issues/474)
+    - Use `-OutputFormat Markdown` or configure `Output.Format` to output markdown.
+    - To format as either detail or summary, use the `-As` parameter or configure `Output.As`.
 - General improvements:
   - Numerical strings can be converted with numeric assertion helpers. [#550](https://github.com/microsoft/PSRule/issues/550)
+  - Added outcome `Output.Outcome` as a configurable option. [#552](https://github.com/microsoft/PSRule/issues/552)
 
 ## v0.20.0
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Output.Culture](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputculture)
   - [Output.Encoding](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputencoding)
   - [Output.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputformat)
+  - [Output.Outcome](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputoutcome)
   - [Output.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputpath)
   - [Output.Style](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputstyle)
   - [Rule.Include](docs/concepts/PSRule/en-US/about_PSRule_Options.md#ruleinclude)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -28,6 +28,7 @@ The following workspace options are available for use:
 - [Output.Culture](#outputculture)
 - [Output.Encoding](#outputencoding)
 - [Output.Format](#outputformat)
+- [Output.Outcome](#outputoutcome)
 - [Output.Path](#outputpath)
 - [Output.Style](#outputstyle)
 - [Requires](#requires)
@@ -854,7 +855,7 @@ This option can be specified using:
 
 ```powershell
 # PowerShell: Using the OutputAs parameter
-$option = New-PSRuleOption -OutputAs Yaml;
+$option = New-PSRuleOption -OutputAs Summary;
 ```
 
 ```powershell
@@ -864,7 +865,7 @@ $option = New-PSRuleOption -Option @{ 'Output.As' = 'Summary' };
 
 ```powershell
 # PowerShell: Using the OutputAs parameter to set YAML
-Set-PSRuleOption -OutputAs Yaml;
+Set-PSRuleOption -OutputAs Summary;
 ```
 
 ```yaml
@@ -947,7 +948,7 @@ output:
 ### Output.Format
 
 Configures the format that results will be presented in.
-This option applies to `Invoke-PSRule`, `Assert-PSRule` and `Get-PSRule`.
+This option applies to `Invoke-PSRule`, `Assert-PSRule`, and `Get-PSRule`.
 This options is ignored by other cmdlets.
 
 The following format options are available:
@@ -955,6 +956,7 @@ The following format options are available:
 - None - Output is presented as an object using PowerShell defaults. This is the default.
 - Yaml - Output is serialized as YAML.
 - Json - Output is serialized as JSON.
+- Markdown - Output is serialized as Markdown.
 - NUnit3 - Output is serialized as NUnit3 (XML).
 - Csv - Output is serialized as a comma separated values (CSV).
   - The following columns are included for `Detail` output:
@@ -987,6 +989,47 @@ Set-PSRuleOption -OutputFormat Yaml;
 # YAML: Using the output/format property
 output:
   format: Yaml
+```
+
+### Output.Outcome
+
+Filters output to include results with the specified outcome.
+This option applies to `Invoke-PSRule`, and `Test-PSRule`.
+
+The following outcome options are available:
+
+- `None` - Results for rules that did not get processed are returned.
+- `Pass` - Results for rules that passed are returned.
+- `Fail` - Results for rules that failed are returned.
+- `Error` - Results for rules that raised an error are returned.
+- `Processed` - Results for rules that either passed, failed, or raised an error are returned.
+This is the default option.
+- `All` - All results for rules are returned.
+
+This option is ignored by `Assert-PSRule`.
+`Assert-PSRule` will always use `Processed`.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the OutputOutcome parameter
+$option = New-PSRuleOption -OutputOutcome Fail;
+```
+
+```powershell
+# PowerShell: Using the Output.Outcome hashtable key
+$option = New-PSRuleOption -Option @{ 'Output.Outcome' = 'Fail' };
+```
+
+```powershell
+# PowerShell: Using the OutputOutcome parameter to set YAML
+Set-PSRuleOption -OutputOutcome Fail;
+```
+
+```yaml
+# YAML: Using the output/outcome property
+output:
+  outcome: 'Fail'
 ```
 
 ### Output.Path
@@ -1266,6 +1309,7 @@ output:
   - en-US
   encoding: UTF8
   format: Json
+  outcome: Fail
   style: GitHubActions
 
 # Configure rule suppression
@@ -1344,6 +1388,7 @@ output:
   culture: [ ]
   encoding: Default
   format: None
+  outcome: Processed
   style: Client
 
 # Configure rule suppression

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -233,7 +233,7 @@
                 ]
             }
         },
-        "output": {
+        "output-option": {
             "type": "object",
             "title": "Output options",
             "description": "Options that affect how output is generated.",
@@ -281,11 +281,26 @@
                         "None",
                         "Yaml",
                         "Json",
+                        "Markdown",
                         "NUnit3",
                         "Csv",
                         "Wide"
                     ],
                     "default": "None"
+                },
+                "outcome": {
+                    "type": "string",
+                    "title": "Output outcome",
+                    "description": "The outcome of rule results to return. The default is Processed.",
+                    "enum": [
+                        "None",
+                        "Fail",
+                        "Pass",
+                        "Error",
+                        "Processed",
+                        "All"
+                    ],
+                    "default": "Processed"
                 },
                 "path": {
                     "type": "string",
@@ -351,7 +366,7 @@
                 },
                 "output": {
                     "type": "object",
-                    "$ref": "#/definitions/output"
+                    "$ref": "#/definitions/output-option"
                 },
                 "requires": {
                     "type": "object",

--- a/src/PSRule/Configuration/OutputFormat.cs
+++ b/src/PSRule/Configuration/OutputFormat.cs
@@ -22,6 +22,8 @@ namespace PSRule.Configuration
 
         Csv = 4,
 
-        Wide = 5
+        Wide = 5,
+
+        Markdown = 6
     }
 }

--- a/src/PSRule/Configuration/OutputOption.cs
+++ b/src/PSRule/Configuration/OutputOption.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using PSRule.Rules;
 using System;
 using System.ComponentModel;
 
@@ -14,6 +15,7 @@ namespace PSRule.Configuration
         private const ResultFormat DEFAULT_AS = ResultFormat.Detail;
         private const OutputEncoding DEFAULT_ENCODING = OutputEncoding.Default;
         private const OutputFormat DEFAULT_FORMAT = OutputFormat.None;
+        private const RuleOutcome DEFAULT_OUTCOME = RuleOutcome.Processed;
         private const OutputStyle DEFAULT_STYLE = OutputStyle.Client;
 
         internal static readonly OutputOption Default = new OutputOption
@@ -21,7 +23,8 @@ namespace PSRule.Configuration
             As = DEFAULT_AS,
             Encoding = DEFAULT_ENCODING,
             Format = DEFAULT_FORMAT,
-            Style = DEFAULT_STYLE
+            Outcome = DEFAULT_OUTCOME,
+            Style = DEFAULT_STYLE,
         };
 
         public OutputOption()
@@ -43,6 +46,7 @@ namespace PSRule.Configuration
             Culture = option.Culture;
             Encoding = option.Encoding;
             Format = option.Format;
+            Outcome = option.Outcome;
             Path = option.Path;
             Style = option.Style;
         }
@@ -59,6 +63,7 @@ namespace PSRule.Configuration
                 Culture == other.Culture &&
                 Encoding == other.Encoding &&
                 Format == other.Format &&
+                Outcome == other.Outcome &&
                 Path == other.Path &&
                 Style == other.Style;
         }
@@ -72,6 +77,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (Culture != null ? Culture.GetHashCode() : 0);
                 hash = hash * 23 + (Encoding.HasValue ? Encoding.Value.GetHashCode() : 0);
                 hash = hash * 23 + (Format.HasValue ? Format.Value.GetHashCode() : 0);
+                hash = hash * 23 + (Outcome.HasValue ? Outcome.Value.GetHashCode() : 0);
                 hash = hash * 23 + (Path != null ? Path.GetHashCode() : 0);
                 hash = hash * 23 + (Style.HasValue ? Style.Value.GetHashCode() : 0);
                 return hash;
@@ -85,6 +91,7 @@ namespace PSRule.Configuration
             result.Culture = o1.Culture ?? o2.Culture;
             result.Encoding = o1.Encoding ?? o2.Encoding;
             result.Format = o1.Format ?? o2.Format;
+            result.Outcome = o1.Outcome ?? o2.Outcome;
             result.Path = o1.Path ?? o2.Path;
             result.Style = o1.Style ?? o2.Style;
             return result;
@@ -110,6 +117,9 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public OutputFormat? Format { get; set; }
+
+        [DefaultValue(null)]
+        public RuleOutcome? Outcome { get; set; }
 
         /// <summary>
         /// The file path location to save results.

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -4,6 +4,7 @@
 using Newtonsoft.Json;
 using PSRule.Definitions;
 using PSRule.Resources;
+using PSRule.Rules;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -364,6 +365,10 @@ namespace PSRule.Configuration
             if (index.TryPopValue("output.format", out value))
             {
                 option.Output.Format = (OutputFormat)Enum.Parse(typeof(OutputFormat), (string)value);
+            }
+            if (index.TryPopValue("output.outcome", out value))
+            {
+                option.Output.Outcome = (RuleOutcome)Enum.Parse(typeof(RuleOutcome), (string)value);
             }
             if (index.TryPopValue("output.path", out value))
             {

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -54,7 +54,7 @@ function Invoke-PSRule {
         [String]$OutputPath,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv', 'Wide')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'NUnit3', 'Csv', 'Wide')]
         [Alias('o')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = [PSRule.Configuration.OutputFormat]::None,
 
@@ -141,6 +141,9 @@ function Invoke-PSRule {
         if ($PSBoundParameters.ContainsKey('OutputFormat')) {
             $Option.Output.Format = $OutputFormat;
         }
+        if ($PSBoundParameters.ContainsKey('Outcome')) {
+            $Option.Output.Outcome = $Outcome;
+        }
         if ($PSBoundParameters.ContainsKey('OutputPath')) {
             $Option.Output.Path = $OutputPath;
         }
@@ -151,15 +154,12 @@ function Invoke-PSRule {
         $builder = [PSRule.Pipeline.PipelineBuilder]::Invoke($sourceFiles, $Option, $PSCmdlet, $ExecutionContext);
         $builder.Name($Name);
         $builder.Tag($Tag);
-        $builder.Limit($Outcome);
         $builder.UseBaseline($Baseline);
 
         if ($PSBoundParameters.ContainsKey('InputPath')) {
             $builder.InputPath($InputPath);
         }
 
-        # $builder.UseCommandRuntime($PSCmdlet);
-        # $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
             if ($Null -ne $pipeline) {
@@ -290,6 +290,9 @@ function Test-PSRuleTarget {
         if ($PSBoundParameters.ContainsKey('TargetType')) {
             $Option.Input.TargetType = $TargetType;
         }
+        if ($PSBoundParameters.ContainsKey('Outcome')) {
+            $Option.Output.Outcome = $Outcome;
+        }
         if ($PSBoundParameters.ContainsKey('Culture')) {
             $Option.Output.Culture = $Culture;
         }
@@ -297,14 +300,11 @@ function Test-PSRuleTarget {
         $builder = [PSRule.Pipeline.PipelineBuilder]::Test($sourceFiles, $Option, $PSCmdlet, $ExecutionContext);
         $builder.Name($Name);
         $builder.Tag($Tag);
-        $builder.Limit($Outcome);
 
         if ($PSBoundParameters.ContainsKey('InputPath')) {
             $builder.InputPath($InputPath);
         }
 
-        # $builder.UseCommandRuntime($PSCmdlet);
-        # $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
             if ($Null -ne $pipeline) {
@@ -485,7 +485,7 @@ function Assert-PSRule {
         [String]$OutputPath,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv')]
+        [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'NUnit3', 'Csv')]
         [Alias('o')]
         [PSRule.Configuration.OutputFormat]$OutputFormat,
 
@@ -575,8 +575,6 @@ function Assert-PSRule {
             $builder.InputPath($InputPath);
         }
 
-        # $builder.UseCommandRuntime($PSCmdlet);
-        # $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
             if ($Null -ne $pipeline) {
@@ -1086,6 +1084,12 @@ function New-PSRuleOption {
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = 'None',
 
+        # Sets the Output.Outcome option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Processed', 'All')]
+        [Alias('Outcome')]
+        [PSRule.Rules.RuleOutcome]$OutputOutcome = 'Processed',
+
         # Sets the Output.Path option
         [Parameter(Mandatory = $False)]
         [String]$OutputPath = '',
@@ -1281,6 +1285,12 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = 'None',
+
+        # Sets the Output.Outcome option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Processed', 'All')]
+        [Alias('Outcome')]
+        [PSRule.Rules.RuleOutcome]$OutputOutcome = 'Processed',
 
         # Sets the Output.Path option
         [Parameter(Mandatory = $False)]
@@ -1870,6 +1880,12 @@ function SetOptions {
         [ValidateSet('None', 'Yaml', 'Json', 'NUnit3')]
         [PSRule.Configuration.OutputFormat]$OutputFormat = 'None',
 
+        # Sets the Output.Outcome option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Processed', 'All')]
+        [Alias('Outcome')]
+        [PSRule.Rules.RuleOutcome]$OutputOutcome = 'Processed',
+
         # Sets the Output.Path option
         [Parameter(Mandatory = $False)]
         [String]$OutputPath = '',
@@ -1980,6 +1996,11 @@ function SetOptions {
         # Sets option Output.Format
         if ($PSBoundParameters.ContainsKey('OutputFormat')) {
             $Option.Output.Format = $OutputFormat;
+        }
+
+        # Sets option Output.Outcome
+        if ($PSBoundParameters.ContainsKey('OutputOutcome')) {
+            $Option.Output.Outcome = $OutputOutcome;
         }
 
         # Sets option Output.Path

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -584,6 +584,14 @@ namespace PSRule.Pipeline
             }
         }
 
+        public override IPipelineBuilder Configure(PSRuleOption option)
+        {
+            base.Configure(option);
+            Option.Output.As = ResultFormat.Detail;
+            Option.Output.Outcome = RuleOutcome.Processed;
+            return this;
+        }
+
         protected override PipelineWriter PrepareWriter()
         {
             return GetWriter();

--- a/src/PSRule/Pipeline/Output/MarkdownOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/MarkdownOutputWriter.cs
@@ -1,0 +1,260 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Configuration;
+using PSRule.Resources;
+using PSRule.Rules;
+using System.Linq;
+using System.Text;
+
+namespace PSRule.Pipeline.Output
+{
+    internal sealed class MarkdownOutputWriter : SerializationOutputWriter<InvokeResult>
+    {
+        private const char Hash = '#';
+        private const char Space = ' ';
+
+        private readonly StringBuilder _Builder;
+
+        private bool _LineBreak = true;
+
+        internal MarkdownOutputWriter(PipelineWriter inner, PSRuleOption option)
+            : base(inner, option)
+        {
+            _Builder = new StringBuilder();
+        }
+
+        public override void WriteObject(object sendToPipeline, bool enumerateCollection)
+        {
+            if (!(sendToPipeline is InvokeResult result))
+                return;
+
+            Add(result);
+        }
+
+        protected override string Serialize(InvokeResult[] o)
+        {
+            if (Option.Output.As == ResultFormat.Detail)
+                AsDetail(o);
+            else
+                AsSummary(o);
+
+            return _Builder.ToString();
+        }
+
+        private void AsDetail(InvokeResult[] o)
+        {
+            Header();
+            for (var i = 0; i < o.Length; i++)
+                if (o[i].Total > 0)
+                    DetailResult(o[i]);
+        }
+
+        private void AsSummary(InvokeResult[] o)
+        {
+            Header();
+            var ruleGroup = o.SelectMany(result => result.AsRecord()).GroupBy(record => record.RuleId).ToArray();
+            for (var i = 0; i < ruleGroup.Length; i++)
+            {
+                RuleSummary(ruleGroup[i].Key, ruleGroup[i].ToArray());
+            }
+        }
+
+        private void DetailResult(InvokeResult invokeResult)
+        {
+            var records = invokeResult.AsRecord();
+
+            Section(2, records[0].TargetName, " : ", records[0].TargetType);
+            LineBreak();
+
+            for (var i = 0; i < records.Length; i++)
+            {
+                CheckedItem(records[i].IsSuccess(), records[i].RuleName);
+                if (!records[i].IsSuccess())
+                {
+                    LineBreak();
+                    AppendLine(records[i].Recommendation);
+                    LineBreak();
+                }
+            }
+        }
+
+        private void CheckedItem(bool ticked, string text)
+        {
+            if (ticked)
+                AppendLine("- [X] ", text);
+            else
+                AppendLine("- [ ] ", text);
+        }
+
+        private void RuleSummary(string name, Rules.RuleRecord[] records)
+        {
+            if (records.Length == 0)
+                return;
+
+            Section(2, records[0].Info.DisplayName);
+            LineBreak();
+            AppendLine("> ", records[0].RuleName);
+            LineBreak();
+            AppendLine(records[0].Info.Synopsis);
+            LineBreak();
+            AppendLine(records[0].Info.Description);
+            LineBreak();
+
+            // Info block
+            AppendLine("```yaml");
+            foreach (var key in records[0].Info.Annotations.Keys)
+            {
+                if (key.ToString() != "online version")
+                {
+                    AppendLine(key.ToString(), ": ", records[0].Info.Annotations[key].ToString());
+                }
+            }
+            AppendLine("```");
+            LineBreak();
+
+            // Add recommendation
+            AppendLine("**", ReportStrings.Markdown_Recommendation, "**:");
+            LineBreak();
+            AppendLine(records[0].Recommendation);
+            LineBreak();
+
+            // Add links
+            if (records[0]?.Info?.Links?.Length > 0)
+            {
+                AppendLine("**", ReportStrings.Markdown_Links, "**:");
+                LineBreak();
+                for (var i = 0; i < records[0].Info.Links.Length; i++)
+                {
+                    Link(records[0].Info.Links[i]);
+                }
+            }
+            LineBreak();
+
+            // Get padding
+            var padding = new int[3] { 0, 0, 0 };
+            GetColumnPadding(padding, ReportStrings.Markdown_TargetName, ReportStrings.Markdown_TargetType, ReportStrings.Markdown_Outcome);
+            for (var i = 0; i < records.Length; i++)
+                GetColumnPadding(padding, records[i].TargetName, records[i].TargetType, records[i].Outcome.ToString());
+
+            // Build results table
+            LineBreak();
+            AppendLine("**", ReportStrings.Markdown_Results, "**:");
+            LineBreak();
+            AppendLine(ReportStrings.Markdown_ResultText);
+            LineBreak();
+            AppendColumn(ReportStrings.Markdown_TargetName, Space, padding[0]);
+            Append(" | ");
+            AppendColumn(ReportStrings.Markdown_TargetType, Space, padding[1]);
+            Append(" | ");
+            AppendColumn(ReportStrings.Markdown_Outcome, Space, padding[2]);
+            LineEnd();
+            AppendColumn('-', ReportStrings.Markdown_TargetName.Length, Space, padding[0]);
+            Append(" | ");
+            AppendColumn('-', ReportStrings.Markdown_TargetType.Length, Space, padding[1]);
+            Append(" | ");
+            Append('-', ReportStrings.Markdown_Outcome.Length);
+            LineEnd();
+            for (var i = 0; i < records.Length; i++)
+            {
+                AppendColumn(records[i].TargetName, Space, padding[0]);
+                Append(" | ");
+                AppendColumn(records[i].TargetType, Space, padding[1]);
+                Append(" | ");
+                Append(records[i].Outcome.ToString());
+                LineEnd();
+            }
+        }
+
+        private void Link(RuleHelpInfo.Link link)
+        {
+            AppendLine("- [", link.Name, "](", link.Uri, ")");
+        }
+
+        private static void GetColumnPadding(int[] padding, string targetName, string targetType, string outcome)
+        {
+            if (targetName.Length > padding[0])
+                padding[0] = targetName.Length;
+
+            if (targetType.Length > padding[1])
+                padding[1] = targetType.Length;
+
+            if (outcome.Length > padding[2])
+                padding[2] = outcome.Length;
+        }
+
+        private void Header()
+        {
+            Section(1, "PSRule");
+        }
+
+        private void Section(int depth, params string[] name)
+        {
+            LineBreak();
+            Append(Hash, depth);
+            Append(Space);
+            AppendLine(name);
+        }
+
+        private void Append(string text)
+        {
+            _LineBreak = false;
+            _Builder.Append(text);
+        }
+
+        private void Append(char c, int count = 1)
+        {
+            _LineBreak = false;
+            _Builder.Append(c, count);
+        }
+
+        private void AppendColumn(string s, char padding, int width)
+        {
+            Append(s);
+            if (s.Length < width)
+                _Builder.Append(padding, width - s.Length);
+        }
+
+        private void AppendColumn(char c, int count, char padding, int width)
+        {
+            Append(c, count);
+            if (count < width)
+                _Builder.Append(padding, width - count);
+        }
+
+        private void AppendLine(params string[] text)
+        {
+            if (text == null || text.Length == 0)
+                return;
+
+            var hasContent = false;
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (!string.IsNullOrEmpty(text[i]))
+                {
+                    Append(text[i]);
+                    hasContent = true;
+                }
+            }
+            if (!hasContent)
+                return;
+
+            _LineBreak = false;
+            LineEnd();
+        }
+
+        private void LineEnd()
+        {
+            _Builder.AppendLine();
+        }
+
+        private void LineBreak()
+        {
+            if (_LineBreak)
+                return;
+
+            _Builder.AppendLine();
+            _LineBreak = true;
+        }
+    }
+}

--- a/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
+++ b/src/PSRule/Pipeline/Output/PSPipelineWriter.cs
@@ -150,7 +150,7 @@ namespace PSRule.Pipeline.Output
 
         public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
-            if (OnWriteObject == null)
+            if (OnWriteObject == null || (sendToPipeline is InvokeResult && Option.Output.As == ResultFormat.Summary))
                 return;
 
             if (sendToPipeline is InvokeResult result)

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -159,6 +159,7 @@ namespace PSRule.Pipeline
             Option.Input = new InputOption(option.Input);
             Option.Input.Format = Option.Input.Format ?? InputOption.Default.Format;
             Option.Output = new OutputOption(option.Output);
+            Option.Output.Outcome = Option.Output.Outcome ?? OutputOption.Default.Outcome;
             return this;
         }
 
@@ -273,6 +274,9 @@ namespace PSRule.Pipeline
 
                 case OutputFormat.Yaml:
                     return new YamlOutputWriter(output, Option);
+
+                case OutputFormat.Markdown:
+                    return new MarkdownOutputWriter(output, Option);
 
                 case OutputFormat.Wide:
                     return new WideOutputWriter(output, Option);

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -5,7 +5,6 @@ using PSRule.Configuration;
 using PSRule.Rules;
 using System.Collections.Generic;
 using System.Management.Automation;
-using System.Threading;
 
 namespace PSRule.Pipeline
 {
@@ -171,6 +170,9 @@ namespace PSRule.Pipeline
 
         public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
+            if (sendToPipeline is InvokeResult && Option.Output.As == ResultFormat.Summary)
+                return;
+
             if (sendToPipeline is InvokeResult result)
             {
                 Add(result.AsRecord());

--- a/src/PSRule/Pipeline/TestPipeline.cs
+++ b/src/PSRule/Pipeline/TestPipeline.cs
@@ -38,7 +38,7 @@ namespace PSRule.Pipeline
 
         protected override PipelineWriter PrepareWriter()
         {
-            return new BooleanWriter(GetOutput(), Outcome);
+            return new BooleanWriter(GetOutput(), Option.Output.Outcome.Value);
         }
     }
 }

--- a/src/PSRule/Resources/ReportStrings.Designer.cs
+++ b/src/PSRule/Resources/ReportStrings.Designer.cs
@@ -61,6 +61,69 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Related resources.
+        /// </summary>
+        internal static string Markdown_Links {
+            get {
+                return ResourceManager.GetString("Markdown_Links", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Outcome.
+        /// </summary>
+        internal static string Markdown_Outcome {
+            get {
+                return ResourceManager.GetString("Markdown_Outcome", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recommendation.
+        /// </summary>
+        internal static string Markdown_Recommendation {
+            get {
+                return ResourceManager.GetString("Markdown_Recommendation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Result summary.
+        /// </summary>
+        internal static string Markdown_Results {
+            get {
+                return ResourceManager.GetString("Markdown_Results", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following results were reported..
+        /// </summary>
+        internal static string Markdown_ResultText {
+            get {
+                return ResourceManager.GetString("Markdown_ResultText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Name.
+        /// </summary>
+        internal static string Markdown_TargetName {
+            get {
+                return ResourceManager.GetString("Markdown_TargetName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type.
+        /// </summary>
+        internal static string Markdown_TargetType {
+            get {
+                return ResourceManager.GetString("Markdown_TargetType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to See details [online]({0})..
         /// </summary>
         internal static string NUnit_DetailsLink {

--- a/src/PSRule/Resources/ReportStrings.resx
+++ b/src/PSRule/Resources/ReportStrings.resx
@@ -117,6 +117,27 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Markdown_Links" xml:space="preserve">
+    <value>Related resources</value>
+  </data>
+  <data name="Markdown_Outcome" xml:space="preserve">
+    <value>Outcome</value>
+  </data>
+  <data name="Markdown_Recommendation" xml:space="preserve">
+    <value>Recommendation</value>
+  </data>
+  <data name="Markdown_Results" xml:space="preserve">
+    <value>Result summary</value>
+  </data>
+  <data name="Markdown_ResultText" xml:space="preserve">
+    <value>The following results were reported.</value>
+  </data>
+  <data name="Markdown_TargetName" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Markdown_TargetType" xml:space="preserve">
+    <value>Type</value>
+  </data>
   <data name="NUnit_DetailsLink" xml:space="preserve">
     <value>See details [online]({0}).</value>
   </data>

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -690,6 +690,28 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Output.Outcome' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Output.Outcome | Should -Be 'Processed';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Output.Outcome' = 'Fail' };
+            $option.Output.Outcome | Should -Be 'Fail';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Output.Outcome | Should -Be 'Pass';
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -OutputOutcome 'Fail' -Path $emptyOptionsFilePath;
+            $option.Output.Outcome | Should -Be 'Fail';
+        }
+    }
+
     Context 'Read Output.Path' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -972,6 +994,13 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -OutputFormat 'Yaml' @optionParams;
             $option.Output.Format | Should -Be 'Yaml';
+        }
+    }
+
+    Context 'Read Output.Outcome' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -OutputOutcome Fail @optionParams;
+            $option.Output.Outcome | Should -Be 'Fail';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -58,6 +58,7 @@ output:
   culture: [ 'en-CC' ]
   encoding: UTF7
   format: Json
+  outcome: Pass
   path: 'out/OutputPath.txt'
   style: GitHubActions
 


### PR DESCRIPTION
## PR Summary

- Engine features:
  - Added support for formatting results as markdown. #474
    - Use `-OutputFormat Markdown` or configure `Output.Format` to output markdown.
    - To format as either detail or summary, use the `-As` parameter or configure `Output.As`.
- General improvements:
  - Added outcome `Output.Outcome` as a configurable option. #552

Fixes #474 
Fixes #552 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
