### PR TITLE
Added help links to assert output #595

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 What's changed since v0.22.0:
 
+- General improvements:
+  - Added rule help link in failed `Assert-PSRule` output. [#595](https://github.com/microsoft/PSRule/issues/595)
 - Engineering:
   - Bump Manatee.Json from 13.0.3 to 13.0.4. [#591](https://github.com/microsoft/PSRule/pull/591)
 

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -75,6 +75,8 @@ namespace PSRule.Pipeline
             /// </summary>
             private abstract class AssertFormatterBase : PipelineLoggerBase, IAssertFormatter
             {
+                const string OUTPUT_SEPARATOR_BAR = "----------------------------";
+
                 private readonly bool _VTSupport;
 
                 protected readonly IPipelineWriter Writer;
@@ -88,6 +90,7 @@ namespace PSRule.Pipeline
                     Writer = writer;
                     Banner();
                     Source(source);
+                    Help(source);
                 }
 
                 public void Error(ErrorRecord errorRecord)
@@ -146,6 +149,13 @@ namespace PSRule.Pipeline
                             WriteLines(record.Reason[i], prefix: FormatterStrings.ReasonPrefix);
                         }
                     }
+                    var link = record.Info?.GetOnlineHelpUri().ToString();
+                    if (!string.IsNullOrEmpty(link))
+                    {
+                        LineBreak();
+                        WriteLine(FormatterStrings.Help);
+                        WriteLines(link, prefix: FormatterStrings.HelpLinkPrefix);
+                    }
                     LineBreak();
                 }
 
@@ -185,16 +195,35 @@ namespace PSRule.Pipeline
                 private void Source(Source[] source)
                 {
                     var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
-                    WriteLine(string.Format(Thread.CurrentThread.CurrentCulture, FormatterStrings.PSRuleVersion, version));
+                    WriteLineFormat(FormatterStrings.PSRuleVersion, version);
                     var list = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     for (var i = 0; source != null && i < source.Length; i++)
                     {
                         if (source[i].Module != null && !list.Contains(source[i].Module.Name))
                         {
-                            WriteLine(string.Format(Thread.CurrentThread.CurrentCulture, FormatterStrings.ModuleVersion, source[i].Module.Name, source[i].Module.Version));
+                            WriteLineFormat(FormatterStrings.ModuleVersion, source[i].Module.Name, source[i].Module.Version);
                             list.Add(source[i].Module.Name);
                         }
                     }
+                    LineBreak();
+                }
+
+                private void Help(Source[] source)
+                {
+                    WriteLine(OUTPUT_SEPARATOR_BAR);
+                    WriteLine(FormatterStrings.HelpDocs);
+                    WriteLine(FormatterStrings.HelpContribute);
+                    WriteLine(FormatterStrings.HelpIssues);
+                    var list = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    for (var i = 0; source != null && i < source.Length; i++)
+                    {
+                        if (source[i].Module != null && !list.Contains(source[i].Module.Name) && !string.IsNullOrEmpty(source[i].Module.ProjectUri))
+                        {
+                            WriteLineFormat(FormatterStrings.HelpModule, source[i].Module.Name, source[i].Module.ProjectUri);
+                            list.Add(source[i].Module.Name);
+                        }
+                    }
+                    WriteLine(OUTPUT_SEPARATOR_BAR);
                     LineBreak();
                 }
 
@@ -231,7 +260,7 @@ namespace PSRule.Pipeline
                 public void End(int total, int fail, int error)
                 {
                     LineBreak();
-                    WriteLine(string.Format(Thread.CurrentThread.CurrentCulture, FormatterStrings.Summary, total, fail, error));
+                    WriteLineFormat(FormatterStrings.Summary, total, fail, error);
                 }
 
                 protected void WriteLine(string prefix, ConsoleColor? forgroundColor, string message, params object[] args)
@@ -244,6 +273,11 @@ namespace PSRule.Pipeline
                 {
                     var output = string.IsNullOrEmpty(prefix) ? message : string.Concat(prefix, message);
                     Writer.WriteHost(new HostInformationMessage { Message = output, ForegroundColor = forgroundColor });
+                }
+
+                protected void WriteLineFormat(string message, params object[] args)
+                {
+                    WriteLine(string.Format(Thread.CurrentThread.CurrentCulture, message, args));
                 }
 
                 protected void WriteLines(string message, string prefix = null, ConsoleColor? forgroundColor = null)
@@ -409,6 +443,13 @@ namespace PSRule.Pipeline
                         {
                             WriteLines(record.Reason[i], prefix: FormatterStrings.ReasonPrefix, forgroundColor: ConsoleColor.Cyan);
                         }
+                    }
+                    var link = record.Info?.GetOnlineHelpUri().ToString();
+                    if (!string.IsNullOrEmpty(link))
+                    {
+                        LineBreak();
+                        WriteLine(FormatterStrings.Help, forgroundColor: ConsoleColor.Cyan);
+                        WriteLines(link, prefix: FormatterStrings.HelpLinkPrefix, forgroundColor: ConsoleColor.Cyan);
                     }
                     LineBreak();
                 }

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -149,7 +149,7 @@ namespace PSRule.Pipeline
                             WriteLines(record.Reason[i], prefix: FormatterStrings.ReasonPrefix);
                         }
                     }
-                    var link = record.Info?.GetOnlineHelpUri().ToString();
+                    var link = record.Info?.GetOnlineHelpUri()?.ToString();
                     if (!string.IsNullOrEmpty(link))
                     {
                         LineBreak();
@@ -444,7 +444,7 @@ namespace PSRule.Pipeline
                             WriteLines(record.Reason[i], prefix: FormatterStrings.ReasonPrefix, forgroundColor: ConsoleColor.Cyan);
                         }
                     }
-                    var link = record.Info?.GetOnlineHelpUri().ToString();
+                    var link = record.Info?.GetOnlineHelpUri()?.ToString();
                     if (!string.IsNullOrEmpty(link))
                     {
                         LineBreak();

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -63,7 +63,6 @@ namespace PSRule.Pipeline
         {
             var hostContext = new HostContext(commandRuntime, executionContext);
             var pipeline = new SourcePipelineBuilder(hostContext, option);
-            pipeline.Configure(option);
             return pipeline;
         }
 

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -104,8 +104,8 @@ namespace PSRule.Pipeline
             {
                 Path = info.ModuleBase;
                 Name = info.Name;
-                Version = info.Version.ToString();
-                ProjectUri = info.ProjectUri.ToString();
+                Version = info.Version?.ToString();
+                ProjectUri = info.ProjectUri?.ToString();
                 if (TryPrivateData(info, "PSRule", out Hashtable moduleData))
                     Baseline = moduleData.ContainsKey("Baseline") ? moduleData["Baseline"] as string : null;
 

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -9,7 +9,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
 using System.Threading;
 
@@ -32,10 +31,10 @@ namespace PSRule.Pipeline
 
         internal Source Source;
 
-        public readonly string Path;
-        public readonly string ModuleName;
-        public readonly RuleSourceType Type;
-        public readonly string HelpPath;
+        public string Path { get; }
+        public string ModuleName { get; }
+        public RuleSourceType Type { get; }
+        public string HelpPath { get; }
 
         public SourceFile(string path, string moduleName, RuleSourceType type, string helpPath)
         {
@@ -61,8 +60,9 @@ namespace PSRule.Pipeline
 
     public sealed class Source
     {
-        public readonly string Path;
-        public readonly SourceFile[] File;
+        public string Path { get; }
+
+        public SourceFile[] File { get; }
 
         internal bool Dependency;
 
@@ -98,12 +98,14 @@ namespace PSRule.Pipeline
             public readonly string Name;
             public readonly string Baseline;
             public readonly string Version;
+            public readonly string ProjectUri;
 
             public ModuleInfo(PSModuleInfo info)
             {
                 Path = info.ModuleBase;
                 Name = info.Name;
                 Version = info.Version.ToString();
+                ProjectUri = info.ProjectUri.ToString();
                 if (TryPrivateData(info, "PSRule", out Hashtable moduleData))
                     Baseline = moduleData.ContainsKey("Baseline") ? moduleData["Baseline"] as string : null;
 
@@ -142,12 +144,7 @@ namespace PSRule.Pipeline
             _Source = new List<Source>();
             _HostContext = hostContext;
             _Writer = new HostPipelineWriter(hostContext, option);
-        }
-
-        public SourcePipelineBuilder Configure(PSRuleOption option)
-        {
             _Writer.EnterScope("[Discovery.Source]");
-            return this;
         }
 
         public bool ShouldLoadModule

--- a/src/PSRule/Resources/FormatterStrings.Designer.cs
+++ b/src/PSRule/Resources/FormatterStrings.Designer.cs
@@ -70,6 +70,60 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to     | HELP:.
+        /// </summary>
+        internal static string Help {
+            get {
+                return ResourceManager.GetString("Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Contribute and find source: https://github.com/microsoft/PSRule.
+        /// </summary>
+        internal static string HelpContribute {
+            get {
+                return ResourceManager.GetString("HelpContribute", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Explore documentation: https://microsoft.github.io/PSRule/.
+        /// </summary>
+        internal static string HelpDocs {
+            get {
+                return ResourceManager.GetString("HelpDocs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Report issues: https://github.com/microsoft/PSRule/issues.
+        /// </summary>
+        internal static string HelpIssues {
+            get {
+                return ResourceManager.GetString("HelpIssues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     | - .
+        /// </summary>
+        internal static string HelpLinkPrefix {
+            get {
+                return ResourceManager.GetString("HelpLinkPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0}: {1}.
+        /// </summary>
+        internal static string HelpModule {
+            get {
+                return ResourceManager.GetString("HelpModule", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to     | MESSAGE:.
         /// </summary>
         internal static string Message {

--- a/src/PSRule/Resources/FormatterStrings.resx
+++ b/src/PSRule/Resources/FormatterStrings.resx
@@ -120,6 +120,24 @@
   <data name="Banner" xml:space="preserve">
     <value>    ____  _____ ____        __\n   / __ \/ ___// __ \__  __/ /__\n  / /_/ /\__ \/ /_/ / / / / / _ \\n / ____/___/ / _, _/ /_/ / /  __/\n/_/    /____/_/ |_|\__,_/_/\___/</value>
   </data>
+  <data name="Help" xml:space="preserve">
+    <value>    | HELP:</value>
+  </data>
+  <data name="HelpContribute" xml:space="preserve">
+    <value>Contribute and find source: https://github.com/microsoft/PSRule</value>
+  </data>
+  <data name="HelpDocs" xml:space="preserve">
+    <value>Explore documentation: https://microsoft.github.io/PSRule/</value>
+  </data>
+  <data name="HelpIssues" xml:space="preserve">
+    <value>Report issues: https://github.com/microsoft/PSRule/issues</value>
+  </data>
+  <data name="HelpLinkPrefix" xml:space="preserve">
+    <value>    | - </value>
+  </data>
+  <data name="HelpModule" xml:space="preserve">
+    <value>{0}: {1}</value>
+  </data>
   <data name="Message" xml:space="preserve">
     <value>    | MESSAGE:</value>
   </data>


### PR DESCRIPTION
## PR Summary

- Added rule help link in failed `Assert-PSRule` output. #595

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
