### PR TITLE
Fixed reason for HasField and HasFields #632

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.0.2:
+
+- Bug fixes:
+  - Fixed reason reported fields for `HasField` and `HasFields` assertion helpers. [#632](https://github.com/microsoft/PSRule/issues/632)
+
 ## v1.0.2
 
 What's changed since v1.0.1:

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -148,7 +148,7 @@ namespace PSRule.Runtime
                 if (ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field[i], caseSensitive: caseSensitive, value: out _))
                     return Pass();
 
-                result.AddReason(ReasonStrings.HasField, field);
+                result.AddReason(ReasonStrings.HasField, field[i]);
             }
             return result;
         }
@@ -163,12 +163,17 @@ namespace PSRule.Runtime
                 GuardNullOrEmptyParam(field, nameof(field), out result))
                 return result;
 
+            result = Fail();
+            var missing = 0;
             for (var i = 0; field != null && i < field.Length; i++)
             {
                 if (!ObjectHelper.GetField(bindingContext: PipelineContext.CurrentThread, targetObject: inputObject, name: field[i], caseSensitive: caseSensitive, value: out _))
-                    return Fail(ReasonStrings.HasField, field);
+                {
+                    result.AddReason(ReasonStrings.HasField, field[i]);
+                    missing++;
+                }
             }
-            return Pass();
+            return missing == 0 ? Pass() : result;
         }
 
         /// <summary>

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -254,7 +254,9 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[1].IsSuccess() | Should -Be $False;
             $result[1].TargetName | Should -Be 'TestObject2';
             $result[1].Reason.Length | Should -Be 3;
-            $result[1].Reason | Should -BeLike "The field '*' does not exist.";
+            $result[1].Reason[0] | Should -Be "The field 'Type' does not exist.";
+            $result[1].Reason[1] | Should -Be "The field 'Not' does not exist.";
+            $result[1].Reason[2] | Should -Be "The field 'Type' does not exist.";
         }
 
         It 'HasFields' {
@@ -270,7 +272,8 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[1].IsSuccess() | Should -Be $False;
             $result[1].TargetName | Should -Be 'TestObject2';
             $result[1].Reason.Length | Should -Be 2;
-            $result[1].Reason | Should -BeLike "The field '*' does not exist.";
+            $result[1].Reason[0] | Should -Be "The field 'Type' does not exist.";
+            $result[1].Reason[1] | Should -Be "The field 'Type' does not exist.";
         }
 
         It 'HasFieldValue' {


### PR DESCRIPTION
## PR Summary

- Fixed reason reported fields for `HasField` and `HasFields` assertion helpers. #632

Fixes #632 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
