### PR TITLE
Add jsonc and markdown extensions #575

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ## Unreleased
 
+- General improvements:
+  - Input format detection now includes `.jsonc` and `.markdown` file extensions. [#575](https://github.com/microsoft/PSRule/issues/575)
+
 ## v0.21.0
 
 What's changed since v0.20.0:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -550,8 +550,8 @@ A `RepositoryInfo` object is generated if the current working path if a `.git` s
 Detect uses the following file extensions:
 
 - Yaml - `.yaml` or `.yml`
-- Json - `.json`
-- Markdown - `.md`
+- Json - `.json` or `.jsonc`
+- Markdown - `.md` or `.markdown`
 - PowerShellData - `.psd1`
 
 This option can be specified using:

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -90,6 +90,9 @@ namespace PSRule
                         value.Properties.Add(new PSNoteProperty(name: name, value: items.ToArray()));
                         break;
 
+                    case JsonToken.Comment:
+                        break;
+
                     default:
                         value.Properties.Add(new PSNoteProperty(name: name, value: reader.Value));
                         break;
@@ -101,7 +104,7 @@ namespace PSRule
         /// <summary>
         /// Serialize a file system info object.
         /// </summary>
-        private bool WriteFileSystemInfo(JsonWriter writer, object value, JsonSerializer serializer)
+        private static bool WriteFileSystemInfo(JsonWriter writer, object value, JsonSerializer serializer)
         {
             if (!(value is FileSystemInfo fileSystemInfo))
                 return false;
@@ -113,7 +116,7 @@ namespace PSRule
         /// <summary>
         /// Serialize the base object.
         /// </summary>
-        private bool WriteBaseObject(JsonWriter writer, PSObject value, JsonSerializer serializer)
+        private static bool WriteBaseObject(JsonWriter writer, PSObject value, JsonSerializer serializer)
         {
             if (value.BaseObject == null || value.HasNoteProperty())
                 return false;
@@ -188,6 +191,10 @@ namespace PSRule
                         var items = ReadArray(reader: reader);
                         result.Properties.Add(new PSNoteProperty(name: name, value: items));
                         break;
+
+                    case JsonToken.Comment:
+                        break;
+
                     default:
                         result.Properties.Add(new PSNoteProperty(name: name, value: reader.Value));
                         break;
@@ -220,6 +227,9 @@ namespace PSRule
 
                     case JsonToken.Null:
                         result.Add(null);
+                        break;
+
+                    case JsonToken.Comment:
                         break;
 
                     default:

--- a/src/PSRule/Pipeline/PipelineReciever.cs
+++ b/src/PSRule/Pipeline/PipelineReciever.cs
@@ -65,7 +65,7 @@ namespace PSRule.Pipeline
             var pathExtension = GetPathExtension(sourceObject);
 
             // Handle JSON
-            if (pathExtension == ".json")
+            if (pathExtension == ".json" || pathExtension == ".jsonc")
             {
                 return ConvertFromJson(sourceObject, next);
             }
@@ -75,7 +75,7 @@ namespace PSRule.Pipeline
                 return ConvertFromYaml(sourceObject, next);
             }
             // Handle Markdown
-            else if (pathExtension == ".md")
+            else if (pathExtension == ".md" || pathExtension == ".markdown")
             {
                 return ConvertFromMarkdown(sourceObject, next);
             }

--- a/tests/PSRule.Tests/ObjectFromFileSingle.jsonc
+++ b/tests/PSRule.Tests/ObjectFromFileSingle.jsonc
@@ -1,0 +1,33 @@
+{
+    // There is comments in this file
+    "TargetName": "TestObject1",
+    "Spec": {
+        "Properties": {
+            "Value1": 1,
+            "Kind": "Test",
+            "array": [
+                {
+                    "id": "1"
+                },
+                {
+                    "id": "2"
+                }
+            ],
+            "array2": [
+                "1",
+                "2",
+                "3"
+            ],
+            "array3": [
+                [
+                    "nested"
+                ],
+                [
+                    1,
+                    2,
+                    3
+                ]
+            ]
+        }
+    }
+}

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1018,12 +1018,25 @@ Describe 'Test-PSRuleTarget' -Tag 'Test-PSRuleTarget','Common' {
 #region Get-PSRuleTarget
 
 Describe 'Get-PSRuleTarget' -Tag 'Get-PSRuleTarget','Common' {
-
     Context 'With defaults' {
-        It 'Returns single object' {
+        It 'Yaml' {
             $result = @(Get-PSRuleTarget -InputPath (Join-Path -Path $rootPath -ChildPath 'ps-project.yaml'));
             $result.Length | Should -Be 1;
             $result[0].info.name | Should -Be 'PSRule';
+
+            $result = @(Get-PSRuleTarget -InputPath (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml'));
+            $result.Length | Should -Be 1;
+            $result[0].input.format | Should -Be 'Yaml';
+        }
+
+        It 'Json' {
+            $result = @(Get-PSRuleTarget -InputPath (Join-Path -Path $here -ChildPath 'ObjectFromFileSingle.json'));
+            $result.Length | Should -Be 1;
+            $result[0].TargetName | Should -Be 'TestObject1';
+
+            $result = @(Get-PSRuleTarget -InputPath (Join-Path -Path $here -ChildPath 'ObjectFromFileSingle.jsonc'));
+            $result.Length | Should -Be 1;
+            $result[0].TargetName | Should -Be 'TestObject1';
         }
     }
 


### PR DESCRIPTION
## PR Summary

- Input format detection now includes `.jsonc` and `.markdown` file extensions. #575

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
