### PR TITLE
Added support for object expansion with conventions #661

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,10 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+- Engine features:
+  - Added support for object expansion with conventions. [#661](https://github.com/microsoft/PSRule/issues/661)
+    - Use the `$PSRule.Import` method to import child source objects into the pipeline.
+
 ## v1.2.0-B2103016 (pre-release)
 
 What's changed since pre-release v1.2.0-B2103008:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -166,7 +166,8 @@ An object representing the current context during execution.
 
 The following properties are available for read access:
 
-- `Field` - A hashtable of custom bound fields. See option `Binding.Field` for more information.
+- `Field` - A hashtable of custom bound fields.
+See option `Binding.Field` for more information.
 - `TargetObject` - The object currently being processed on the pipeline.
 - `TargetName` - The name of the object currently being processed on the pipeline.
 This property will automatically default to `TargetName` or `Name` properties of the object if they exist.
@@ -175,7 +176,8 @@ This property will automatically bind to `PSObject.TypeNames[0]` by default.
 
 The following properties are available for read/ write access:
 
-- `Data` - A hashtable of custom data. This property can be populated during rule execution.
+- `Data` - A hashtable of custom data.
+This property can be populated during rule or begin/ process convention execution.
 Custom data is not used by PSRule directly, and is intended to be used by downstream processes that need to interpret PSRule results.
 
 To bind fields that already exist on the target object use custom binding and `Binding.Field`.
@@ -193,6 +195,9 @@ If the field does not exist on the object, an object is not returned.
 The parameter `sourceObject` should be a `InputFileInfo`,`FileInfo`, or `Uri` object.
 If more than one object is contained in the file, only the first object is returned.
 When the source file contains no objects null is returned.
+- `Import(PSObject[] sourceObject)` - Imports one or more source objects into the pipeline.
+Use this method to expand an object into child objects that will be processed independently.
+Objects imported using this method will be excluded from the `Input.ObjectPath` option if set.
 
 The file format is detected based on the same file formats as the option `Input.Format`.
 i.e. Yaml, Json, Markdown, and PowerShell Data.

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -58,12 +58,37 @@ namespace PSRule
             return JsonConvert.SerializeObject(o, settings);
         }
 
+        public static bool TryTargetInfo(this PSObject o, out PSRuleTargetInfo targetInfo)
+        {
+            return TryProperty(o, PSRuleTargetInfo.PropertyName, out targetInfo);
+        }
+
+        public static void UseTargetInfo(this PSObject o, out PSRuleTargetInfo targetInfo)
+        {
+            if (TryTargetInfo(o, out targetInfo))
+                return;
+
+            targetInfo = new PSRuleTargetInfo();
+            o.Properties.Add(new PSNoteProperty(PSRuleTargetInfo.PropertyName, targetInfo));
+        }
+
         private static T ConvertValue<T>(object value)
         {
             if (value == null)
                 return default;
 
             return typeof(T).IsValueType ? (T)Convert.ChangeType(value, typeof(T)) : (T)value;
+        }
+
+        private static bool TryProperty<T>(PSObject o, string name, out T value)
+        {
+            value = default;
+            if (o.Properties[name] != null && o.Properties[name] is T tValue)
+            {
+                value = tValue;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -702,7 +702,7 @@ namespace PSRule.Pipeline
             if (!RequireModules() || !RequireSources())
                 return null;
 
-            return new InvokeRulePipeline(PrepareContext(BindTargetNameHook, BindTargetTypeHook, BindFieldHook), Source, PrepareReader(), PrepareWriter(), RuleOutcome.Processed);
+            return new InvokeRulePipeline(PrepareContext(BindTargetNameHook, BindTargetTypeHook, BindFieldHook), Source, PrepareWriter(), RuleOutcome.Processed);
         }
     }
 }

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -90,7 +90,7 @@ namespace PSRule.Pipeline
             if (!RequireModules() || !RequireSources())
                 return null;
 
-            return new InvokeRulePipeline(PrepareContext(BindTargetNameHook, BindTargetTypeHook, BindFieldHook), Source, PrepareReader(), PrepareWriter(), Option.Output.Outcome.Value);
+            return new InvokeRulePipeline(PrepareContext(BindTargetNameHook, BindTargetTypeHook, BindFieldHook), Source, PrepareWriter(), Option.Output.Outcome.Value);
         }
 
         protected override PipelineReader PrepareReader()
@@ -173,8 +173,8 @@ namespace PSRule.Pipeline
         // Track whether Dispose has been called.
         private bool _Disposed;
 
-        internal InvokeRulePipeline(PipelineContext context, Source[] source, PipelineReader reader, PipelineWriter writer, RuleOutcome outcome)
-            : base(context, source, reader, writer)
+        internal InvokeRulePipeline(PipelineContext context, Source[] source, PipelineWriter writer, RuleOutcome outcome)
+            : base(context, source, context.Reader, writer)
         {
             HostHelper.ImportResource(Source, Context);
             _RuleGraph = HostHelper.GetRuleBlockGraph(Source, Context);

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -255,6 +255,7 @@ namespace PSRule.Pipeline
             return PipelineContext.New(
                 option: Option,
                 hostContext: HostContext,
+                reader: PrepareReader(),
                 binder: new TargetBinder(bindTargetName, bindTargetType, bindField, Option.Input.TargetType),
                 baseline: GetOptionContext(),
                 unresolved: unresolved

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -39,13 +39,12 @@ namespace PSRule.Pipeline
 
         internal PSRuleOption Option;
 
-        //internal ExecutionScope ExecutionScope;
-
         internal readonly Dictionary<string, Hashtable> LocalizedDataCache;
         internal readonly Dictionary<string, object> ExpressionCache;
         internal readonly Dictionary<string, PSObject[]> ContentCache;
         internal readonly OptionContext Baseline;
         internal readonly HostContext HostContext;
+        internal readonly PipelineReader Reader;
 
         public HashAlgorithm ObjectHashAlgorithm
         {
@@ -58,10 +57,11 @@ namespace PSRule.Pipeline
             }
         }
 
-        private PipelineContext(PSRuleOption option, HostContext hostContext, TargetBinder binder, OptionContext baseline, IDictionary<string, ResourceRef> unresolved)
+        private PipelineContext(PSRuleOption option, HostContext hostContext, PipelineReader reader, TargetBinder binder, OptionContext baseline, IDictionary<string, ResourceRef> unresolved)
         {
             Option = option;
             HostContext = hostContext;
+            Reader = reader;
             _LanguageMode = option.Execution.LanguageMode ?? ExecutionOption.Default.LanguageMode.Value;
             _NameTokenCache = new Dictionary<string, NameToken>();
             LocalizedDataCache = new Dictionary<string, Hashtable>();
@@ -72,9 +72,9 @@ namespace PSRule.Pipeline
             _Unresolved = unresolved;
         }
 
-        public static PipelineContext New(PSRuleOption option, HostContext hostContext, TargetBinder binder, OptionContext baseline, IDictionary<string, ResourceRef> unresolved)
+        public static PipelineContext New(PSRuleOption option, HostContext hostContext, PipelineReader reader, TargetBinder binder, OptionContext baseline, IDictionary<string, ResourceRef> unresolved)
         {
-            var context = new PipelineContext(option, hostContext, binder, baseline, unresolved);
+            var context = new PipelineContext(option, hostContext, reader, binder, baseline, unresolved);
             CurrentThread = context;
             return context;
         }

--- a/src/PSRule/Pipeline/PipelineReader.cs
+++ b/src/PSRule/Pipeline/PipelineReader.cs
@@ -25,12 +25,12 @@ namespace PSRule.Pipeline
 
         public bool IsEmpty => _Queue.IsEmpty;
 
-        public void Enqueue(PSObject sourceObject)
+        public void Enqueue(PSObject sourceObject, bool skipExpansion = false)
         {
             if (sourceObject == null)
                 return;
 
-            if (_Input == null)
+            if (_Input == null || skipExpansion)
             {
                 _Queue.Enqueue(sourceObject);
                 return;

--- a/src/PSRule/Pipeline/PipelineReciever.cs
+++ b/src/PSRule/Pipeline/PipelineReciever.cs
@@ -332,13 +332,18 @@ namespace PSRule.Pipeline
                 return;
 
             if (!value.HasProperty(PropertyName_PSPath))
-                value.Properties.Add(new PSNoteProperty(PropertyName_PSPath, source.PSPath));
+               value.Properties.Add(new PSNoteProperty(PropertyName_PSPath, source.PSPath));
 
             if (!value.HasProperty(PropertyName_PSParentPath))
-                value.Properties.Add(new PSNoteProperty(PropertyName_PSParentPath, source.PSParentPath));
+               value.Properties.Add(new PSNoteProperty(PropertyName_PSParentPath, source.PSParentPath));
 
             if (!value.HasProperty(PropertyName_PSChildName))
-                value.Properties.Add(new PSNoteProperty(PropertyName_PSChildName, source.PSChildName));
+               value.Properties.Add(new PSNoteProperty(PropertyName_PSChildName, source.PSChildName));
+
+            value.UseTargetInfo(out PSRuleTargetInfo targetInfo);
+            targetInfo.PSPath = source.PSPath;
+            targetInfo.PSParentPath = source.PSParentPath;
+            targetInfo.PSChildName = source.PSChildName;
         }
     }
 }

--- a/src/PSRule/Runtime/PSRule.cs
+++ b/src/PSRule/Runtime/PSRule.cs
@@ -128,5 +128,23 @@ namespace PSRule.Runtime
 
             return content[0];
         }
+
+        /// <summary>
+        /// Imports source objects into the pipeline for processing.
+        /// </summary>
+        public void Import(PSObject[] sourceObject)
+        {
+            if (sourceObject == null || sourceObject.Length == 0)
+                return;
+
+            RequireScope(RunspaceScope.ConventionBegin);
+            for (var i = 0; i < sourceObject.Length; i++)
+            {
+                if (sourceObject[i] == null)
+                    continue;
+
+                GetContext().Pipeline.Reader.Enqueue(sourceObject[i], skipExpansion: true);
+            }
+        }
     }
 }

--- a/src/PSRule/Runtime/PSRuleMemberInfo.cs
+++ b/src/PSRule/Runtime/PSRuleMemberInfo.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Runtime
+{
+    internal sealed class PSRuleTargetInfo
+    {
+        internal const string PropertyName = "_PSRule";
+
+        public string PSPath { get; internal set; }
+
+        public string PSParentPath { get; internal set; }
+
+        public string PSChildName { get; internal set; }
+    }
+}

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -856,7 +856,7 @@ namespace PSRule
 
         private static void SetContext()
         {
-            var context = PipelineContext.New(new Configuration.PSRuleOption(), null, null, null, null);
+            var context = PipelineContext.New(new Configuration.PSRuleOption(), null, null, null, null, null);
             var runspace = new RunspaceContext(context, null);
             runspace.PushScope(RunspaceScope.Rule);
         }

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -18,7 +18,7 @@ namespace PSRule
         [Fact]
         public void ReadBaseline()
         {
-            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, new OptionContext(), null), null);
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, new OptionContext(), null), null);
             var baseline = HostHelper.GetBaseline(GetSource(), context).ToArray();
             Assert.NotNull(baseline);
             Assert.Equal(5, baseline.Length);

--- a/tests/PSRule.Tests/ConfigTests.cs
+++ b/tests/PSRule.Tests/ConfigTests.cs
@@ -18,7 +18,7 @@ namespace PSRule
         [Fact]
         public void ReadModuleConfig()
         {
-            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, new OptionContext(), null), null);
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, new OptionContext(), null), null);
             var configuration = HostHelper.GetModuleConfig(GetSource(), context).ToArray();
             Assert.NotNull(configuration);
             Assert.Equal("Configuration1", configuration[0].Name);

--- a/tests/PSRule.Tests/FromFileConventions.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileConventions.Rule.ps1
@@ -34,6 +34,15 @@ Export-PSRuleConvention 'Convention3' -If { $Assert.HasFieldValue($TargetObject,
     $PSRule.Data.count += 1000;
 }
 
+# Synopsis: A convention for unit testing
+Export-PSRuleConvention 'Convention.Expansion' -If { $TargetObject.Name -eq 'TestObject1' } -Begin {
+    $newObject = [PSCustomObject]@{
+        Name = 'TestObject2'
+    };
+    $PSRule.Import($newObject);
+    $PSRule.Import(@($newObject, $newObject));
+}
+
 # Synopsis: A rule for testing conventions
 Rule 'ConventionTest' {
     $Assert.HasFieldValue($PSRule.Data, 'count', 1);

--- a/tests/PSRule.Tests/PSRule.Conventions.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Conventions.Tests.ps1
@@ -83,5 +83,13 @@ Describe 'PSRule -- Conventions' -Tag 'Conventions' {
             $result | Should -Not -BeNullOrEmpty;
             $result[0].Data.Order | Should -Be 'Convention1|M4.Convention1|M4.Convention2|';
         }
+
+        It 'Expands input object' {
+            $result = @(Invoke-PSRule @invokeParams -Name 'ConventionTest' -Convention 'Convention.Expansion');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 4;
+            $result[0].TargetName | Should -Be 'TestObject1';
+            $result[1].TargetName | Should -Be 'TestObject2';
+        }
     }
 }

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -4,9 +4,7 @@
 using PSRule.Configuration;
 using PSRule.Pipeline;
 using PSRule.Resources;
-using PSRule.Rules;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Management.Automation;
@@ -57,7 +55,7 @@ namespace PSRule
         public void PipelineWithInvariantCulture()
         {
             PSRuleOption.UseCurrentCulture(CultureInfo.InvariantCulture);
-            var context = PipelineContext.New(GetOption(), null, null, new OptionContext(), null);
+            var context = PipelineContext.New(GetOption(), null, null, null, new OptionContext(), null);
             var writer = new TestWriter(GetOption());
             var pipeline = new GetRulePipeline(context, GetSource(), new PipelineReader(null, null), writer, false);
             try

--- a/tests/PSRule.Tests/TargetNameBindingTests.cs
+++ b/tests/PSRule.Tests/TargetNameBindingTests.cs
@@ -28,7 +28,7 @@ namespace PSRule
             var pso1 = PSObject.AsPSObject(testObject1);
             var pso2 = PSObject.AsPSObject(testObject2);
 
-            PipelineContext.CurrentThread = PipelineContext.New(option: new PSRuleOption(), hostContext: null, binder: new TargetBinder(null, null, null, null), baseline: null, unresolved: null);
+            PipelineContext.CurrentThread = PipelineContext.New(option: new PSRuleOption(), hostContext: null, reader: null, binder: new TargetBinder(null, null, null, null), baseline: null, unresolved: null);
             var actual1 = PipelineHookActions.BindTargetName(null, false, pso1);
             var actual2 = PipelineHookActions.BindTargetName(null, false, pso2);
 


### PR DESCRIPTION
## PR Summary

- Added support for object expansion with conventions. #661
  - Use the `$PSRule.Import` method to import child source objects into the pipeline.

Fixes #661 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
