### PR TITLE
Added character case assertion helpers #555

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ## Unreleased
 
+- Engine features:
+  - Added character case assertion helpers `IsLower`, and `IsUpper`. [#555](https://github.com/microsoft/PSRule/issues/555)
+    - `IsLower` checks that all letters in a field value are lowercase.
+    - `IsUpper` checks that all letters in a field value are uppercase.
+
 ## v0.21.0-B2009006 (pre-release)
 
 What's changed since v0.20.0:

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ The following conceptual topics exist in the `PSRule` module:
   - [HasFieldValue](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasfieldvalue)
   - [HasJsonSchema](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#hasjsonschema)
   - [In](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#in)
+  - [IsLower](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#islower)
+  - [IsUpper](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#isupper)
   - [JsonSchema](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#jsonschema)
   - [Less](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#less)
   - [Match](docs/concepts/PSRule/en-US/about_PSRule_Assert.md#match)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -26,6 +26,8 @@ The following built-in assertion methods are provided:
 - [HasFieldValue](#hasfieldvalue) - The object must have the specified field and that field is not empty.
 - [HasJsonSchema](#hasjsonschema) - The object must reference a JSON schema with the `$schema` field.
 - [In](#in) - The field value must be included in the set.
+- [IsLower](#islower) - The field value must include only lowercase characters.
+- [IsUpper](#isupper) - The field value must include only uppercase characters.
 - [JsonSchema](#jsonschema) - The object must validate successfully against a JSON schema.
 - [Less](#less) - The field value must be less.
 - [LessOrEqual](#lessorequal) - The field value must be less or equal to.
@@ -366,7 +368,9 @@ The following parameters are accepted:
 
 - `inputObject` - The object being checked for the specified field.
 - `field` - The name of the field to check. This is a case insensitive compare.
-- `expectedValue` (optional) - Check that the field value is set to a specific value. To check `$Null` use `NullOrEmpty` instead. If `expectedValue` is `$Null` the field value will not be compared.
+- `expectedValue` (optional) - Check that the field value is set to a specific value.
+To check `$Null` use `NullOrEmpty` instead.
+If `expectedValue` is `$Null` the field value will not be compared.
 
 Reasons include:
 
@@ -393,7 +397,8 @@ If the `$schema` property is defined, it must match one of the supplied schemas.
 The following parameters are accepted:
 
 - `inputObject` - The object being compared.
-- `uri` - Optional. When specified, the object being compared must have a `$schema` property set to one of the specified schemas.
+- `uri` - Optional.
+When specified, the object being compared must have a `$schema` property set to one of the specified schemas.
 
 Reasons include:
 
@@ -462,6 +467,72 @@ Examples:
 Rule 'In' {
     $Assert.In($TargetObject, 'Sku.tier', @('PremiumV2', 'Premium', 'Standard'))
     $Assert.In($TargetObject, 'Sku.tier', @('PremiumV2', 'Premium', 'Standard'), $True)
+}
+```
+
+### IsLower
+
+The `IsLower` assertion method checks the field value uses only lowercase characters.
+Non-letter characters are ignored by default and will pass.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being checked for the specified field.
+- `field` - The name of the field to check. This is a case insensitive compare.
+- `requireLetters` (optional) - Require each character to be lowercase letters only.
+Non-letter characters are ignored by default.
+
+Reasons include:
+
+- _The parameter 'inputObject' is null._
+- _The parameter 'field' is null or empty._
+- _The field '{0}' does not exist._
+- _The field value '{0}' is not a string._
+- _The value '{0}' does not contain only lowercase characters._
+- _The value '{0}' does not contain only letters._
+
+Examples:
+
+```powershell
+Rule 'IsLower' {
+    # Require Name to be lowercase
+    $Assert.IsLower($TargetObject, 'Name')
+
+    # Require Name to only contain lowercase letters
+    $Assert.IsLower($TargetObject, 'Name', $True)
+}
+```
+
+### IsUpper
+
+The `IsUpper` assertion method checks the field value uses only uppercase characters.
+Non-letter characters are ignored by default and will pass.
+
+The following parameters are accepted:
+
+- `inputObject` - The object being checked for the specified field.
+- `field` - The name of the field to check. This is a case insensitive compare.
+- `requireLetters` (optional) - Require each character to be uppercase letters only.
+Non-letter characters are ignored by default.
+
+Reasons include:
+
+- _The parameter 'inputObject' is null._
+- _The parameter 'field' is null or empty._
+- _The field '{0}' does not exist._
+- _The field value '{0}' is not a string._
+- _The value '{0}' does not contain only uppercase characters._
+- _The value '{0}' does not contain only letters._
+
+Examples:
+
+```powershell
+Rule 'IsUpper' {
+    # Require Name to be uppercase
+    $Assert.IsUpper($TargetObject, 'Name')
+
+    # Require Name to only contain uppercase letters
+    $Assert.IsUpper($TargetObject, 'Name', $True)
 }
 ```
 
@@ -542,7 +613,8 @@ The following parameters are accepted:
 - `inputObject` - The object being checked for the specified field.
 - `field` - The name of the field to check. This is a case insensitive compare.
 - `pattern` - A regular expression pattern to match.
-- `caseSensitive` (optional) - Use a case sensitive compare of the field value. Case is ignored by default.
+- `caseSensitive` (optional) - Use a case sensitive compare of the field value.
+Case is ignored by default.
 
 Reasons include:
 
@@ -574,7 +646,8 @@ The following parameters are accepted:
 - `inputObject` - The object being checked for the specified field.
 - `field` - The name of the field to check. This is a case insensitive compare.
 - `values` - An array of one or more values that the field value is compared against.
-- `caseSensitive` (optional) - Use a case sensitive compare of the field value. Case is ignored by default.
+- `caseSensitive` (optional) - Use a case sensitive compare of the field value.
+Case is ignored by default.
 
 Reasons include:
 
@@ -602,7 +675,8 @@ The following parameters are accepted:
 - `inputObject` - The object being checked for the specified field.
 - `field` - The name of the field to check. This is a case insensitive compare.
 - `pattern` - A regular expression pattern to match.
-- `caseSensitive` (optional) - Use a case sensitive compare of the field value. Case is ignored by default.
+- `caseSensitive` (optional) - Use a case sensitive compare of the field value.
+Case is ignored by default.
 
 Reasons include:
 
@@ -634,7 +708,8 @@ A field value is null or empty if any of the following are true:
 The following parameters are accepted:
 
 - `inputObject` - The object being checked for the specified field.
-- `field` - The name of the field to check. This is a case insensitive compare.
+- `field` - The name of the field to check.
+This is a case insensitive compare.
 
 Reasons include:
 
@@ -661,7 +736,8 @@ The following parameters are accepted:
 - `inputObject` - The object being checked for the specified field.
 - `field` - The name of the field to check. This is a case insensitive compare.
 - `prefix` - One or more prefixes to compare the field value with. Only one prefix must match.
-- `caseSensitive` (optional) - Use a case sensitive compare of the field value. Case is ignored by default.
+- `caseSensitive` (optional) - Use a case sensitive compare of the field value.
+Case is ignored by default.
 
 Reasons include:
 

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -187,6 +187,33 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only letters..
+        /// </summary>
+        internal static string IsLetter {
+            get {
+                return ResourceManager.GetString("IsLetter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only lowercase characters..
+        /// </summary>
+        internal static string IsLower {
+            get {
+                return ResourceManager.GetString("IsLower", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only uppercase characters..
+        /// </summary>
+        internal static string IsUpper {
+            get {
+                return ResourceManager.GetString("IsUpper", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed schema validation on {0}. {1}.
         /// </summary>
         internal static string JsonSchemaInvalid {

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -162,6 +162,15 @@
     <value>The field value '{0}' was not included in the set.</value>
     <comment>The field value '{0}' was not included in the set.</comment>
   </data>
+  <data name="IsLetter" xml:space="preserve">
+    <value>The value '{0}' does not contain only letters.</value>
+  </data>
+  <data name="IsLower" xml:space="preserve">
+    <value>The value '{0}' does not contain only lowercase characters.</value>
+  </data>
+  <data name="IsUpper" xml:space="preserve">
+    <value>The value '{0}' does not contain only uppercase characters.</value>
+  </data>
   <data name="JsonSchemaInvalid" xml:space="preserve">
     <value>Failed schema validation on {0}. {1}</value>
   </data>

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using Manatee.Json;
@@ -214,10 +214,11 @@ namespace PSRule.Runtime
                 return result;
 
             // Assert
-            for (var i = 0; i < prefix.Length; i++)
+            for (var i = 0; prefix != null && i < prefix.Length; i++)
+            {
                 if (value.StartsWith(prefix[i], caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
                     return Pass();
-            
+            }
             return Fail(ReasonStrings.StartsWith, field, FormatArray(prefix));
         }
 
@@ -234,10 +235,11 @@ namespace PSRule.Runtime
                 return result;
 
             // Assert
-            for (var i = 0; i < suffix.Length; i++)
+            for (var i = 0; suffix != null && i < suffix.Length; i++)
+            {
                 if (value.EndsWith(suffix[i], caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
                     return Pass();
-
+            }
             return Fail(ReasonStrings.EndsWith, field, FormatArray(suffix));
         }
 
@@ -254,11 +256,58 @@ namespace PSRule.Runtime
                 return result;
 
             // Assert
-            for (var i = 0; i < text.Length; i++)
+            for (var i = 0; text != null && i < text.Length; i++)
+            {
                 if (value.IndexOf(text[i], caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) >= 0)
                     return Pass();
-
+            }
             return Fail(ReasonStrings.Contains, field, FormatArray(text));
+        }
+
+        /// <summary>
+        /// The object field value should only contain lowercase characters.
+        /// </summary>
+        public AssertResult IsLower(PSObject inputObject, string field, bool requireLetters = false)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, false, out object fieldValue, out result) ||
+                GuardString(fieldValue, out string value, out result))
+                return result;
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (!char.IsLetter(value, i) && requireLetters)
+                    return Fail(ReasonStrings.IsLetter, value);
+
+                if (char.IsLetter(value, i) && !char.IsLower(value, i))
+                    return Fail(ReasonStrings.IsLower, value);
+            }
+            return Pass();
+        }
+
+        /// <summary>
+        /// The object field value should only contain uppercase characters.
+        /// </summary>
+        public AssertResult IsUpper(PSObject inputObject, string field, bool requireLetters = false)
+        {
+            // Guard parameters
+            if (GuardNullParam(inputObject, nameof(inputObject), out AssertResult result) ||
+                GuardNullOrEmptyParam(field, nameof(field), out result) ||
+                GuardField(inputObject, field, false, out object fieldValue, out result) ||
+                GuardString(fieldValue, out string value, out result))
+                return result;
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (!char.IsLetter(value, i) && requireLetters)
+                    return Fail(ReasonStrings.IsLetter, value);
+
+                if (char.IsLetter(value, i) && !char.IsUpper(value, i))
+                    return Fail(ReasonStrings.IsUpper, value);
+            }
+            return Pass();
         }
 
         /// <summary>
@@ -648,13 +697,26 @@ namespace PSRule.Runtime
         /// <summary>
         /// Fails of the value is null or empty.
         /// </summary>
-        /// <returns>Returns true if the field does not exist.</returns>
+        /// <returns>Returns true if the value is null or an empty string.</returns>
         /// <remarks>
         /// Reason: The parameter '{0}' is null or empty.
         /// </remarks>
         private bool GuardNullOrEmptyParam(string value, string parameterName, out AssertResult result)
         {
             result = string.IsNullOrEmpty(value) ? Fail(ReasonStrings.NullOrEmptyParameter, parameterName) : null;
+            return result != null;
+        }
+
+        /// <summary>
+        /// Fails of the value is null or empty.
+        /// </summary>
+        /// <returns>Returns true if the value is null or is empty.</returns>
+        /// <remarks>
+        /// Reason: The parameter '{0}' is null or empty.
+        /// </remarks>
+        private bool GuardNullOrEmptyParam(Array value, string parameterName, out AssertResult result)
+        {
+            result = value == null || value.Length == 0 ? Fail(ReasonStrings.NullOrEmptyParameter, parameterName) : null;
             return result != null;
         }
 

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -125,6 +125,44 @@ namespace PSRule
         }
 
         [Fact]
+        public void IsLower()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject(
+                (name: "name1", value: "abc"),
+                (name: "name2", value: "aBc"),
+                (name: "name3", value: "123"),
+                (name: "name4", value: 123)
+            );
+
+            Assert.True(assert.IsLower(value, "name1").Result);
+            Assert.False(assert.IsLower(value, "name2").Result);
+            Assert.True(assert.IsLower(value, "name3").Result);
+            Assert.False(assert.IsLower(value, "name3", requireLetters: true).Result);
+            Assert.False(assert.IsLower(value, "name4").Result);
+        }
+
+        [Fact]
+        public void IsUpper()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject(
+                (name: "name1", value: "ABC"),
+                (name: "name2", value: "AbC"),
+                (name: "name3", value: "123"),
+                (name: "name4", value: 123)
+            );
+
+            Assert.True(assert.IsUpper(value, "name1").Result);
+            Assert.False(assert.IsUpper(value, "name2").Result);
+            Assert.True(assert.IsUpper(value, "name3").Result);
+            Assert.False(assert.IsUpper(value, "name3", requireLetters: true).Result);
+            Assert.False(assert.IsUpper(value, "name4").Result);
+        }
+
+        [Fact]
         public void Version()
         {
             SetContext();

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -132,6 +132,18 @@ Rule 'Assert.In' {
     $Assert.In($TargetObject, 'InArrayPSObject', @('item2'), $True)
 }
 
+# Synopsis: Test for $Assert.IsLower
+Rule 'Assert.IsLower' {
+    $Assert.IsLower($TargetObject, 'Lower')
+    $Assert.IsLower($TargetObject, 'LetterLower', $True)
+}
+
+# Synopsis: Test for $Assert.IsUpper
+Rule 'Assert.IsUpper' {
+    $Assert.IsUpper($TargetObject, 'Upper')
+    $Assert.IsUpper($TargetObject, 'LetterUpper', $True)
+}
+
 # Synopsis: Test for $Assert.Less
 Rule 'Assert.Less' {
     $Assert.Less($TargetObject, 'CompareNumeric', 2)

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -51,6 +51,10 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                 )
                 Path = $PSCommandPath
                 ParentPath = $here
+                Lower = 'test123'
+                Upper = 'TEST123'
+                LetterLower = 'test'
+                LetterUpper = 'TEST'
             }
             [PSCustomObject]@{
                 '$schema' = "http://json-schema.org/draft-07/schema`#"
@@ -78,6 +82,10 @@ Describe 'PSRule assertions' -Tag 'Assert' {
                     'item3'
                 )
                 ParentPath = (Join-Path -Path $here -ChildPath 'notapath')
+                Lower = 'Test123'
+                Upper = 'Test123'
+                LetterLower = 'test123'
+                LetterUpper = 'TEST123'
             }
         )
 
@@ -326,6 +334,40 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             # Positive case
             $result[1].IsSuccess() | Should -Be $True;
             $result[1].TargetName | Should -Be 'TestObject2';
+        }
+
+        It 'IsLower' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.IsLower');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 2;
+            $result[1].Reason[0] | Should -BeLike "The value '*' does not contain only lowercase characters.";
+            $result[1].Reason[1] | Should -BeLike "The value '*' does not contain only letters.";
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
+        }
+
+        It 'IsUpper' {
+            $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'Assert.IsUpper');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+
+            # Negative case
+            $result[1].IsSuccess() | Should -Be $False;
+            $result[1].TargetName | Should -Be 'TestObject2';
+            $result[1].Reason.Length | Should -Be 2;
+            $result[1].Reason[0] | Should -BeLike "The value '*' does not contain only uppercase characters.";
+            $result[1].Reason[1] | Should -BeLike "The value '*' does not contain only letters.";
+
+            # Positive case
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[0].TargetName | Should -Be 'TestObject1';
         }
 
         It 'Less' {


### PR DESCRIPTION
## PR Summary

- Engine features:
  - Added character case assertion helpers `IsLower`, and `IsUpper`. [#555](https://github.com/microsoft/PSRule/issues/555)
    - `IsLower` checks that all letters in a field value are lowercase.
    - `IsUpper` checks that all letters in a field value are uppercase.

Fixes #555 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
