### PR TITLE
Improved handling of field names #693

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,9 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+- General improvements:
+  - Improved handling of field names for objects implementing `IList`, `IEnumerable`, and index properties. [#693](https://github.com/microsoft/PSRule/issues/693)
+
 ## v1.3.0-B2104021 (pre-release)
 
 What's changed since v1.2.0:

--- a/tests/PSRule.Tests/ObjectHelperTests.cs
+++ b/tests/PSRule.Tests/ObjectHelperTests.cs
@@ -3,6 +3,7 @@
 
 using PSRule.Definitions;
 using System.Collections;
+using System.Collections.Generic;
 using Xunit;
 
 namespace PSRule
@@ -20,6 +21,10 @@ namespace PSRule
             Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: "Value2[1]", caseSensitive: false, value: out object actual4);
             Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".", caseSensitive: true, value: out object actual5);
             Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".Value2[1]", caseSensitive: false, value: out object actual6);
+            Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".Value3[1]", caseSensitive: false, value: out object actual7);
+            Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".Value4[0]", caseSensitive: false, value: out object actual8);
+            Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".Value5.name", caseSensitive: false, value: out object actual9);
+            Runtime.ObjectHelper.GetField(bindingContext: null, targetObject: testObject, name: ".Value5[2]", caseSensitive: false, value: out object actual10);
 
             Assert.Equal(expected: testObject.Name, actual: actual1);
             Assert.Equal(expected: testObject.Value.Value1, actual: actual2);
@@ -27,6 +32,10 @@ namespace PSRule
             Assert.Equal(expected: testObject.Value2[1], actual: actual4);
             Assert.Equal(expected: testObject, actual: actual5);
             Assert.Equal(expected: testObject.Value2[1], actual: actual6);
+            Assert.Equal(expected: testObject.Value3[1], actual: actual7);
+            Assert.Equal(expected: "1", actual: actual8);
+            Assert.Equal(expected: testObject.Value5["name"], actual: actual9);
+            Assert.Equal(expected: testObject.Value5[2], actual: actual10);
         }
 
         [Fact]
@@ -48,7 +57,20 @@ namespace PSRule
 
         private static TestObject1 GetTestObject()
         {
-            var result = new TestObject1 { Name = "TestObject1", Value = new TestObject2 { Value1 = "Value1" }, Value2 = new string[] { "1", "2" }, Metadata = new Hashtable() };
+            var value5 = new TestObject3();
+            value5["name"] = "1";
+            value5[2] = "2";
+
+            var result = new TestObject1
+            {
+                Name = "TestObject1",
+                Value = new TestObject2 { Value1 = "Value1" },
+                Value2 = new string[] { "1", "2" },
+                Metadata = new Hashtable(),
+                Value3 = new List<string>(new string[] { "1", "2" }),
+                Value4 = new List<string>(new string[] { "1" }).AsReadOnly(),
+                Value5 = value5
+            };
             result.Metadata.Add("app.kubernetes.io/name", "KubeName");
             return result;
         }
@@ -62,11 +84,33 @@ namespace PSRule
             public string[] Value2;
 
             public Hashtable Metadata;
+
+            public IList<string> Value3;
+
+            public ICollection<string> Value4;
+
+            public TestObject3 Value5;
         }
 
         public sealed class TestObject2
         {
             public string Value1;
+        }
+
+        public sealed class TestObject3
+        {
+            private readonly Dictionary<object, object> _Internal;
+
+            public TestObject3()
+            {
+                _Internal = new Dictionary<object, object>();
+            }
+
+            public object this[object key]
+            {
+                get => _Internal[key];
+                set => _Internal[key] = value;
+            }
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Improved handling of field names for objects implementing `IList`, `IEnumerable`, and index properties. #693

Fixes #693

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
