### PR TITLE
Removed deprecated $Rule properties #495

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ What's changed since v0.22.0:
 - General improvements:
   - Added rule help link in failed `Assert-PSRule` output. [#595](https://github.com/microsoft/PSRule/issues/595)
 - Engineering:
+  - **Breaking change**: Removed deprecated `$Rule` properties. [#495](https://github.com/microsoft/PSRule/pull/495)
   - Bump Manatee.Json from 13.0.3 to 13.0.4. [#591](https://github.com/microsoft/PSRule/pull/591)
 
 ## v0.22.0

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -8,7 +8,8 @@ Describes the automatic variables that can be used within PSRule rule definition
 
 ## LONG DESCRIPTION
 
-PSRule lets you define rules using PowerShell blocks. A rule is defined within script files by using the `rule` keyword.
+PSRule lets you define rules using PowerShell blocks.
+A rule is defined within script files by using the `rule` keyword.
 
 Within a rule definition, PSRule exposes a number of automatic variables that can be read to assist with rule execution.
 Overwriting these variables or variable properties is not supported.
@@ -26,7 +27,8 @@ The following variables are available for use:
 
 ### Assert
 
-An assertion helper with methods to evaluate objects. The `$Assert` object provides a set of built-in methods and provides a consistent variable for extension.
+An assertion helper with methods to evaluate objects.
+The `$Assert` object provides a set of built-in methods and provides a consistent variable for extension.
 
 Each `$Assert` method returns an `AssertResult` object that contains the result of the condition.
 
@@ -207,11 +209,6 @@ The following properties are available for read access:
 
 - `RuleName` - The name of the rule.
 - `RuleId` - A unique identifier for the rule.
-- `TargetObject` - (deprecated) The object currently being processed on the pipeline.
-- `TargetName` - (deprecated) The name of the object currently being processed on the pipeline. This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
-- `TargetType` - (deprecated) The type of the object currently being processed on the pipeline. This property will automatically bind to `PSObject.TypeNames[0]` by default.
-
-**Note:** Use `TargetName`, `TargetType` and `TargetObject` on `$PSRule` instead.
 
 Syntax:
 
@@ -230,7 +227,8 @@ Rule 'resource.NamingConvention' {
 
 ### TargetObject
 
-The value of the pipeline object currently being processed. `$TargetObject` is set by using the `-InputObject` parameter of `Invoke-PSRule`.
+The value of the pipeline object currently being processed.
+`$TargetObject` is set by using the `-InputObject` parameter of `Invoke-PSRule`.
 
 When more than one input object is set, each object will be processed sequentially.
 

--- a/src/PSRule/Runtime/Rule.cs
+++ b/src/PSRule/Runtime/Rule.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using PSRule.Pipeline;
-using System;
-using System.Management.Automation;
 
 namespace PSRule.Runtime
 {
@@ -14,8 +12,6 @@ namespace PSRule.Runtime
     /// </summary>
     public sealed class Rule
     {
-        private const string VariableName = "Rule";
-
         public string RuleName
         {
             get
@@ -29,36 +25,6 @@ namespace PSRule.Runtime
             get
             {
                 return RunspaceContext.CurrentThread.RuleRecord.RuleId;
-            }
-        }
-
-        [Obsolete("Use property on $PSRule instead")]
-        public PSObject TargetObject
-        {
-            get
-            {
-                RunspaceContext.CurrentThread.WarnPropertyObsolete(VariableName, nameof(TargetObject));
-                return RunspaceContext.CurrentThread.RuleRecord.TargetObject;
-            }
-        }
-
-        [Obsolete("Use property on $PSRule instead")]
-        public string TargetName
-        {
-            get
-            {
-                RunspaceContext.CurrentThread.WarnPropertyObsolete(VariableName, nameof(TargetName));
-                return RunspaceContext.CurrentThread.RuleRecord.TargetName;
-            }
-        }
-
-        [Obsolete("Use property on $PSRule instead")]
-        public string TargetType
-        {
-            get
-            {
-                RunspaceContext.CurrentThread.WarnPropertyObsolete(VariableName, nameof(TargetType));
-                return RunspaceContext.CurrentThread.RuleRecord.TargetType;
             }
         }
     }


### PR DESCRIPTION
## PR Summary

- **Breaking change**: Removed deprecated `$Rule` properties. #495

Fixes #495 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
