### PR TITLE
Improved file support #664 #665

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,15 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.2.0-B2103023:
+
+- General improvements:
+  - Added support for detecting files headers from additional file extensions. [#664](https://github.com/microsoft/PSRule/issues/664)
+    - Added `.bicep`, `.csx`, `.jsx`, `.groovy`, `.java`, `.json`, `.jsonc`,
+    `.scala`, `.rb`, `.bat`, `.cmd`.
+    - Added support for `Jenkinsfile` and `Dockerfile` without an extension.
+  - Added support for automatic type binding with files that do not have a file extension. [#665](https://github.com/microsoft/PSRule/issues/665)
+
 ## v1.2.0-B2103023 (pre-release)
 
 What's changed since pre-release v1.2.0-B2103016:

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -130,6 +130,11 @@ When the `-InputPath` parameter is used with a file path or URL.
 If the `Detect` format is used, the file extension will be used to automatically detect the format.
 When `-InputPath` is not used, `Detect` is the same as `None`.
 
+When this option is set to `File` PSRule scans the path and subdirectories specified by `-InputPath`.
+Files are treated as objects instead of being deserialized.
+Additional, PSRule uses the file extension as the object type.
+When files have no extension the whole file name is used.
+
 See `about_PSRule_Options` for details.
 
 This parameter takes precedence over the `Input.Format` option if set.

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -272,6 +272,11 @@ When the `-InputPath` parameter is used with a file path or URL.
 If the `Detect` format is used, the file extension will be used to automatically detect the format.
 When `-InputPath` is not used, `Detect` is the same as `None`.
 
+When this option is set to `File` PSRule scans the path and subdirectories specified by `-InputPath`.
+Files are treated as objects instead of being deserialized.
+Additional, PSRule uses the file extension as the object type.
+When files have no extension the whole file name is used.
+
 See `about_PSRule_Options` for details.
 
 This parameter takes precedence over the `Input.Format` option if set.

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -181,6 +181,11 @@ When the `-InputPath` parameter is used with a file path or URL.
 If the `Detect` format is used, the file extension will be used to automatically detect the format.
 When `-InputPath` is not used, `Detect` is the same as `None`.
 
+When this option is set to `File` PSRule scans the path and subdirectories specified by `-InputPath`.
+Files are treated as objects instead of being deserialized.
+Additional, PSRule uses the file extension as the object type.
+When files have no extension the whole file name is used.
+
 See `about_PSRule_Options` for details.
 
 This parameter takes precedence over the `Input.Format` option if set.

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -187,9 +187,14 @@ When set, detection by file extension is skipped.
 
 Prefix detection for line comments is supported with the following file extensions:
 
-- `.cs`, `.ts`, `.js`, `.fs`, `.go`, `.php`, `.cpp`, `.h` - Use a prefix of (`// `).
-- `.ps1`, `.psd1`, `.psm1`, `.yaml`, `.yml`, `.r`, `.py`, `.sh`, `.tf`, `.tfvars`, `.gitignore`, `.pl` - Use a prefix of (`# `).
+- `.bicep`, `.cs`, `.csx` `.ts`, `.js`, `.jsx`,
+`.fs`, `.go`, `.groovy`, `.php`, `.cpp`, `.h`,
+`.java`, `.json`, `.jsonc`, `.scala`, `Jenkinsfile` - Use a prefix of (`// `).
+- `.ps1`, `.psd1`, `.psm1`, `.yaml`, `.yml`,
+`.r`, `.py`, `.sh`, `.tf`, `.tfvars`, `.gitignore`,
+`.pl`, `.rb`, `Dockerfile` - Use a prefix of (`# `).
 - `.sql`, `.lau` - Use a prefix of (`-- `).
+- `.bat`, `.cmd` - Use a prefix of (`:: `).
 
 Reasons include:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -574,9 +574,12 @@ The `Markdown` format does not parse the whole markdown document.
 Specifically this format deserializes YAML front matter from the top of the document if any exists.
 
 The `File` format does not deserialize file contents.
+Each file is returned as an object.
 Files within `.git` sub-directories are ignored.
 Path specs specified in `.gitignore` directly in the current working path are ignored.
 A `RepositoryInfo` object is generated if the current working path if a `.git` sub-directory is present.
+Additionally, PSRule performs automatic type binding for file objects, using the extension as the type.
+When files have no extension the whole file name is used.
 
 Detect uses the following file extensions:
 

--- a/src/PSRule/Data/InputFileInfo.cs
+++ b/src/PSRule/Data/InputFileInfo.cs
@@ -10,6 +10,8 @@ namespace PSRule.Data
         private const char Backslash = '\\';
         private const char Slash = '/';
 
+        private readonly string _TargetType;
+
         internal readonly bool IsUrl;
 
         internal InputFileInfo(string basePath, string path)
@@ -25,6 +27,7 @@ namespace PSRule.Data
             Extension = Path.GetExtension(path);
             DirectoryName = Path.GetDirectoryName(path);
             DisplayName = FullName.Substring(basePath.Length).Replace(Backslash, Slash);
+            _TargetType = string.IsNullOrEmpty(Extension) ? Path.GetFileNameWithoutExtension(path) : Extension;
         }
 
         public string FullName { get; }
@@ -41,7 +44,7 @@ namespace PSRule.Data
 
         string ITargetInfo.TargetName => DisplayName;
 
-        string ITargetInfo.TargetType => Extension;
+        string ITargetInfo.TargetType => _TargetType;
 
         /// <summary>
         /// Convert to string.

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -760,7 +760,7 @@ namespace PSRule.Runtime
                 return Pass();
 
             if (string.IsNullOrEmpty(prefix))
-                prefix = DetectLinePrefix(Path.GetExtension(value));
+                prefix = DetectLinePrefix(GetFileType(value));
 
             var lineNo = 0;
             foreach (var content in File.ReadLines(value))
@@ -1147,20 +1147,38 @@ namespace PSRule.Runtime
         }
 
         /// <summary>
+        /// Get the file extension of the name of the file if an extension is not set.
+        /// </summary>
+        private static string GetFileType(string value)
+        {
+            var ext = Path.GetExtension(value);
+            return string.IsNullOrEmpty(ext) ? Path.GetFileNameWithoutExtension(value) : ext;
+        }
+
+        /// <summary>
         /// Determine line comment prefix by file extension
         /// </summary>
         private static string DetectLinePrefix(string extension)
         {
             switch (extension)
             {
+                case ".bicep":
                 case ".cs":
+                case ".csx":
                 case ".ts":
                 case ".js":
+                case ".jsx":
                 case ".fs":
                 case ".go":
+                case ".groovy":
                 case ".php":
                 case ".cpp":
                 case ".h":
+                case ".java":
+                case ".json":
+                case ".jsonc":
+                case ".scala":
+                case "Jenkinsfile":
                     return "// ";
 
                 case ".ps1":
@@ -1175,11 +1193,17 @@ namespace PSRule.Runtime
                 case ".tfvars":
                 case ".gitignore":
                 case ".pl":
+                case ".rb":
+                case "Dockerfile":
                     return "# ";
 
                 case ".sql":
                 case ".lua":
                     return "-- ";
+
+                case ".bat":
+                case ".cmd":
+                    return ":: ";
 
                 default:
                     return string.Empty;

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -833,11 +833,19 @@ namespace PSRule
         {
             SetContext();
             var assert = GetAssertionHelper();
+            var header = new string[] { "Copyright (c) Microsoft Corporation.", "Licensed under the MIT License." };
 
+            // .ps1
             var value = GetObject((name: "FullName", value: GetSourcePath("FromFile.Rule.ps1")));
-            Assert.True(assert.FileHeader(value, "FullName", new string[] { "Copyright (c) Microsoft Corporation.", "Licensed under the MIT License." }).Result);
+            Assert.True(assert.FileHeader(value, "FullName", header).Result);
+
+            // .yaml
             value = GetObject((name: "FullName", value: GetSourcePath("Baseline.Rule.yaml")));
-            Assert.False(assert.FileHeader(value, "FullName", new string[] { "Copyright (c) Microsoft Corporation.", "Licensed under the MIT License." }).Result);
+            Assert.False(assert.FileHeader(value, "FullName", header).Result);
+
+            // Dockerfile
+            value = GetObject((name: "FullName", value: GetSourcePath("Dockerfile")));
+            Assert.True(assert.FileHeader(value, "FullName", header).Result);
         }
 
         [Fact]

--- a/tests/PSRule.Tests/Dockerfile
+++ b/tests/PSRule.Tests/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+ARG MODULE_VERSION=1.1.0
+
+FROM mcr.microsoft.com/powershell:7.1.2-alpine-3.12-20210211
+SHELL ["pwsh", "-Command"]
+RUN $ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue; \
+    $Null = New-Item -Path /ps_modules/ -ItemType Directory -Force; \
+    Save-Module -Name PSRule -RequiredVersion ${MODULE_VERSION} -Force -Path /ps_modules/;
+
+COPY LICENSE README.md powershell.ps1 /
+CMD ["pwsh", "-File", "/powershell.ps1"]

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -168,6 +168,7 @@ Rule 'WithFileFormat' {
     $Assert.HasFieldValue($TargetObject, 'DisplayName');
     $PSRule.Data['FullName'] = $TargetObject.FullName;
     $PSRule.Data['DisplayName'] = $TargetObject.DisplayName;
+    $PSRule.Data['TargetType'] = $PSRule.TargetType;
 }
 
 # Synopsis: Test $PSRule automatic variables

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -633,6 +633,10 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             # Success only
             $filteredResult = @($result | Where-Object { $_.Outcome -ne 'Pass' });
             $filteredResult | Should -BeNullOrEmpty;
+
+            # Dockerfile
+            $filteredResult = @($result | Where-Object { $_.Data.FullName.Replace('\', '/') -like '*/Dockerfile' });
+            $filteredResult[0].Data.TargetType | Should -Be 'Dockerfile';
         }
 
         It 'Globbing processes paths' {

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -27,6 +27,9 @@
     <None Update="Baseline.Rule.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Dockerfile">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="FromFile.Rule.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## PR Summary

- Added support for detecting files headers from additional file extensions. #664
  - Added `.bicep`, `.csx`, `.jsx`, `.groovy`, `.java`, `.json`, `.jsonc`,
  `.scala`, `.rb`, `.bat`, `.cmd`.
  - Added support for `Jenkinsfile` and `Dockerfile` without an extension.
- Added support for automatic type binding with files that do not have a file extension. #665

Fixes #664 
Fixes #665 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
