### PR TITLE
Pre-release v0.21.0-B2010003

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@
 
 ## Unreleased
 
+## v0.21.0-B2010003 (pre-release)
+
+What's changed since pre-release v0.21.0-B2009016:
+
 - General improvements:
   - Added help links and default snippets to schemas. [#561](https://github.com/microsoft/PSRule/issues/561)
+- Engineering:
+  - Bump Manatee.Json from 13.0.2 to 13.0.3. [#563](https://github.com/microsoft/PSRule/pull/563)
 - Bug fixes:
   - Fixed reporting of error when rule error is handled. [#564](https://github.com/microsoft/PSRule/issues/564)
   - Fixed first exception stops other rules from being processed. [#566](https://github.com/microsoft/PSRule/issues/566)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v0.21.0-B2009016:

- General improvements:
  - Added help links and default snippets to schemas. #561
- Engineering:
  - Bump Manatee.Json from 13.0.2 to 13.0.3. #563
- Bug fixes:
  - Fixed reporting of error when rule error is handled. #564
  - Fixed first exception stops other rules from being processed. #566

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
