### PR TITLE
Pre-release v1.2.0-B2103023

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,10 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.2.0-B2103023 (pre-release)
+
+What's changed since pre-release v1.2.0-B2103016:
+
 - Engine features:
   - Added support for object expansion with conventions. [#661](https://github.com/microsoft/PSRule/issues/661)
     - Use the `$PSRule.Import` method to import child source objects into the pipeline.
@@ -23,7 +27,7 @@ What's changed since v1.1.0:
 
 - Engine features:
   - Added support for extensibility with conventions. [#650](https://github.com/microsoft/PSRule/issues/650)
-    - Conventions provide an extensibility point within PSRule to execution actions within the pipeline.
+    - Conventions provide an extensibility point within PSRule to execute actions within the pipeline.
     - A convention can expose `Begin`, `Process`, and `End` blocks.
     - In additional to within rules `$PSRule.Data` can be accessed from `Begin` and `Process` blocks.
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.2.0-B2103016:

- Engine features:
  - Added support for object expansion with conventions. #661
    - Use the `$PSRule.Import` method to import child source objects into the pipeline.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
