### PR TITLE
Fixed dependent rule execution is skipped for consequent input object #657

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.2.0-B2103008:
+
+- Bug fixes:
+  - Fixed dependent rule execution is skipped for consequent input objects. [#657](https://github.com/microsoft/PSRule/issues/657)
+
 ## v1.2.0-B2103008 (pre-release)
 
 What's changed since v1.1.0:

--- a/src/PSRule/Host/DependencyGraph.cs
+++ b/src/PSRule/Host/DependencyGraph.cs
@@ -10,6 +10,7 @@ namespace PSRule.Host
     {
         private readonly Dictionary<string, DependencyTarget> _Index;
         private readonly DependencyTarget[] _Targets;
+        private readonly Dictionary<DependencyTarget, DependencyTargetState> _State;
 
         // Track whether Dispose has been called.
         private bool _Disposed;
@@ -18,6 +19,7 @@ namespace PSRule.Host
         {
             _Targets = new DependencyTarget[targets.Length];
             _Index = new Dictionary<string, DependencyTarget>(targets.Length);
+            _State = new Dictionary<DependencyTarget, DependencyTargetState>(targets.Length);
             Prepare(targets);
         }
 
@@ -45,12 +47,16 @@ namespace PSRule.Host
             public readonly DependencyGraph<T> Graph;
             public readonly T Value;
 
-            private DependencyTargetState State;
-
             public DependencyTarget(DependencyGraph<T> graph, T value)
             {
                 Graph = graph;
                 Value = value;
+            }
+
+            private DependencyTargetState State
+            {
+                get { return Graph._State.TryGetValue(this, out DependencyTargetState state) ? state : DependencyTargetState.None; }
+                set { Graph._State[this] = value; }
             }
 
             public bool Skipped
@@ -86,6 +92,7 @@ namespace PSRule.Host
 
         public IEnumerable<DependencyTarget> GetSingleTarget()
         {
+            _State.Clear();
             for (var t = 0; t < _Targets.Length; t++)
             {
                 var target = _Targets[t];

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -20,7 +20,7 @@ namespace PSRule.Rules
     /// <summary>
     /// Define an instance of a rule block. Each rule block has a unique id.
     /// </summary>
-    [DebuggerDisplay("{RuleId} @{SourcePath}")]
+    [DebuggerDisplay("{RuleId} @{Source.Path}")]
     public sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable
     {
         internal RuleBlock(SourceFile source, string ruleName, RuleHelpInfo info, PowerShell condition, TagSet tag, string[] dependsOn, Hashtable configuration, RuleExtent extent, ActionPreference errorPreference)

--- a/tests/PSRule.Tests/FromFileDependency.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileDependency.Rule.ps1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Synopsis: Tests for dependencies
+Rule 'Rule.1' {
+    $TargetObject
+}
+
+# Synopsis: Tests for dependencies
+Rule 'Rule.2' -DependsOn 'Rule.1' {
+    $TargetObject
+}
+
+# Synopsis: Tests for dependencies
+Rule 'Rule.3' -DependsOn 'Rule.2' {
+    $TargetObject
+}
+
+# Synopsis: Tests for dependencies
+Rule 'Rule.4' -DependsOn 'Rule.1' {
+    !$TargetObject
+}
+
+# Synopsis: Tests for dependencies
+Rule 'Rule.5' -DependsOn 'Rule.4' {
+    !$TargetObject
+}

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -187,6 +187,31 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             ($result | Where-Object -FilterScript { $_.RuleName -eq 'WithDependency2' }).Outcome | Should -Be 'None';
             ($result | Where-Object -FilterScript { $_.RuleName -eq 'WithDependency1' }).Outcome | Should -Be 'None';
 
+            # Multiple objects
+            $dependsRuleFilePath = Join-Path -Path $here -ChildPath 'FromFileDependency.Rule.ps1';
+            $result = @($True, $False, $True | Invoke-PSRule -Path $dependsRuleFilePath -Outcome All);
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 15;
+            # True
+            $result[0..2].Outcome | Should -BeIn Pass;
+            $result[0..2].OutcomeReason | Should -BeIn Processed;
+            $result[3].Outcome | Should -BeIn Fail;
+            $result[3].OutcomeReason | Should -BeIn Processed;
+            $result[4].Outcome | Should -BeIn None;
+            $result[4].OutcomeReason | Should -BeIn DependencyFail;
+            # False
+            $result[5].Outcome | Should -BeIn Fail;
+            $result[5].OutcomeReason | Should -BeIn Processed;
+            $result[6..9].Outcome | Should -BeIn None;
+            $result[6..9].OutcomeReason | Should -BeIn DependencyFail;
+            # True
+            $result[10..12].Outcome | Should -BeIn Pass;
+            $result[10..12].OutcomeReason | Should -BeIn Processed;
+            $result[13].Outcome | Should -BeIn Fail;
+            $result[13].OutcomeReason | Should -BeIn Processed;
+            $result[14].Outcome | Should -BeIn None;
+            $result[14].OutcomeReason | Should -BeIn DependencyFail;
+
             # Same module, cross file
             $testModuleSourcePath = Join-Path $here -ChildPath 'TestModule2';
             $Null = Import-Module $testModuleSourcePath;
@@ -247,7 +272,8 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
         }
 
         It 'Returns error with bad path' {
-            { $testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'NotAFile.ps1') } | Should -Throw -ExceptionType System.IO.FileNotFoundException;
+            $notFilePath = Join-Path -Path $here -ChildPath 'NotAFile.ps1';
+            { $testObject | Invoke-PSRule -Path $notFilePath } | Should -Throw -ExceptionType System.IO.FileNotFoundException;
         }
 
         It 'Returns warning with empty path' {


### PR DESCRIPTION
## PR Summary

- Fixed dependent rule execution is skipped for consequent input objects. #657

Fixes #657 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
