### PR TITLE
Added support to prefer target info #670

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Binding.Field](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingfield)
   - [Binding.IgnoreCase](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingignorecase)
   - [Binding.NameSeparator](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingnameseparator)
+  - [Binding.PreferTargetInfo](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingprefertargetinfo)
   - [Binding.TargetName](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingtargetname)
   - [Binding.TargetType](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingtargettype)
   - [Binding.UseQualifiedName](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingusequalifiedname)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.2.0-B2103031:
+
+- General improvements:
+  - Added support for preferring automatic binding over custom binding configurations. [#670](https://github.com/microsoft/PSRule/issues/670)
+    - Added the `Binding.PreferTargetInfo` option to prefer target info specified by the object.
+
 ## 1.2.0-B2103031 (pre-release)
 
 What's changed since pre-release v1.2.0-B2103023:

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -16,21 +16,22 @@ Evaluate objects against matching rules and assert any failures.
 ### Input (Default)
 
 ```text
-Assert-PSRule [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>] [-Style <OutputStyle>]
- [-Outcome <RuleOutcome>] [-As <ResultFormat>] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>]
- [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>]
- [-TargetType <String[]>] [-Culture <String[]>] -InputObject <PSObject> [-ResultVariable <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Assert-PSRule [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>]
+ [-Convention <String[]>] [-Style <OutputStyle>] [-Outcome <RuleOutcome>] [-As <ResultFormat>]
+ [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-OutputPath <String>]
+ [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
+ [-Culture <String[]>] -InputObject <PSObject> [-ResultVariable <String>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### InputPath
 
 ```text
 Assert-PSRule -InputPath <String[]> [-Module <String[]>] [-Format <InputFormat>] [-Baseline <BaselineOption>]
- [-Style <OutputStyle>] [-Outcome <RuleOutcome>] [-As <ResultFormat>] [[-Path] <String[]>] [-Name <String[]>]
- [-Tag <Hashtable>] [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>]
- [-ObjectPath <String>] [-TargetType <String[]>] [-Culture <String[]>] [-ResultVariable <String>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-Convention <String[]>] [-Style <OutputStyle>] [-Outcome <RuleOutcome>] [-As <ResultFormat>]
+ [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-OutputPath <String>]
+ [-OutputFormat <OutputFormat>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
+ [-Culture <String[]>] [-ResultVariable <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -169,9 +170,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Convention
+
+Specifies conventions by name to execute in the pipeline when processing objects.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Culture
 
-Specifies the culture to use for rule documentation and messages. By default, the culture of PowerShell is used.
+Specifies the culture to use for rule documentation and messages.
+By default, the culture of PowerShell is used.
 
 This option does not affect the culture used for the PSRule engine, which always uses the culture of PowerShell.
 
@@ -462,6 +480,22 @@ Accept pipeline input: True (ByValue)
 Accept wildcard characters: False
 ```
 
+### -ResultVariable
+
+Stores output result objects in the specified variable.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -WhatIf
 
 Shows what would happen if the cmdlet runs.
@@ -487,22 +521,6 @@ Prompts you for confirmation before running the cmdlet.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: cf
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -ResultVariable
-
-Stores output result objects in the specified variable.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -17,9 +17,10 @@ Evaluate objects against matching rules and output the results.
 
 ```text
 Invoke-PSRule [-Module <String[]>] [-Outcome <RuleOutcome>] [-As <ResultFormat>] [-Format <InputFormat>]
- [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Baseline <BaselineOption>] [[-Path] <String[]>]
- [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>]
- [-Culture <String[]>] -InputObject <PSObject> [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Baseline <BaselineOption>] [-Convention <String[]>]
+ [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>]
+ [-TargetType <String[]>] [-Culture <String[]>] -InputObject <PSObject> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ### InputPath
@@ -27,8 +28,9 @@ Invoke-PSRule [-Module <String[]>] [-Outcome <RuleOutcome>] [-As <ResultFormat>]
 ```text
 Invoke-PSRule -InputPath <String[]> [-Module <String[]>] [-Outcome <RuleOutcome>] [-As <ResultFormat>]
  [-Format <InputFormat>] [-OutputPath <String>] [-OutputFormat <OutputFormat>] [-Baseline <BaselineOption>]
- [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>]
- [-TargetType <String[]>] [-Culture <String[]>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Convention <String[]>] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>]
+ [-ObjectPath <String>] [-TargetType <String[]>] [-Culture <String[]>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -294,6 +296,60 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Baseline
+
+Specifies an explicit baseline by name to use for evaluating rules.
+Baselines can contain filters and custom configuration that overrides the defaults.
+
+```yaml
+Type: BaselineOption
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Convention
+
+Specifies conventions by name to execute in the pipeline when processing objects.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Culture
+
+Specifies the culture to use for rule documentation and messages.
+By default, the culture of PowerShell is used.
+
+This option does not affect the culture used for the PSRule engine, which always uses the culture of PowerShell.
+
+The PowerShell cmdlet `Get-Culture` shows the current culture of PowerShell.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ObjectPath
 
 The name of a property to use instead of the pipeline object.
@@ -418,26 +474,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -Culture
-
-Specifies the culture to use for rule documentation and messages. By default, the culture of PowerShell is used.
-
-This option does not affect the culture used for the PSRule engine, which always uses the culture of PowerShell.
-
-The PowerShell cmdlet `Get-Culture` shows the current culture of PowerShell.
-
-```yaml
-Type: String[]
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -Confirm
 
 Prompts you for confirmation before running the cmdlet.
@@ -462,23 +498,6 @@ Shows what would happen if the cmdlet runs. The cmdlet is not run.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: wi
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Baseline
-
-Specifies an explicit baseline by name to use for evaluating rules.
-Baselines can contain filters and custom configuration that overrides the defaults.
-
-```yaml
-Type: BaselineOption
-Parameter Sets: (All)
-Aliases:
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -19,12 +19,14 @@ Create options to configure PSRule execution.
 New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
- [-BindingNameSeparator <String>] [-TargetName <String[]>] [-TargetType <String[]>]
- [-BindingUseQualifiedName <Boolean>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
+ [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
+ [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -33,12 +35,14 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
 New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-SuppressTargetName <SuppressionOption>] [-BindTargetName <BindTargetName[]>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
- [-BindingNameSeparator <String>] [-TargetName <String[]>] [-TargetType <String[]>]
- [-BindingUseQualifiedName <Boolean>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
+ [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
+ [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -46,12 +50,14 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
 ```text
 New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTargetName <SuppressionOption>]
  [-BindTargetName <BindTargetName[]>] [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>]
- [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-TargetName <String[]>] [-TargetType <String[]>]
- [-BindingUseQualifiedName <Boolean>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>]
+ [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
+ [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
+ [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -248,7 +254,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -281,6 +287,42 @@ See about_PSRule_Options for more information.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BindingPreferTargetInfo
+
+Sets the option `Binding.PreferTargetInfo`.
+This option specifies if automatic binding is preferred over configured binding options.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Convention
+
+Sets the `Option.ConventionInclude` option.
+This option specifies the name of conventions to execute in the pipeline when processing objects.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: ConventionInclude
 
 Required: False
 Position: Named
@@ -406,6 +448,24 @@ See about_PSRule_Options for more information.
 Type: String
 Parameter Sets: (All)
 Aliases: InputObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputPathIgnore
+
+Sets the `Input.PathIgnore` option.
+If specified, files that match the path spec will not be processed.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -568,6 +628,24 @@ Accepted values: None, Yaml, Json, Markdown, NUnit3, Csv, Wide
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputOutcome
+
+Sets the `Output.Outcome` option.
+This option can be set to include or exclude output results.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: RuleOutcome
+Parameter Sets: (All)
+Aliases: Outcome
+
+Required: False
+Position: Named
+Default value: Processed
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -16,12 +16,13 @@ Sets options that configure PSRule execution.
 ```text
 Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-AllowClobber]
  [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>] [-BindingNameSeparator <String>]
- [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-ObjectPath <String>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm]
+ [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
+ [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-InconclusiveWarning <Boolean>]
+ [-NotProcessedWarning <Boolean>] [-Format <InputFormat>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
+ [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -155,7 +156,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -188,6 +189,42 @@ See about_PSRule_Options for more information.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BindingPreferTargetInfo
+
+Sets the option `Binding.PreferTargetInfo`.
+This option specifies if automatic binding is preferred over configured binding options.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Convention
+
+Sets the `Option.ConventionInclude` option.
+This option specifies the name of conventions to execute in the pipeline when processing objects.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases: ConventionInclude
 
 Required: False
 Position: Named
@@ -311,6 +348,24 @@ Sets the `Input.ObjectPath` option to use an object path to use instead of the p
 Type: String
 Parameter Sets: (All)
 Aliases: InputObjectPath
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputPathIgnore
+
+Sets the `Input.PathIgnore` option.
+If specified, files that match the path spec will not be processed.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named
@@ -469,6 +524,24 @@ Accepted values: None, Yaml, Json, Markdown, NUnit3, Csv, Wide
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputOutcome
+
+Sets the `Output.Outcome` option.
+This option can be set to include or exclude output results.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: RuleOutcome
+Parameter Sets: (All)
+Aliases: Outcome
+
+Required: False
+Position: Named
+Default value: Processed
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -16,17 +16,18 @@ Pass or fail objects against matching rules.
 ### Input (Default)
 
 ```text
-Test-PSRuleTarget [-Module <String[]>] [-Outcome <RuleOutcome>] [-Format <InputFormat>] [[-Path] <String[]>]
- [-Name <String[]>] [-Tag <Hashtable>] -InputObject <PSObject> [-Option <PSRuleOption>] [-ObjectPath <String>]
- [-TargetType <String[]>] [-Culture <String>] [<CommonParameters>]
+Test-PSRuleTarget [-Module <String[]>] [-Outcome <RuleOutcome>] [-Format <InputFormat>]
+ [-Convention <String[]>] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] -InputObject <PSObject>
+ [-Option <PSRuleOption>] [-ObjectPath <String>] [-TargetType <String[]>] [-Culture <String>]
+ [<CommonParameters>]
 ```
 
 ### InputPath
 
 ```text
 Test-PSRuleTarget -InputPath <String[]> [-Module <String[]>] [-Outcome <RuleOutcome>] [-Format <InputFormat>]
- [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>] [-ObjectPath <String>]
- [-TargetType <String[]>] [-Culture <String>] [<CommonParameters>]
+ [-Convention <String[]>] [[-Path] <String[]>] [-Name <String[]>] [-Tag <Hashtable>] [-Option <PSRuleOption>]
+ [-ObjectPath <String>] [-TargetType <String[]>] [-Culture <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -203,6 +204,43 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Convention
+
+Specifies conventions by name to execute in the pipeline when processing objects.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Culture
+
+Specifies the culture to use for rule documentation and messages.
+By default, the culture of PowerShell is used.
+
+This option does not affect the culture used for the PSRule engine, which always uses the culture of PowerShell.
+
+The PowerShell cmdlet `Get-Culture` shows the current culture of PowerShell.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ObjectPath
 
 The name of a property to use instead of the pipeline object.
@@ -276,26 +314,6 @@ Parameter Sets: InputPath
 Aliases: f
 
 Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Culture
-
-Specifies the culture to use for rule documentation and messages. By default, the culture of PowerShell is used.
-
-This option does not affect the culture used for the PSRule engine, which always uses the culture of PowerShell.
-
-The PowerShell cmdlet `Get-Culture` shows the current culture of PowerShell.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-
-Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False

--- a/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
@@ -16,6 +16,7 @@ The following baseline options can be configured:
 - [Binding.Field](about_PSRule_Options.md#bindingfield)
 - [Binding.IgnoreCase](about_PSRule_Options.md#bindingignorecase)
 - [Binding.NameSeparator](about_PSRule_Options.md#bindingnameseparator)
+- [Binding.PreferTargetInfo](about_PSRule_Options.md#bindingprefertargetinfo)
 - [Binding.TargetName](about_PSRule_Options.md#bindingtargetname)
 - [Binding.TargetType](about_PSRule_Options.md#bindingtargettype)
 - [Binding.UseQualifiedName](about_PSRule_Options.md#bindingusequalifiedname)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -40,6 +40,7 @@ Additionally the following baseline options can be included:
 - [Binding.Field](#bindingfield)
 - [Binding.IgnoreCase](#bindingignorecase)
 - [Binding.NameSeparator](#bindingnameseparator)
+- [Binding.PreferTargetInfo](#bindingprefertargetinfo)
 - [Binding.TargetName](#bindingtargetname)
 - [Binding.TargetType](#bindingtargettype)
 - [Binding.UseQualifiedName](#bindingusequalifiedname)
@@ -231,6 +232,39 @@ Set-PSRuleOption -BindingNameSeparator '::';
 # YAML: Using the binding/nameSeparator property
 binding:
   nameSeparator: '::'
+```
+
+### Binding.PreferTargetInfo
+
+Some built-in objects within PSRule perform automatic binding of TargetName and TargetType.
+These built-in objects provide their own target info.
+
+When binding has been configured these values override automatic binding by default.
+This can occur when the built-in object uses one of the fields specified by the custom configuration.
+The common occurrences of this are on fields such as `Name` and `FullName` which are widely used.
+To prefer automatic binding when specified set this option to `$True`.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the BindingPreferTargetInfo parameter
+$option = New-PSRuleOption -BindingPreferTargetInfo $True;
+```
+
+```powershell
+# PowerShell: Using the Binding.PreferTargetInfo hashtable key
+$option = New-PSRuleOption -Option @{ 'Binding.PreferTargetInfo' = $True };
+```
+
+```powershell
+# PowerShell: Using the BindingPreferTargetInfo parameter to set YAML
+Set-PSRuleOption -BindingPreferTargetInfo $True;
+```
+
+```yaml
+# YAML: Using the binding/preferTargetInfo property
+binding:
+  preferTargetInfo: true
 ```
 
 ### Binding.TargetName
@@ -1038,9 +1072,6 @@ The following outcome options are available:
 This is the default option.
 - `All` - All results for rules are returned.
 
-This option is ignored by `Assert-PSRule`.
-`Assert-PSRule` will always use `Processed`.
-
 This option can be specified using:
 
 ```powershell
@@ -1364,6 +1395,7 @@ binding:
     - AlternativeId
   ignoreCase: false
   nameSeparator: '::'
+  preferTargetInfo: true
   targetName:
   - ResourceName
   - AlternateName
@@ -1440,6 +1472,7 @@ binding:
   field: { }
   ignoreCase: true
   nameSeparator: '/'
+  preferTargetInfo: false
   targetName:
   - TargetName
   - Name
@@ -1469,5 +1502,7 @@ An online version of this document is available at https://github.com/Microsoft/
 
 - Options
 - PSRule
+- TargetInfo
+- Binding
 
 [about_PSRule_Assert]: about_PSRule_Assert.md

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -253,6 +253,13 @@
                     "markdownDescription": "Configures the separator to use for building a qualified name. The default is `/`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingnameseparator)",
                     "default": "/"
                 },
+                "preferTargetInfo": {
+                    "type": "boolean",
+                    "title": "Prefer target info",
+                    "description": "Determines if binding prefers target info provided by the object over custom configuration. The default is false.",
+                    "markdownDescription": "Determines if binding prefers target info provided by the object over custom configuration. The default is `false`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingprefertargetinfo)",
+                    "default": false
+                },
                 "targetName": {
                     "type": "array",
                     "title": "Bind TargetName",

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -69,6 +69,13 @@
                     "markdownDescription": "Configures the separator to use for building a qualified name. The default is `/`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingnameseparator)",
                     "default": "/"
                 },
+                "preferTargetInfo": {
+                    "type": "boolean",
+                    "title": "Prefer target info",
+                    "description": "Determines if binding prefers target info provided by the object over custom configuration. The default is false.",
+                    "markdownDescription": "Determines if binding prefers target info provided by the object over custom configuration. The default is `false`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#bindingprefertargetinfo)",
+                    "default": false
+                },
                 "targetName": {
                     "type": "array",
                     "title": "Bind TargetName",

--- a/src/PSRule.Benchmark/PSRule.cs
+++ b/src/PSRule.Benchmark/PSRule.cs
@@ -254,7 +254,7 @@ namespace PSRule.Benchmark
         {
             foreach (var targetObject in _TargetObject)
             {
-                PipelineHookActions.BindTargetName(null, false, targetObject);
+                PipelineHookActions.BindTargetName(null, false, false, targetObject);
             }
         }
 
@@ -266,6 +266,7 @@ namespace PSRule.Benchmark
                 PipelineHookActions.BindTargetName(
                     propertyNames: new string[] { "TargetName", "Name" },
                     caseSensitive: true,
+                    preferTargetInfo: false,
                     targetObject: targetObject
                 );
             }
@@ -279,6 +280,7 @@ namespace PSRule.Benchmark
                 PipelineHookActions.BindTargetName(
                     propertyNames: new string[] { "TargetName", "Name" },
                     caseSensitive: true,
+                    preferTargetInfo: false,
                     targetObject: targetObject
                 );
             }

--- a/src/PSRule/Configuration/BaselineOption.cs
+++ b/src/PSRule/Configuration/BaselineOption.cs
@@ -72,47 +72,50 @@ namespace PSRule.Configuration
         /// <param name="properties">One or more indexed properties.</param>
         internal static void Load(IBaselineSpec option, Dictionary<string, object> properties)
         {
-            if (properties.TryPopValue("binding.field", out Hashtable map))
+            if (properties.TryPopValue("Binding.Field", out Hashtable map))
                 option.Binding.Field = new FieldMap(map);
 
-            if (properties.TryPopBool("binding.ignorecase", out bool bvalue))
+            if (properties.TryPopBool("Binding.IgnoreCase", out bool bvalue))
                 option.Binding.IgnoreCase = bvalue;
 
-            if (properties.TryPopValue("binding.nameseparator", out object value))
+            if (properties.TryPopBool("Binding.PreferTargetInfo", out bvalue))
+                option.Binding.PreferTargetInfo = bvalue;
+
+            if (properties.TryPopValue("Binding.NameSeparator", out object value))
                 option.Binding.NameSeparator = value.ToString();
 
-            if (properties.TryPopValue("binding.targetname", out value))
+            if (properties.TryPopValue("Binding.TargetName", out value))
             {
                 if (value.GetType().IsArray)
                     option.Binding.TargetName = ((object[])value).OfType<string>().ToArray();
                 else
                     option.Binding.TargetName = new string[] { value.ToString() };
             }
-            if (properties.TryPopValue("binding.targettype", out value))
+            if (properties.TryPopValue("Binding.targettype", out value))
             {
                 if (value.GetType().IsArray)
                     option.Binding.TargetType = ((object[])value).OfType<string>().ToArray();
                 else
                     option.Binding.TargetType = new string[] { value.ToString() };
             }
-            if (properties.TryPopValue("binding.usequalifiedname", out bvalue))
+            if (properties.TryPopValue("Binding.UseQualifiedName", out bvalue))
                 option.Binding.UseQualifiedName = bvalue;
 
-            if (properties.TryPopValue("rule.include", out value))
+            if (properties.TryPopValue("Rule.Include", out value))
             {
                 if (value.GetType().IsArray)
                     option.Rule.Include = ((object[])value).OfType<string>().ToArray();
                 else
                     option.Rule.Include = new string[] { value.ToString() };
             }
-            if (properties.TryPopValue("rule.exclude", out value))
+            if (properties.TryPopValue("Rule.Exclude", out value))
             {
                 if (value.GetType().IsArray)
                     option.Rule.Exclude = ((object[])value).OfType<string>().ToArray();
                 else
                     option.Rule.Exclude = new string[] { value.ToString() };
             }
-            if (properties.TryPopValue("rule.tag", out Hashtable tag))
+            if (properties.TryPopValue("Rule.Tag", out Hashtable tag))
                 option.Rule.Tag = tag;
 
             // Process configuration values

--- a/src/PSRule/Configuration/BindingOption.cs
+++ b/src/PSRule/Configuration/BindingOption.cs
@@ -12,6 +12,7 @@ namespace PSRule.Configuration
     public sealed class BindingOption : IEquatable<BindingOption>
     {
         private const bool DEFAULT_IGNORECASE = true;
+        private const bool DEFAULT_PREFERTARGETINFO = false;
         private const string DEFAULT_NAMESEPARATOR = "/";
         private const bool DEFAULT_USEQUALIFIEDNAME = false;
 
@@ -19,6 +20,7 @@ namespace PSRule.Configuration
         {
             IgnoreCase = DEFAULT_IGNORECASE,
             NameSeparator = DEFAULT_NAMESEPARATOR,
+            PreferTargetInfo = DEFAULT_PREFERTARGETINFO,
             UseQualifiedName = DEFAULT_USEQUALIFIEDNAME
         };
 
@@ -27,6 +29,7 @@ namespace PSRule.Configuration
             Field = null;
             IgnoreCase = null;
             NameSeparator = null;
+            PreferTargetInfo = null;
             TargetName = null;
             TargetType = null;
             UseQualifiedName = null;
@@ -40,6 +43,7 @@ namespace PSRule.Configuration
             Field = option.Field;
             IgnoreCase = option.IgnoreCase;
             NameSeparator = option.NameSeparator;
+            PreferTargetInfo = option.PreferTargetInfo;
             TargetName = option.TargetName;
             TargetType = option.TargetType;
             UseQualifiedName = option.UseQualifiedName;
@@ -56,6 +60,7 @@ namespace PSRule.Configuration
                 Field == other.Field &&
                 IgnoreCase == other.IgnoreCase &&
                 NameSeparator == other.NameSeparator &&
+                PreferTargetInfo == other.PreferTargetInfo &&
                 TargetName == other.TargetName &&
                 TargetType == other.TargetType &&
                 UseQualifiedName == other.UseQualifiedName;
@@ -69,6 +74,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (Field != null ? Field.GetHashCode() : 0);
                 hash = hash * 23 + (IgnoreCase.HasValue ? IgnoreCase.Value.GetHashCode() : 0);
                 hash = hash * 23 + (NameSeparator != null ? NameSeparator.GetHashCode() : 0);
+                hash = hash * 23 + (PreferTargetInfo.HasValue ? PreferTargetInfo.Value.GetHashCode() : 0);
                 hash = hash * 23 + (TargetName != null ? TargetName.GetHashCode() : 0);
                 hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
                 hash = hash * 23 + (UseQualifiedName.HasValue ? UseQualifiedName.Value.GetHashCode() : 0);
@@ -83,6 +89,7 @@ namespace PSRule.Configuration
                 Field = o1.Field ?? o2.Field,
                 IgnoreCase = o1.IgnoreCase ?? o2.IgnoreCase,
                 NameSeparator = o1.NameSeparator ?? o2.NameSeparator,
+                PreferTargetInfo = o1.PreferTargetInfo ?? o2.PreferTargetInfo,
                 TargetName = o1.TargetName ?? o2.TargetName,
                 TargetType = o1.TargetType ?? o2.TargetType,
                 UseQualifiedName = o1.UseQualifiedName ?? o2.UseQualifiedName
@@ -107,6 +114,12 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public string NameSeparator { get; set; }
+
+        /// <summary>
+        /// Determines if binding prefers target info provided by the object over custom configuration.
+        /// </summary>
+        [DefaultValue(null)]
+        public bool? PreferTargetInfo { get; set; }
 
         /// <summary>
         /// One or more property names to use to bind TargetName.

--- a/src/PSRule/Configuration/PipelineHook.cs
+++ b/src/PSRule/Configuration/PipelineHook.cs
@@ -11,8 +11,8 @@ namespace PSRule.Configuration
     /// </summary>
     public delegate string BindTargetName(PSObject targetObject);
 
-    internal delegate string BindTargetMethod(string[] propertyNames, bool caseSensitive, PSObject targetObject);
-    internal delegate string BindTargetFunc(string[] propertyNames, bool caseSensitive, PSObject targetObject, BindTargetMethod next);
+    internal delegate string BindTargetMethod(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject);
+    internal delegate string BindTargetFunc(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, BindTargetMethod next);
 
     /// <summary>
     /// Hooks that provide customize pipeline execution.

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1031,6 +1031,10 @@ function New-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [String]$BindingNameSeparator = '/',
 
+        # Sets the Binding.PreferTargetInfo option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$BindingPreferTargetInfo = $False,
+
         # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
         [Alias('BindingTargetName')]
@@ -1237,6 +1241,10 @@ function Set-PSRuleOption {
         # Sets the Binding.NameSeparator option
         [Parameter(Mandatory = $False)]
         [String]$BindingNameSeparator = '/',
+
+        # Sets the Binding.PreferTargetInfo option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$BindingPreferTargetInfo = $False,
 
         # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
@@ -1852,6 +1860,10 @@ function SetOptions {
         [Parameter(Mandatory = $False)]
         [String]$BindingNameSeparator = '/',
 
+        # Sets the Binding.PreferTargetInfo option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$BindingPreferTargetInfo = $False,
+
         # Sets the Binding.TargetName option
         [Parameter(Mandatory = $False)]
         [Alias('BindingTargetName')]
@@ -1956,6 +1968,11 @@ function SetOptions {
         # Sets option Binding.IgnoreCase
         if ($PSBoundParameters.ContainsKey('BindingIgnoreCase')) {
             $Option.Binding.IgnoreCase = $BindingIgnoreCase;
+        }
+
+        # Sets option Binding.PreferTargetInfo
+        if ($PSBoundParameters.ContainsKey('BindingPreferTargetInfo')) {
+            $Option.Binding.PreferTargetInfo = $BindingPreferTargetInfo;
         }
 
         # Sets option Binding.Field

--- a/src/PSRule/Pipeline/OptionContext.cs
+++ b/src/PSRule/Pipeline/OptionContext.cs
@@ -20,6 +20,8 @@ namespace PSRule.Pipeline
 
         string NameSeparator { get; }
 
+        bool PreferTargetInfo { get; }
+
         string[] TargetName { get; }
 
         string[] TargetType { get; }
@@ -94,6 +96,7 @@ namespace PSRule.Pipeline
             public FieldMap Field;
             public bool? IgnoreCase;
             public string NameSeparator;
+            public bool? PreferTargetInfo;
             public string[] TargetName;
             public string[] TargetType;
             public bool? UseQualifiedName;
@@ -106,6 +109,7 @@ namespace PSRule.Pipeline
                 Field = option.Binding?.Field;
                 IgnoreCase = option.Binding?.IgnoreCase;
                 NameSeparator = option?.Binding?.NameSeparator;
+                PreferTargetInfo = option.Binding?.PreferTargetInfo;
                 TargetName = option.Binding?.TargetName;
                 TargetType = option.Binding?.TargetType;
                 UseQualifiedName = option.Binding?.UseQualifiedName;
@@ -141,6 +145,7 @@ namespace PSRule.Pipeline
             public FieldMap Field;
             public bool? IgnoreCase;
             public string NameSeparator;
+            public bool? PreferTargetInfo;
             public string[] TargetName;
             public string[] TargetType;
             public bool? UseQualifiedName;
@@ -154,6 +159,7 @@ namespace PSRule.Pipeline
                 Field = option.Binding?.Field;
                 IgnoreCase = option.Binding?.IgnoreCase;
                 NameSeparator = option?.Binding?.NameSeparator;
+                PreferTargetInfo = option.Binding?.PreferTargetInfo;
                 TargetName = option.Binding?.TargetName;
                 TargetType = option.Binding?.TargetType;
                 UseQualifiedName = option.Binding?.UseQualifiedName;
@@ -169,6 +175,7 @@ namespace PSRule.Pipeline
                 Field = spec.Binding?.Field;
                 IgnoreCase = spec.Binding?.IgnoreCase;
                 NameSeparator = spec?.Binding?.NameSeparator;
+                PreferTargetInfo = spec.Binding?.PreferTargetInfo;
                 TargetName = spec.Binding?.TargetName;
                 TargetType = spec.Binding?.TargetType;
                 UseQualifiedName = spec.Binding?.UseQualifiedName;
@@ -181,10 +188,11 @@ namespace PSRule.Pipeline
 
         private sealed class BindingOption : IBindingOption, IEquatable<BindingOption>
         {
-            public BindingOption(FieldMap[] field, bool ignoreCase, string nameSeparator, string[] targetName, string[] targetType, bool useQualifiedName)
+            public BindingOption(FieldMap[] field, bool ignoreCase, bool ignoreTargetInfo, string nameSeparator, string[] targetName, string[] targetType, bool useQualifiedName)
             {
                 Field = field;
                 IgnoreCase = ignoreCase;
+                PreferTargetInfo = ignoreTargetInfo;
                 NameSeparator = nameSeparator;
                 TargetName = targetName;
                 TargetType = targetType;
@@ -196,6 +204,8 @@ namespace PSRule.Pipeline
             public bool IgnoreCase { get; }
 
             public string NameSeparator { get; }
+
+            public bool PreferTargetInfo { get; }
 
             public string[] TargetName { get; }
 
@@ -214,6 +224,7 @@ namespace PSRule.Pipeline
                     Field == other.Field &&
                     IgnoreCase == other.IgnoreCase &&
                     NameSeparator == other.NameSeparator &&
+                    PreferTargetInfo == other.PreferTargetInfo &&
                     TargetName == other.TargetName &&
                     TargetType == other.TargetType &&
                     UseQualifiedName == other.UseQualifiedName;
@@ -227,6 +238,7 @@ namespace PSRule.Pipeline
                     hash = hash * 23 + (Field != null ? Field.GetHashCode() : 0);
                     hash = hash * 23 + (IgnoreCase ? IgnoreCase.GetHashCode() : 0);
                     hash = hash * 23 + (NameSeparator != null ? NameSeparator.GetHashCode() : 0);
+                    hash = hash * 23 + (PreferTargetInfo ? PreferTargetInfo.GetHashCode() : 0);
                     hash = hash * 23 + (TargetName != null ? TargetName.GetHashCode() : 0);
                     hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
                     hash = hash * 23 + (UseQualifiedName ? UseQualifiedName.GetHashCode() : 0);
@@ -283,10 +295,11 @@ namespace PSRule.Pipeline
             FieldMap[] field = new FieldMap[] { _Explicit?.Field, _WorkspaceBaseline?.Field, _ModuleBaseline?.Field, _ModuleConfig?.Field };
             bool ignoreCase = _Explicit?.IgnoreCase ?? _WorkspaceBaseline?.IgnoreCase ?? _ModuleBaseline?.IgnoreCase ?? _ModuleConfig?.IgnoreCase ?? Configuration.BindingOption.Default.IgnoreCase.Value;
             string nameSeparator = _Explicit?.NameSeparator ?? _WorkspaceBaseline?.NameSeparator ?? _ModuleBaseline?.NameSeparator ?? _ModuleConfig?.NameSeparator ?? Configuration.BindingOption.Default.NameSeparator;
+            bool preferTargetInfo = _Explicit?.PreferTargetInfo ?? _WorkspaceBaseline?.PreferTargetInfo ?? _ModuleBaseline?.PreferTargetInfo ?? _ModuleConfig?.PreferTargetInfo ?? Configuration.BindingOption.Default.PreferTargetInfo.Value;
             string[] targetName = _Explicit?.TargetName ?? _WorkspaceBaseline?.TargetName ?? _ModuleBaseline?.TargetName ?? _ModuleConfig?.TargetName;
             string[] targetType = _Explicit?.TargetType ?? _WorkspaceBaseline?.TargetType ?? _ModuleBaseline?.TargetType ?? _ModuleConfig?.TargetType;
             bool useQualifiedName = _Explicit?.UseQualifiedName ?? _WorkspaceBaseline?.UseQualifiedName ?? _ModuleBaseline?.UseQualifiedName ?? _ModuleConfig?.UseQualifiedName ?? Configuration.BindingOption.Default.UseQualifiedName.Value;
-            return _Binding = new BindingOption(field, ignoreCase, nameSeparator, targetName, targetType, useQualifiedName);
+            return _Binding = new BindingOption(field, ignoreCase, preferTargetInfo, nameSeparator, targetName, targetType, useQualifiedName);
         }
 
         public Dictionary<string, object> GetConfiguration()

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -413,15 +413,15 @@ namespace PSRule.Pipeline
         {
             // Nest the previous write action in the new supplied action
             // Execution chain will be: action -> previous -> previous..n
-            return (propertyNames, caseSensitive, targetObject) => action(propertyNames, caseSensitive, targetObject, previous);
+            return (propertyNames, caseSensitive, preferTargetInfo, targetObject) => action(propertyNames, caseSensitive, preferTargetInfo, targetObject, previous);
         }
 
         private static BindTargetMethod AddBindTargetAction(BindTargetName action, BindTargetMethod previous)
         {
-            return AddBindTargetAction((parameterNames, caseSensitive, targetObject, next) =>
+            return AddBindTargetAction((parameterNames, caseSensitive, preferTargetInfo, targetObject, next) =>
             {
                 var targetType = action(targetObject);
-                return string.IsNullOrEmpty(targetType) ? next(parameterNames, caseSensitive, targetObject) : targetType;
+                return string.IsNullOrEmpty(targetType) ? next(parameterNames, caseSensitive, preferTargetInfo, targetObject) : targetType;
             }, previous);
         }
 

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -19,8 +19,11 @@ namespace PSRule.Pipeline
         private const string Property_TargetName = "TargetName";
         private const string Property_Name = "Name";
 
-        public static string BindTargetName(string[] propertyNames, bool caseSensitive, PSObject targetObject)
+        public static string BindTargetName(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject)
         {
+            if (preferTargetInfo && TryGetInfoTargetName(targetObject, out string targetName))
+                return targetName;
+
             if (propertyNames != null)
                 if (propertyNames.Any(n => n.Contains('.')))
                     return NestedTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultTargetNameBinding);
@@ -30,8 +33,11 @@ namespace PSRule.Pipeline
             return DefaultTargetNameBinding(targetObject);
         }
 
-        public static string BindTargetType(string[] propertyNames, bool caseSensitive, PSObject targetObject)
+        public static string BindTargetType(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject)
         {
+            if (preferTargetInfo && TryGetInfoTargetType(targetObject, out string targetType))
+                return targetType;
+
             if (propertyNames != null)
                 if (propertyNames.Any(n => n.Contains('.')))
                     return NestedTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultTargetTypeBinding);
@@ -41,7 +47,7 @@ namespace PSRule.Pipeline
             return DefaultTargetTypeBinding(targetObject);
         }
 
-        public static string BindField(string[] propertyNames, bool caseSensitive, PSObject targetObject)
+        public static string BindField(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject)
         {
             if (propertyNames != null)
                 if (propertyNames.Any(n => n.Contains('.')))

--- a/src/PSRule/Pipeline/TargetBinder.cs
+++ b/src/PSRule/Pipeline/TargetBinder.cs
@@ -102,8 +102,8 @@ namespace PSRule.Pipeline
         public void Bind(OptionContext baseline, PSObject targetObject)
         {
             var binding = baseline.GetTargetBinding();
-            TargetName = _BindTargetName(binding.TargetName, !binding.IgnoreCase, targetObject);
-            TargetType = _BindTargetType(binding.TargetType, !binding.IgnoreCase, targetObject);
+            TargetName = _BindTargetName(binding.TargetName, !binding.IgnoreCase, binding.PreferTargetInfo, targetObject);
+            TargetType = _BindTargetType(binding.TargetType, !binding.IgnoreCase, binding.PreferTargetInfo, targetObject);
             ShouldFilter = !(_TypeFilter == null || _TypeFilter.Contains(TargetType));
 
             // Use qualified name
@@ -133,7 +133,7 @@ namespace PSRule.Pipeline
                     if (hashtable.ContainsKey(field.Key))
                         continue;
 
-                    hashtable.Add(field.Key, _BindField(field.Value, caseSensitive, targetObject));
+                    hashtable.Add(field.Key, _BindField(field.Value, caseSensitive, false, targetObject));
                 }
             }
             hashtable.Protect();

--- a/tests/PSRule.Tests/InputFormatDeserializerTests.cs
+++ b/tests/PSRule.Tests/InputFormatDeserializerTests.cs
@@ -22,7 +22,7 @@ namespace PSRule
             Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
             Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value2"));
             Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<PSObject[]>("array").Length);
-            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, false, actual[0]));
         }
 
         [Fact]
@@ -35,7 +35,7 @@ namespace PSRule
             Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
             Assert.Equal(2, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value2"));
             Assert.Equal(3, actual[1].PropertyValue("spec").PropertyValue("properties").PropertyValue<PSObject[]>("array").Length);
-            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, false, actual[0]));
 
             // Single item
             actual = PipelineReceiverActions.ConvertFromJson(GetJsonContent("Single"), PipelineReceiverActions.PassThru).ToArray();
@@ -58,7 +58,7 @@ namespace PSRule
             Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
             Assert.Equal(1, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value1"));
             Assert.Equal(2, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<PSObject[]>("array").Length);
-            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, false, actual[0]));
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace PSRule
             Assert.Equal("Test", actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<string>("kind"));
             Assert.Equal(1, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<int>("value1"));
             Assert.Equal(2, actual[0].PropertyValue("spec").PropertyValue("properties").PropertyValue<Array>("array").Length);
-            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, actual[0]));
+            Assert.Equal("TestObject1", PipelineHookActions.BindTargetName(null, false, false, actual[0]));
         }
 
         private static string GetYamlContent()

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -233,6 +233,28 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Binding.PreferTargetInfo' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Binding.PreferTargetInfo | Should -Be $False;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Binding.PreferTargetInfo' = $True };
+            $option.Binding.PreferTargetInfo | Should -Be $True;
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Binding.PreferTargetInfo | Should -Be $True;
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -BindingPreferTargetInfo $True -Path $emptyOptionsFilePath;
+            $option.Binding.PreferTargetInfo | Should -Be $True;
+        }
+    }
+
     Context 'Read Binding.TargetName' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -907,6 +929,14 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         }
     }
 
+    Context 'Read Binding.Field' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -BindingField @{ id = 'resourceId' } @optionParams;
+            $option.Binding.Field | Should -Not -BeNullOrEmpty;
+            $option.Binding.Field.id[0] | Should -Be 'resourceId';
+        }
+    }
+
     Context 'Read Binding.IgnoreCase' {
         It 'from parameter' {
             $option = Set-PSRuleOption -BindingIgnoreCase $False @optionParams;
@@ -914,11 +944,17 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         }
     }
 
-    Context 'Read Binding.Field' {
+    Context 'Read Binding.NameSeparator' {
         It 'from parameter' {
-            $option = Set-PSRuleOption -BindingField @{ id = 'resourceId' } @optionParams;
-            $option.Binding.Field | Should -Not -BeNullOrEmpty;
-            $option.Binding.Field.id[0] | Should -Be 'resourceId';
+            $option = Set-PSRuleOption -BindingNameSeparator '::' @optionParams;
+            $option.Binding.NameSeparator | Should -Be $True;
+        }
+    }
+
+    Context 'Read Binding.PreferTargetInfo' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -BindingPreferTargetInfo $True @optionParams;
+            $option.Binding.PreferTargetInfo | Should -Be $True;
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -27,6 +27,7 @@ binding:
     - resourceId
   ignoreCase: false
   nameSeparator: '::'
+  preferTargetInfo: true
   targetName:
   - ResourceName
   targetType:

--- a/tests/PSRule.Tests/TargetNameBindingTests.cs
+++ b/tests/PSRule.Tests/TargetNameBindingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
+using PSRule.Data;
 using PSRule.Pipeline;
 using System.Management.Automation;
 using Xunit;
@@ -20,6 +21,15 @@ namespace PSRule
             public string NotName { get; set; }
         }
 
+        internal class TestModel3 : ITargetInfo
+        {
+            public string Name { get; set; }
+
+            string ITargetInfo.TargetName => "TestModel3";
+
+            string ITargetInfo.TargetType => "TestModel3";
+        }
+
         [Fact]
         public void UnboundObjectTargetName()
         {
@@ -27,13 +37,36 @@ namespace PSRule
             var testObject2 = new TestModel2 { NotName = "TestObject1" };
             var pso1 = PSObject.AsPSObject(testObject1);
             var pso2 = PSObject.AsPSObject(testObject2);
-
-            PipelineContext.CurrentThread = PipelineContext.New(option: new PSRuleOption(), hostContext: null, reader: null, binder: new TargetBinder(null, null, null, null), baseline: null, unresolved: null);
-            var actual1 = PipelineHookActions.BindTargetName(null, false, pso1);
-            var actual2 = PipelineHookActions.BindTargetName(null, false, pso2);
+            
+            PipelineContext.CurrentThread = PipelineContext.New(option: GetOption(), hostContext: null, reader: null, binder: new TargetBinder(null, null, null, null), baseline: null, unresolved: null);
+            var actual1 = PipelineHookActions.BindTargetName(null, false, false, pso1);
+            var actual2 = PipelineHookActions.BindTargetName(null, false, false, pso2);
 
             Assert.Equal(expected: "f209c623345144be61087d91f30c17b01c6e86d2", actual: actual1);
             Assert.Equal(expected: "f209c623345144be61087d91f30c17b01c6e86d2", actual: actual2);
+        }
+
+        [Fact]
+        public void PreferTargetInfo()
+        {
+            var testObject1 = new TestModel3 { Name = "OtherName" };
+            var pso1 = PSObject.AsPSObject(testObject1);
+
+            PipelineContext.CurrentThread = PipelineContext.New(option: GetOption(), hostContext: null, reader: null, binder: new TargetBinder(null, null, null, null), baseline: null, unresolved: null);
+
+            var actual = PipelineHookActions.BindTargetName(new string[] { "Name" }, false, false, pso1);
+            Assert.Equal(expected: "OtherName", actual: actual);
+
+            actual = PipelineHookActions.BindTargetName(new string[] { "NotName" }, false, false, pso1);
+            Assert.Equal(expected: "TestModel3", actual: actual);
+
+            actual = PipelineHookActions.BindTargetName(new string[] { "Name" }, false, true, pso1);
+            Assert.Equal(expected: "TestModel3", actual: actual);
+        }
+
+        private static PSRuleOption GetOption()
+        {
+            return new PSRuleOption();
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Added support for preferring automatic binding over custom binding configurations. #670
- Updates and fixes to documentation.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
