### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change log
 
-**Important notes**:
+See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
 
-- Removal of deprecated `$Rule` properties are scheduled for PSRule v1.0.0. [#495](https://github.com/microsoft/PSRule/issues/495)
+[upgrade-notes]: docs/upgrade-notes.md
 
 ## Current release
 

--- a/docs/CHANGELOG-v0.md
+++ b/docs/CHANGELOG-v0.md
@@ -1,5 +1,9 @@
 # Change log
 
+See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+
+[upgrade-notes]: upgrade-notes.md
+
 ## v0.22.0
 
 What's changed since v0.21.0:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -1,8 +1,22 @@
 # Change log
 
-**Important notes**:
+See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
 
-- Removal of deprecated `$Rule` properties are scheduled for PSRule v1.0.0. [#495](https://github.com/microsoft/PSRule/issues/495)
+[upgrade-notes]: upgrade-notes.md
+
+## v1.0.0
+
+What's changed since v0.22.0:
+
+- General improvements:
+  - Added rule help link in failed `Assert-PSRule` output. [#595](https://github.com/microsoft/PSRule/issues/595)
+- Engineering:
+  - **Breaking change**: Removed deprecated `$Rule` properties. [#495](https://github.com/microsoft/PSRule/pull/495)
+  - Bump Manatee.Json from 13.0.3 to 13.0.4. [#591](https://github.com/microsoft/PSRule/pull/591)
+
+What's changed since pre-release v1.0.0-B2011028:
+
+- No additional changes.
 
 ## v1.0.0-B2011028 (pre-release)
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -1,0 +1,39 @@
+# Upgrade notes
+
+This document contains notes to help upgrade from previous versions of PSRule.
+
+## Upgrade to v0.22.0 from v1.0.0
+
+Follow these notes to upgrade from PSRule version _v0.22.0_ to _v1.0.0_.
+
+### Replaced $Rule target properties
+
+Previously in PSRule _v0.22.0_ and prior the `$Rule` automatic variable had the following properties:
+
+- `TargetName`
+- `TargetType`
+- `TargetObject`
+
+For example:
+
+```powershell
+Rule 'Rule1' {
+    $Rule.TargetName -eq 'Name1';
+    $Rule.TargetType -eq '.json';
+    $Rule.TargetObject.someProperty -eq 1;
+}
+```
+
+In _v1.0.0_ these properties have been removed after being deprecated in _v0.12.0_.
+These properties are instead available on the `$PSRule` variable.
+Rules referencing the deprecated properties of `$Rule` must be updated.
+
+For example:
+
+```powershell
+Rule 'Rule1' {
+    $PSRule.TargetName -eq 'Name1';
+    $PSRule.TargetType -eq '.json';
+    $PSRule.TargetObject.someProperty -eq 1;
+}
+```


### PR DESCRIPTION
## PR Summary

What's changed since v0.22.0:

- General improvements:
  - Added rule help link in failed `Assert-PSRule` output. #595
- Engineering:
  - **Breaking change**: Removed deprecated `$Rule` properties. #495
  - Bump Manatee.Json from 13.0.3 to 13.0.4. #591

What's changed since pre-release v1.0.0-B2011028:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
