### PR TITLE
Pre-release v1.0.0-B2011028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Unreleased
 
+## v1.0.0-B2011028 (pre-release)
+
 What's changed since v0.22.0:
 
 - General improvements:


### PR DESCRIPTION
## PR Summary

What's changed since v0.22.0:

- General improvements:
  - Added rule help link in failed `Assert-PSRule` output. #595
- Engineering:
  - **Breaking change**: Removed deprecated `$Rule` properties. #495
  - Bump Manatee.Json from 13.0.3 to 13.0.4. #591

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
