### PR TITLE
Fixed NUnit report reasons escaping markdown #471

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Added character case assertion helpers `IsLower`, and `IsUpper`. [#555](https://github.com/microsoft/PSRule/issues/555)
     - `IsLower` checks that all letters in a field value are lowercase.
     - `IsUpper` checks that all letters in a field value are uppercase.
+- Bug fixes:
+  - Fixed NUnit report reasons should be escaped in markdown. [#471](https://github.com/microsoft/PSRule/issues/471)
 
 ## v0.21.0-B2009006 (pre-release)
 

--- a/src/PSRule/Common/StringBuilderExtensions.cs
+++ b/src/PSRule/Common/StringBuilderExtensions.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+
+namespace PSRule.Common
+{
+    internal static class StringBuilderExtensions
+    {
+        private const char Backtick = '`';
+        private const char BracketOpen = '[';
+        private const char BracketClose = ']';
+        private const char ParenthesesOpen = '(';
+        private const char ParenthesesClose = ')';
+        private const char AngleOpen = '<';
+        private const char AngleClose = '>';
+        private const char Backslash = '\\';
+
+        public static void AppendMarkdownText(this StringBuilder builder, string value)
+        {
+            for (var i = 0; i < value.Length; i++)
+            {
+                if (IsEscapableCharacter(value[i]))
+                    builder.Append(Backslash);
+
+                builder.Append(value[i]);
+            }
+        }
+
+        private static bool IsEscapableCharacter(char c)
+        {
+            return c == Backslash || c == BracketOpen || c == ParenthesesOpen || c == AngleOpen || c == AngleClose || c == Backtick || c == BracketClose || c == ParenthesesClose;
+        }
+    }
+}

--- a/src/PSRule/Parser/MarkdownConvert.cs
+++ b/src/PSRule/Parser/MarkdownConvert.cs
@@ -13,13 +13,12 @@ namespace PSRule.Parser
         public static PSObject[] DeserializeObject(string markdown)
         {
             var result = YamlHeader(markdown);
-            return result == null ? new PSObject[] { } : new PSObject[] { result };
+            return result == null ? System.Array.Empty<PSObject>() : new PSObject[] { result };
         }
 
         private static PSObject YamlHeader(string markdown)
         {
             var stream = new MarkdownStream(markdown);
-
             if (stream.EOF || stream.Line > 1 || stream.Current != Dash)
                 return null;
 

--- a/src/PSRule/Parser/MarkdownLexer.cs
+++ b/src/PSRule/Parser/MarkdownLexer.cs
@@ -8,30 +8,27 @@ namespace PSRule.Parser
 {
     internal abstract class MarkdownLexer
     {
-        protected bool IsHeading(MarkdownToken token, int level)
+        protected static bool IsHeading(MarkdownToken token, int level)
         {
             return token.Type == MarkdownTokenType.Header &&
                 token.Depth == level;
         }
 
-        protected bool IsHeading(MarkdownToken token, int level, string text)
+        protected static bool IsHeading(MarkdownToken token, int level, string text)
         {
             return token.Type == MarkdownTokenType.Header &&
                 token.Depth == level &&
                 string.Equals(text, token.Text, StringComparison.OrdinalIgnoreCase);
         }
 
-        protected Dictionary<string, string> YamlHeader(TokenStream stream)
+        protected static Dictionary<string, string> YamlHeader(TokenStream stream)
         {
             var metadata = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             while (!stream.EOF && stream.IsTokenType(MarkdownTokenType.YamlKeyValue))
             {
                 metadata[stream.Current.Meta] = stream.Current.Text;
-
                 stream.Next();
             }
-
             return metadata.Count == 0 ? null : metadata;
         }
     }

--- a/src/PSRule/Parser/MarkdownReader.cs
+++ b/src/PSRule/Parser/MarkdownReader.cs
@@ -66,7 +66,6 @@ namespace PSRule.Parser
             _Stream = new MarkdownStream(markdown);
 
             YamlHeader();
-
             if (_YamlHeaderOnly)
                 return _Output;
 
@@ -81,7 +80,6 @@ namespace PSRule.Parser
                 if (!processed)
                     Text();
             }
-
             return _Output;
         }
 

--- a/src/PSRule/Parser/MarkdownStream.cs
+++ b/src/PSRule/Parser/MarkdownStream.cs
@@ -57,9 +57,9 @@ namespace PSRule.Parser
     {
         private sealed class StreamCursor
         {
-            public int Position = 0;
-            public int Line = 0;
-            public int Column = 0;
+            public int Position;
+            public int Line;
+            public int Column;
         }
 
         private readonly string _Source;
@@ -369,11 +369,9 @@ namespace PSRule.Parser
         public bool Next(bool ignoreEscaping = false)
         {
             _Position += _EscapeLength > 0 ? _EscapeLength + 1 : 1;
-
             if (_Position >= _Length)
             {
                 _Current = char.MinValue;
-
                 return false;
             }
 
@@ -387,9 +385,7 @@ namespace PSRule.Parser
             {
                 _Column += _EscapeLength + 1;
             }
-
             UpdateCurrent(ignoreEscaping);
-
             return true;
         }
 

--- a/src/PSRule/Parser/RuleLexer.cs
+++ b/src/PSRule/Parser/RuleLexer.cs
@@ -63,7 +63,7 @@ namespace PSRule.Parser
         /// <summary>
         /// Read synopsis.
         /// </summary>
-        private bool Synopsis(TokenStream stream, RuleDocument doc)
+        private static bool Synopsis(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Synopsis))
                 return false;
@@ -76,7 +76,7 @@ namespace PSRule.Parser
         /// <summary>
         /// Read description.
         /// </summary>
-        private bool Description(TokenStream stream, RuleDocument doc)
+        private static bool Description(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Description))
                 return false;
@@ -89,7 +89,7 @@ namespace PSRule.Parser
         /// <summary>
         /// Read recommendation.
         /// </summary>
-        private bool Recommendation(TokenStream stream, RuleDocument doc)
+        private static bool Recommendation(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Recommendation))
                 return false;
@@ -102,7 +102,7 @@ namespace PSRule.Parser
         /// <summary>
         /// Read notes.
         /// </summary>
-        private bool Notes(TokenStream stream, RuleDocument doc)
+        private static bool Notes(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Notes))
                 return false;
@@ -115,7 +115,7 @@ namespace PSRule.Parser
         /// <summary>
         /// Read links.
         /// </summary>
-        private bool Links(TokenStream stream, RuleDocument doc)
+        private static bool Links(TokenStream stream, RuleDocument doc)
         {
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Links))
                 return false;

--- a/src/PSRule/Pipeline/Output/MarkdownOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/MarkdownOutputWriter.cs
@@ -56,7 +56,7 @@ namespace PSRule.Pipeline.Output
             var ruleGroup = o.SelectMany(result => result.AsRecord()).GroupBy(record => record.RuleId).ToArray();
             for (var i = 0; i < ruleGroup.Length; i++)
             {
-                RuleSummary(ruleGroup[i].Key, ruleGroup[i].ToArray());
+                RuleSummary(ruleGroup[i].ToArray());
             }
         }
 
@@ -87,7 +87,7 @@ namespace PSRule.Pipeline.Output
                 AppendLine("- [ ] ", text);
         }
 
-        private void RuleSummary(string name, Rules.RuleRecord[] records)
+        private void RuleSummary(RuleRecord[] records)
         {
             if (records.Length == 0)
                 return;

--- a/src/PSRule/Pipeline/Output/NUnit3OutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/NUnit3OutputWriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using PSRule.Common;
 using PSRule.Configuration;
 using PSRule.Resources;
 using System;
@@ -37,10 +38,9 @@ namespace PSRule.Pipeline.Output
             var error = o.Sum(r => r.Error);
             var fail = o.Sum(r => r.Fail);
 
-            _Builder.Append($"<test-results xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"nunit_schema_2.5.xsd\" name=\"PSRule\" total=\"{total}\" errors=\"{error}\" failures=\"{fail}\" not-run=\"0\" inconclusive=\"0\" ignored=\"0\" skipped=\"0\" invalid=\"0\" date=\"{DateTime.UtcNow.ToString("yyyy-MM-dd")}\" time=\"{TimeSpan.FromMilliseconds(time).ToString()}\">");
+            _Builder.Append($"<test-results xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"nunit_schema_2.5.xsd\" name=\"PSRule\" total=\"{total}\" errors=\"{error}\" failures=\"{fail}\" not-run=\"0\" inconclusive=\"0\" ignored=\"0\" skipped=\"0\" invalid=\"0\" date=\"{DateTime.UtcNow.ToString("yyyy-MM-dd", Thread.CurrentThread.CurrentCulture)}\" time=\"{TimeSpan.FromMilliseconds(time).ToString()}\">");
             _Builder.Append($"<environment user=\"{Environment.UserName}\" machine-name=\"{Environment.MachineName}\" cwd=\"{Configuration.PSRuleOption.GetWorkingPath()}\" user-domain=\"{Environment.UserDomainName}\" platform=\"{Environment.OSVersion.Platform}\" nunit-version=\"2.5.8.0\" os-version=\"{Environment.OSVersion.Version}\" clr-version=\"{Environment.Version.ToString()}\" />");
-            _Builder.Append($"<culture-info current-culture=\"{System.Threading.Thread.CurrentThread.CurrentCulture.ToString()}\" current-uiculture=\"{System.Threading.Thread.CurrentThread.CurrentUICulture.ToString()}\" />");
-
+            _Builder.Append($"<culture-info current-culture=\"{Thread.CurrentThread.CurrentCulture.ToString()}\" current-uiculture=\"{System.Threading.Thread.CurrentThread.CurrentUICulture.ToString()}\" />");
             foreach (var result in o)
             {
                 if (result.Total == 0)
@@ -113,7 +113,13 @@ namespace PSRule.Pipeline.Output
                 for (var i = 0; i < record.Reason.Length; i++)
                 {
                     sb.Append("- ");
-                    sb.AppendLine(record.Reason[i]);
+                    if (useMarkdown)
+                    {
+                        sb.AppendMarkdownText(record.Reason[i]);
+                        sb.AppendLine();
+                    }
+                    else
+                        sb.AppendLine(record.Reason[i]);
                 }
             }
             return sb.ToString();

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -5,6 +5,7 @@ using PSRule.Configuration;
 using PSRule.Rules;
 using System.Collections.Generic;
 using System.Management.Automation;
+using System.Text;
 
 namespace PSRule.Pipeline
 {

--- a/src/PSRule/Runtime/RuleConditionResult.cs
+++ b/src/PSRule/Runtime/RuleConditionResult.cs
@@ -47,7 +47,7 @@ namespace PSRule.Runtime
         private static bool TryBoolean(object o, out bool result)
         {
             result = false;
-            if (o == null || !(o is bool bresult))
+            if (!(o is bool bresult))
                 return false;
 
             result = bresult;
@@ -57,7 +57,7 @@ namespace PSRule.Runtime
         private static bool TryAssertResult(object o, out bool result)
         {
             result = false;
-            if (o == null || !(o is AssertResult assert))
+            if (!(o is AssertResult assert))
                 return false;
 
             result = assert.Result;

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -15,6 +15,7 @@ Rule 'FromFile1' -Tag @{ category = "group1"; test = "Test1" } {
 # Synopsis: Test rule 2
 Rule 'FromFile2' -Tag @{ category = "group1"; test = "Test2" } {
     # Fail
+    Reason 'Returned a `false`.'
     $False;
     $True;
     $True;

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -430,9 +430,10 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.String;
 
-            $result = $testObject | Invoke-PSRule @invokeParams -Name 'FromFile1','FromFile2','FromFile3' -WarningAction SilentlyContinue | Out-String;
+            $result = $testObject | Invoke-PSRule @invokeParams -Name 'FromFile1','FromFile2','FromFile3' -Option @{ 'Output.Style' = 'AzurePipelines' } -WarningAction SilentlyContinue | Out-String;
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.String;
+            $result | Should -Match 'Returned a \\`false\\`\.'
 
             # Check XML schema
 


### PR DESCRIPTION
## PR Summary

- Fixed NUnit report reasons should be escaped in markdown. #471

Fixed #471 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
