### PR TITLE
Fixed GetContent and markdown help #625 #626 #627 #628

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,16 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.0.1:
+
+- Engineering:
+  - Bump Manatee.Json from 13.0.4 to 13.0.5. [#619](https://github.com/microsoft/PSRule/pull/619)
+- Bug fixes:
+  - Fixed `GetContent` processing of `InputFileInfo`. [#625](https://github.com/microsoft/PSRule/issues/625)
+  - Fixed null reference of rule reason with wide output. [#626](https://github.com/microsoft/PSRule/issues/626)
+  - Fixed markdown help handling of include code blocks with `[`. [#627](https://github.com/microsoft/PSRule/issues/627)
+  - Fixed markdown help inclusion of fenced code blocks in notes and description. [#628](https://github.com/microsoft/PSRule/issues/628)
+
 ## v1.0.1
 
 What's changed since v1.0.0:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -164,7 +164,7 @@ Use custom data to store data that must be calculated during rule execution.
 The following helper methods are available:
 
 - `GetContent(PSObject sourceObject)` - Returns the content of a file as one or more objects.
-The parameter `sourceObject` should be a `FileInfo` or a `Uri` object.
+The parameter `sourceObject` should be a `InputFileInfo`,`FileInfo`, or `Uri` object.
 The file format is detected based on the same file formats as the option `Input.Format`.
 i.e. Yaml, Json, Markdown and PowerShell Data.
 

--- a/src/PSRule/Data/InputFileInfo.cs
+++ b/src/PSRule/Data/InputFileInfo.cs
@@ -42,5 +42,21 @@ namespace PSRule.Data
         string ITargetInfo.TargetName => DisplayName;
 
         string ITargetInfo.TargetType => Extension;
+
+        /// <summary>
+        /// Convert to string.
+        /// </summary>
+        public override string ToString()
+        {
+            return FullName;
+        }
+
+        /// <summary>
+        /// Convert to FileInfo.
+        /// </summary>
+        public FileInfo AsFileInfo()
+        {
+            return new FileInfo(FullName);
+        }
     }
 }

--- a/src/PSRule/Parser/MarkdownReader.cs
+++ b/src/PSRule/Parser/MarkdownReader.cs
@@ -257,7 +257,11 @@ namespace PSRule.Parser
             var styleCount = styleChar == Asterix || styleChar == Underscore ? stream.Skip(styleChar, max: 0) : 0;
             var codeCount = styleChar == Backtick ? stream.Skip(Backtick, max: 0) : 0;
 
-            var text = stream.CaptureUntil(IsTextStop, ignoreEscaping: false);
+            CharacterMatchDelegate stop = IsTextStop;
+            if (codeCount > 0)
+                stop = IsCodeStop;
+
+            var text = stream.CaptureUntil(stop, ignoreEscaping: false);
 
             // Check for italic and bold endings
             if (styleCount > 0)
@@ -428,6 +432,11 @@ namespace PSRule.Parser
         private static bool IsTextStop(char c)
         {
             return c == '\r' || c == '\n' || c == '[' || c == '*' || c == '`' || c == '_';
+        }
+
+        private static bool IsCodeStop(char c)
+        {
+            return c == '\r' || c == '\n' || c == '`';
         }
     }
 }

--- a/src/PSRule/Parser/RuleLexer.cs
+++ b/src/PSRule/Parser/RuleLexer.cs
@@ -78,7 +78,7 @@ namespace PSRule.Parser
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Description))
                 return false;
 
-            doc.Description = TextBlock(stream);
+            doc.Description = TextBlock(stream, includeNonYamlFencedBlocks: true);
             stream.SkipUntilHeader();
             return true;
         }
@@ -104,7 +104,7 @@ namespace PSRule.Parser
             if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Notes))
                 return false;
 
-            doc.Notes = TextBlock(stream);
+            doc.Notes = TextBlock(stream, includeNonYamlFencedBlocks: true);
             stream.SkipUntilHeader();
             return true;
         }
@@ -147,18 +147,18 @@ namespace PSRule.Parser
             return true;
         }
 
-        private static TextBlock TextBlock(TokenStream stream)
+        private static TextBlock TextBlock(TokenStream stream, bool includeNonYamlFencedBlocks = false)
         {
             var useBreak = stream.Current.IsDoubleLineEnding();
             stream.Next();
-            var text = ReadText(stream);
+            var text = ReadText(stream, includeNonYamlFencedBlocks);
             return new TextBlock(text: text, formatOption: useBreak ? FormatOptions.LineBreak : FormatOptions.None);
         }
 
         /// <summary>
         /// Read tokens from the stream as text.
         /// </summary>
-        private static string ReadText(TokenStream stream, bool includeNonYamlFencedBlocks = false)
+        private static string ReadText(TokenStream stream, bool includeNonYamlFencedBlocks)
         {
             var sb = new StringBuilder();
             while (stream.IsTokenType(MarkdownTokenType.Text, MarkdownTokenType.Link, MarkdownTokenType.FencedBlock, MarkdownTokenType.LineBreak))

--- a/src/PSRule/Parser/RuleModels.cs
+++ b/src/PSRule/Parser/RuleModels.cs
@@ -21,7 +21,7 @@ namespace PSRule.Parser
     }
 
     /// <summary>
-    /// YAML text content.
+    /// Markdown text content.
     /// </summary>
     internal sealed class TextBlock
     {

--- a/src/PSRule/Parser/TokenStream.cs
+++ b/src/PSRule/Parser/TokenStream.cs
@@ -172,9 +172,7 @@ namespace PSRule.Parser
         public static IEnumerable<MarkdownToken> GetSection(this TokenStream stream, string header)
         {
             if (stream.Count == 0)
-            {
                 return Enumerable.Empty<MarkdownToken>();
-            }
 
             return stream
                 // Skip until we reach the header
@@ -188,9 +186,7 @@ namespace PSRule.Parser
         public static IEnumerable<MarkdownToken> GetSections(this TokenStream stream)
         {
             if (stream.Count == 0)
-            {
                 return Enumerable.Empty<MarkdownToken>();
-            }
 
             return stream
                 // Skip until we reach the header
@@ -220,9 +216,7 @@ namespace PSRule.Parser
             : this()
         {
             foreach (var token in tokens)
-            {
                 Add(token);
-            }
         }
 
         #region Properties
@@ -255,14 +249,10 @@ namespace PSRule.Parser
         public bool IsTokenType(params MarkdownTokenType[] tokenType)
         {
             if (Current == null || tokenType == null)
-            {
                 return false;
-            }
 
             if (tokenType.Length == 1)
-            {
                 return tokenType[0] == Current.Type;
-            }
 
             return tokenType.Contains(Current.Type);
         }
@@ -270,21 +260,13 @@ namespace PSRule.Parser
         public MarkdownTokenType PeakTokenType(int offset = 1)
         {
             var p = _Position + offset;
-            if (p < 0 || p >= _Token.Count)
-            {
-                return MarkdownTokenType.None;
-            }
-            return _Token[p].Type;
+            return p < 0 || p >= _Token.Count ? MarkdownTokenType.None : _Token[p].Type;
         }
 
         public MarkdownToken Peak(int offset = 1)
         {
             var p = _Position + offset;
-            if (p < 0 || p >= _Token.Count)
-            {
-                return null;
-            }
-            return _Token[p];
+            return p < 0 || p >= _Token.Count ? null : _Token[p];
         }
 
         public void SkipUntilHeader()
@@ -295,9 +277,7 @@ namespace PSRule.Parser
         public void SkipUntil(MarkdownTokenType tokenType)
         {
             while (!EOF && Current.Type != tokenType)
-            {
                 Next();
-            }
         }
 
         public IEnumerable<MarkdownToken> CaptureUntil(MarkdownTokenType tokenType)
@@ -307,7 +287,6 @@ namespace PSRule.Parser
             while (!EOF && Current.Type != tokenType)
             {
                 count++;
-
                 Next();
             }
             return _Token.GetRange(start, count);

--- a/src/PSRule/Rules/RuleRecord.cs
+++ b/src/PSRule/Rules/RuleRecord.cs
@@ -138,9 +138,12 @@ namespace PSRule.Rules
 
         public string GetReasonViewString()
         {
+            if (Reason != null || Reason.Length == 0)
+                return string.Empty;
+
             var sb = new StringBuilder();
-            foreach (var item in Reason)
-                sb.AppendLine(item);
+            for (var i = 0; i < Reason.Length; i++)
+                sb.AppendLine(Reason[i]);
 
             return sb.ToString();
         }

--- a/src/PSRule/Runtime/PSRule.cs
+++ b/src/PSRule/Runtime/PSRule.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using PSRule.Data;
 using PSRule.Pipeline;
-using PSRule.Rules;
 using System;
 using System.Collections;
 using System.IO;
@@ -85,7 +85,10 @@ namespace PSRule.Runtime
         /// </summary>
         public PSObject[] GetContent(PSObject sourceObject)
         {
-            if (sourceObject == null || !(sourceObject.BaseObject is FileInfo || sourceObject.BaseObject is Uri))
+            if (sourceObject == null)
+                return Array.Empty<PSObject>();
+
+            if (!(sourceObject.BaseObject is InputFileInfo || sourceObject.BaseObject is FileInfo || sourceObject.BaseObject is Uri))
                 return new PSObject[] { sourceObject };
 
             var cacheKey = sourceObject.BaseObject.ToString();

--- a/tests/PSRule.Tests/RuleDocument.md
+++ b/tests/PSRule.Tests/RuleDocument.md
@@ -8,11 +8,11 @@ online version:
 
 ## SYNOPSIS
 
-Containers should use specific tags instead of latest.
+Containers should use specific tags instead of `latest`.
 
 ## DESCRIPTION
 
-Containers should use specific tags instead of latest.
+Containers should use specific tags instead of `latest`.
 
 ## RECOMMENDATION
 
@@ -22,6 +22,20 @@ When `latest` is used it may be hard to determine which version of the image is 
 When using variable tags such as v1.0 (which may refer to v1.0.0 or v1.0.1) consider using `imagePullPolicy: Always` to ensure that the an out-of-date cached image is not used.
 
 The `latest` tag automatically uses `imagePullPolicy: Always` instead of the default `imagePullPolicy: IfNotPresent`.
+
+## NOTES
+
+Test that `[isIgnored]`.
+
+```json
+{
+    "type": "Microsoft.Network/virtualNetworks",
+    "name": "[parameters('VNETName')]",
+    "apiVersion": "2020-06-01",
+    "location": "[parameters('location')]",
+    "properties": {}
+}
+```
 
 ## LINKS
 

--- a/tests/PSRule.Tests/RuleDocumentTests.cs
+++ b/tests/PSRule.Tests/RuleDocumentTests.cs
@@ -41,6 +41,7 @@ namespace PSRule
             Assert.Equal(expected.Name, document.Name);
             Assert.Equal(expected.Synopsis.Text, document.Synopsis.Text);
             Assert.Equal(expected.Recommendation.Text, document.Recommendation.Text);
+            Assert.Equal(expected.Notes.Text, document.Notes.Text);
             Assert.Equal(expected.Annotations["severity"], document.Annotations["severity"]);
             Assert.Equal(expected.Annotations["category"], document.Annotations["category"]);
             Assert.Equal(expected.Links.Length, document.Links.Length);
@@ -84,7 +85,7 @@ The latest tag automatically uses imagePullPolicy: Always instead of the default
         private RuleDocument GetDocument(TokenStream stream)
         {
             var lexer = new RuleLexer();
-            return lexer.Process(stream: stream);
+            return lexer.Process(stream);
         }
 
         private TokenStream GetToken(bool nx)
@@ -95,9 +96,9 @@ The latest tag automatically uses imagePullPolicy: Always instead of the default
             {
                 content = content.Replace("\r\n", "\n");
             }
-            else if (!content.Contains("\r\n"))
+            else
             {
-                content = content.Replace("\n", "\r\n");
+                content = content.Replace("\r\n", "\n").Replace("\n", "\r\n");
             }
             return reader.Read(content, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "RuleDocument.md"));
         }

--- a/tests/PSRule.Tests/RuleDocumentTests.cs
+++ b/tests/PSRule.Tests/RuleDocumentTests.cs
@@ -22,6 +22,7 @@ namespace PSRule
             Assert.Equal(expected.Name, document.Name);
             Assert.Equal(expected.Synopsis.Text, document.Synopsis.Text);
             Assert.Equal(expected.Recommendation.Text, document.Recommendation.Text);
+            Assert.Equal(expected.Notes.Text, document.Notes.Text);
             Assert.Equal(expected.Annotations["severity"], document.Annotations["severity"]);
             Assert.Equal(expected.Annotations["category"], document.Annotations["category"]);
             Assert.Equal(expected.Links.Length, document.Links.Length);
@@ -66,6 +67,15 @@ namespace PSRule
                 Recommendation = new TextBlock(text: @"Deployments or pods should identify a specific tag to use for container images instead of latest. When latest is used it may be hard to determine which version of the image is running.
 When using variable tags such as v1.0 (which may refer to v1.0.0 or v1.0.1) consider using imagePullPolicy: Always to ensure that the an out-of-date cached image is not used.
 The latest tag automatically uses imagePullPolicy: Always instead of the default imagePullPolicy: IfNotPresent."),
+                Notes = new TextBlock(@"Test that [isIgnored].
+
+{
+    ""type"": ""Microsoft.Network/virtualNetworks"",
+    ""name"": ""[parameters('VNETName')]"",
+    ""apiVersion"": ""2020-06-01"",
+    ""location"": ""[parameters('location')]"",
+    ""properties"": {}
+}"),
                 Links = links.ToArray()
             };
             return result;


### PR DESCRIPTION
## PR Summary

- Bug fixes:
  - Fixed `GetContent` processing of `InputFileInfo`. #625
  - Fixed null reference of rule reason with wide output. #626
  - Fixed markdown help handling of include code blocks with `[`. #627
  - Fixed markdown help inclusion of fenced code blocks in notes and description. #628

Fixes #625 
Fixes #626
Fixes #627 
Fixes #628 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
