### PR TITLE
Pre-release v1.3.0-B2104021

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,10 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.3.0-B2104021 (pre-release)
+
+What's changed since v1.2.0:
+
 - General improvements:
   - Added file path assertion helpers. [#679](https://github.com/microsoft/PSRule/issues/679)
     - Added `WithinPath` to check the file path field is within a specified path.


### PR DESCRIPTION
## PR Summary

What's changed since v1.2.0:

- General improvements:
  - Added file path assertion helpers. #679
    - Added `WithinPath` to check the file path field is within a specified path.
    - Added `NotWithinPath` to check the file path field is not within a specified path
    - See [about_PSRule_Assert] for details.
  - Added DateTime type assertion helper. #680
    - Added `IsDateTime` to check of object field is `[DateTime]`.
    - See [about_PSRule_Assert] for details.
  - Improved numeric comparison assertion helpers to compare `[DateTime]` fields. #685
    - `Less`, `LessOrEqual`, `Greater`, and `GreaterOrEqual` compare the number of days from the current time.
    - See [about_PSRule_Assert] for details.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
