### PR TITLE
Exclude .git sub-directory by default #697

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,6 +72,7 @@
         },
         {
             "label": "scaffold-docs",
+            "detail": "Generate cmdlet markdown docs.",
             "type": "shell",
             "command": "Invoke-Build ScaffoldHelp",
             "problemMatcher": []

--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.InconclusiveWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executioninconclusivewarning)
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionnotprocessedwarning)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
+  - [Input.IgnoreGitPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputignoregitpath)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)
   - [Input.PathIgnore](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputpathignore)
   - [Input.TargetType](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputtargettype)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -15,6 +15,10 @@ What's changed since pre-release v1.3.0-B2104042:
 - Engine features:
   - Options can be configured with environment variables. [#691](https://github.com/microsoft/PSRule/issues/691)
     - See [about_PSRule_Options] for details.
+- General improvements:
+  - Exclude `.git` sub-directory by default for recursive scans. [#697](https://github.com/microsoft/PSRule/issues/697)
+    - Added `Input.IgnoreGitPath` option to configure inclusion of `.git` path.
+    - See [about_PSRule_Options] for details.
 
 ## v1.3.0-B2104042 (pre-release)
 

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -22,11 +22,11 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
- [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -38,11 +38,11 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
- [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -53,11 +53,11 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>]
  [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
  [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
- [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -435,6 +435,23 @@ Accepted values: None, Yaml, Json, Markdown, PowerShellData, File, Detect
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputIgnoreGitPath
+
+Sets the `Input.IgnoreGitPath` option to determine if files within the .git path are ignored.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -18,12 +18,12 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>] [-BindingNameSeparator <String>]
  [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-InconclusiveWarning <Boolean>]
- [-NotProcessedWarning <Boolean>] [-Format <InputFormat>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
- [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-NotProcessedWarning <Boolean>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-ObjectPath <String>] [-InputPathIgnore <String[]>] [-InputTargetType <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -326,6 +326,7 @@ Accept wildcard characters: False
 ### -Format
 
 Sets the `Input.Format` option to configure the input format for when a string is passed in as a target object.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: InputFormat
@@ -340,9 +341,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -InputIgnoreGitPath
+
+Sets the `Input.IgnoreGitPath` option to determine if files within the .git path are ignored.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ObjectPath
 
 Sets the `Input.ObjectPath` option to use an object path to use instead of the pipeline object.
+See about_PSRule_Options for more information.
 
 ```yaml
 Type: String

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -18,6 +18,7 @@ The following workspace options are available for use:
 - [Execution.InconclusiveWarning](#executioninconclusivewarning)
 - [Execution.NotProcessedWarning](#executionnotprocessedwarning)
 - [Input.Format](#inputformat)
+- [Input.IgnoreGitPath](#inputignoregitpath)
 - [Input.ObjectPath](#inputobjectpath)
 - [Input.PathIgnore](#inputpathignore)
 - [Input.TargetType](#inputtargettype)
@@ -886,6 +887,53 @@ env:
 variables:
 - name: PSRULE_INPUT_FORMAT
   value: Yaml
+```
+
+### Input.IgnoreGitPath
+
+When reading files from an input path, files within the `.git` sub-directory are ignored by default.
+Files stored within the `.git` sub-directory are system repository files used by git.
+To read files stored within the `.git` path, set this option to `$False`.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the InputIgnoreGitPath parameter
+$option = New-PSRuleOption -InputIgnoreGitPath $False;
+```
+
+```powershell
+# PowerShell: Using the Input.IgnoreGitPath hashtable key
+$option = New-PSRuleOption -Option @{ 'Input.IgnoreGitPath' = $False };
+```
+
+```powershell
+# PowerShell: Using the InputIgnoreGitPath parameter to set YAML
+Set-PSRuleOption -InputIgnoreGitPath $False;
+```
+
+```yaml
+# YAML: Using the input/ignoreGitPath property
+input:
+  ignoreGitPath: false
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_INPUT_IGNOREGITPATH=false
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_INPUT_IGNOREGITPATH: false
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_INPUT_IGNOREGITPATH
+  value: false
 ```
 
 ### Input.ObjectPath
@@ -1838,6 +1886,7 @@ execution:
 # Configures input options
 input:
   format: Yaml
+  ignoreGitPath: false
   objectPath: items
   pathIgnore:
   - '*.Designer.cs'
@@ -1930,6 +1979,7 @@ execution:
 # Configures input options
 input:
   format: Detect
+  ignoreGitPath: true
   objectPath: null
   pathIgnore: [ ]
   targetType: [ ]

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -160,6 +160,13 @@
                     ],
                     "default": "Detect"
                 },
+                "ignoreGitPath": {
+                    "type": "boolean",
+                    "title": "Ignore .git path",
+                    "description": "Determine if files within the .git path are ignored when the -InputPath parameter is used.",
+                    "markdownDescription": "Determine if files within the `.git` path are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#ignoregitpath)",
+                    "default": true
+                },
                 "objectPath": {
                     "type": "string",
                     "title": "Object path",

--- a/src/PSRule/Configuration/InputOption.cs
+++ b/src/PSRule/Configuration/InputOption.cs
@@ -13,6 +13,7 @@ namespace PSRule.Configuration
     public sealed class InputOption : IEquatable<InputOption>
     {
         private const InputFormat DEFAULT_FORMAT = PSRule.Configuration.InputFormat.Detect;
+        private const bool DEFAULT_IGNOREGITPATH = true;
         private const string DEFAULT_OBJECTPATH = null;
         private const string[] DEFAULT_PATHIGNORE = null;
         private const string[] DEFAULT_TARGETTYPE = null;
@@ -20,6 +21,7 @@ namespace PSRule.Configuration
         internal static readonly InputOption Default = new InputOption
         {
             Format = DEFAULT_FORMAT,
+            IgnoreGitPath = DEFAULT_IGNOREGITPATH,
             ObjectPath = DEFAULT_OBJECTPATH,
             PathIgnore = DEFAULT_PATHIGNORE,
             TargetType = DEFAULT_TARGETTYPE,
@@ -28,6 +30,7 @@ namespace PSRule.Configuration
         public InputOption()
         {
             Format = null;
+            IgnoreGitPath = null;
             ObjectPath = null;
             PathIgnore = null;
             TargetType = null;
@@ -39,6 +42,7 @@ namespace PSRule.Configuration
                 return;
 
             Format = option.Format;
+            IgnoreGitPath = option.IgnoreGitPath;
             ObjectPath = option.ObjectPath;
             PathIgnore = option.PathIgnore;
             TargetType = option.TargetType;
@@ -53,6 +57,7 @@ namespace PSRule.Configuration
         {
             return other != null &&
                 Format == other.Format &&
+                IgnoreGitPath == other.IgnoreGitPath &&
                 ObjectPath == other.ObjectPath &&
                 PathIgnore == other.PathIgnore &&
                 TargetType == other.TargetType;
@@ -64,6 +69,7 @@ namespace PSRule.Configuration
             {
                 int hash = 17;
                 hash = hash * 23 + (Format.HasValue ? Format.Value.GetHashCode() : 0);
+                hash = hash * 23 + (IgnoreGitPath.HasValue ? IgnoreGitPath.Value.GetHashCode() : 0);
                 hash = hash * 23 + (ObjectPath != null ? ObjectPath.GetHashCode() : 0);
                 hash = hash * 23 + (PathIgnore != null ? PathIgnore.GetHashCode() : 0);
                 hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
@@ -76,6 +82,7 @@ namespace PSRule.Configuration
             var result = new InputOption(o1)
             {
                 Format = o1.Format ?? o2.Format,
+                IgnoreGitPath = o1.IgnoreGitPath ?? o2.IgnoreGitPath,
                 ObjectPath = o1.ObjectPath ?? o2.ObjectPath,
                 PathIgnore = o1.PathIgnore ?? o2.PathIgnore,
                 TargetType = o1.TargetType ?? o2.TargetType
@@ -88,6 +95,12 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public InputFormat? Format { get; set; }
+
+        /// <summary>
+        /// Determine if files within the .git path are ignored.
+        /// </summary>
+        [DefaultValue(null)]
+        public bool? IgnoreGitPath { get; set; }
 
         /// <summary>
         /// The object path to a property to use instead of the pipeline object.
@@ -112,6 +125,9 @@ namespace PSRule.Configuration
             if (env.TryEnum("PSRULE_INPUT_FORMAT", out InputFormat format))
                 Format = format;
 
+            if (env.TryBool("PSRULE_INPUT_IGNOREGITPATH", out bool ignoreGitPath))
+                IgnoreGitPath = ignoreGitPath;
+
             if (env.TryString("PSRULE_INPUT_OBJECTPATH", out string objectPath))
                 ObjectPath = objectPath;
 
@@ -126,6 +142,9 @@ namespace PSRule.Configuration
         {
             if (index.TryPopEnum("Input.Format", out InputFormat format))
                 Format = format;
+
+            if (index.TryPopBool("Input.IgnoreGitPath", out bool ignoreGitPath))
+                IgnoreGitPath = ignoreGitPath;
 
             if (index.TryPopString("Input.ObjectPath", out string objectPath))
                 ObjectPath = objectPath;

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1070,6 +1070,10 @@ function New-PSRuleOption {
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
+        # Sets the Input.IgnoreGitPath option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$InputIgnoreGitPath = $True,
+
         # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
         [Alias('InputObjectPath')]
@@ -1280,6 +1284,10 @@ function Set-PSRuleOption {
         [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'PowerShellData', 'Detect')]
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
+
+        # Sets the Input.IgnoreGitPath option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$InputIgnoreGitPath = $True,
 
         # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
@@ -1902,6 +1910,10 @@ function SetOptions {
         [Alias('InputFormat')]
         [PSRule.Configuration.InputFormat]$Format = 'Detect',
 
+        # Sets the Input.IgnoreGitPath option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$InputIgnoreGitPath = $True,
+
         # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
         [Alias('InputObjectPath')]
@@ -2021,6 +2033,11 @@ function SetOptions {
         # Sets option Input.Format
         if ($PSBoundParameters.ContainsKey('Format')) {
             $Option.Input.Format = $Format;
+        }
+
+        # Sets option Input.IgnoreGitPath
+        if ($PSBoundParameters.ContainsKey('InputIgnoreGitPath')) {
+            $Option.Input.IgnoreGitPath = $InputIgnoreGitPath;
         }
 
         # Sets option Input.ObjectPath

--- a/src/PSRule/Pipeline/GetTargetPipeline.cs
+++ b/src/PSRule/Pipeline/GetTargetPipeline.cs
@@ -48,7 +48,8 @@ namespace PSRule.Pipeline
                 return;
 
             var basePath = PSRuleOption.GetWorkingPath();
-            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore);
+            var ignoreGitPath = Option.Input.IgnoreGitPath ?? InputOption.Default.IgnoreGitPath.Value;
+            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore, ignoreGitPath);
             if (Option.Input.Format == InputFormat.File)
                 filter.UseGitIgnore();
 

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -36,7 +36,8 @@ namespace PSRule.Pipeline
                 return;
 
             var basePath = PSRuleOption.GetWorkingPath();
-            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore);
+            var ignoreGitPath = Option.Input.IgnoreGitPath ?? InputOption.Default.IgnoreGitPath.Value;
+            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore, ignoreGitPath);
             if (Option.Input.Format == InputFormat.File)
                 filter.UseGitIgnore();
 

--- a/src/PSRule/Pipeline/PathFilter.cs
+++ b/src/PSRule/Pipeline/PathFilter.cs
@@ -16,21 +16,22 @@ namespace PSRule.Pipeline
         private readonly List<string> _Expressions;
         private readonly bool _MatchResult;
 
-        private PathFilterBuilder(string basePath, string[] expressions, bool matchResult)
+        private PathFilterBuilder(string basePath, string[] expressions, bool matchResult, bool ignoreGitPath)
         {
             _BasePath = basePath;
             _Expressions = expressions == null || expressions.Length == 0 ? new List<string>() : new List<string>(expressions);
             _MatchResult = matchResult;
+            if (ignoreGitPath)
+                _Expressions.Add(".git/");
         }
 
-        internal static PathFilterBuilder Create(string basePath, string[] expressions, bool matchResult = false)
+        internal static PathFilterBuilder Create(string basePath, string[] expressions, bool ignoreGitPath)
         {
-            return new PathFilterBuilder(basePath, expressions, matchResult);
+            return new PathFilterBuilder(basePath, expressions, false, ignoreGitPath);
         }
 
         internal void UseGitIgnore(string basePath = null)
         {
-            _Expressions.Add(".git/");
             _Expressions.Add("!.git/HEAD");
             ReadFile(Path.Combine(basePath ?? _BasePath, GitIgnoreFileName));
         }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1073,6 +1073,14 @@ Describe 'Get-PSRuleTarget' -Tag 'Get-PSRuleTarget','Common' {
             $result.Length | Should -Be 1;
             $result[0].TargetName | Should -Be 'TestObject1';
         }
+
+        It 'None' {
+            $result = @(Get-PSRuleTarget -InputPath '**/HEAD');
+            $result.Length | Should -Be 0;
+
+            $result = @(Get-PSRuleTarget -InputPath '**/HEAD' -Option @{ 'Input.IgnoreGitPath' = $False });
+            $result.Length | Should -BeGreaterThan 0;
+        }
     }
 
     Context 'With -Format' {

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -688,6 +688,45 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Input.IgnoreGitPath' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Input.IgnoreGitPath | Should -Be $True;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Input.IgnoreGitPath' = $False };
+            $option.Input.IgnoreGitPath | Should -Be $False;
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Input.IgnoreGitPath | Should -Be $False;
+        }
+
+        It 'from Environment' {
+            try {
+                # With bool
+                $Env:PSRULE_INPUT_IGNOREGITPATH = 'false';
+                $option = New-PSRuleOption;
+                $option.Input.IgnoreGitPath | Should -Be $False;
+
+                # With int
+                $Env:PSRULE_INPUT_IGNOREGITPATH = '0';
+                $option = New-PSRuleOption;
+                $option.Input.IgnoreGitPath | Should -Be $False;
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_INPUT_IGNOREGITPATH' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InputIgnoreGitPath $False -Path $emptyOptionsFilePath;
+            $option.Input.IgnoreGitPath | Should -Be $False;
+        }
+    }
+
     Context 'Read Input.ObjectPath' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -1349,6 +1388,13 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -Format 'Yaml' @optionParams;
             $option.Input.Format | Should -Be 'Yaml';
+        }
+    }
+
+    Context 'Read Input.IgnoreGitPath' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -InputIgnoreGitPath $False @optionParams;
+            $option.Input.IgnoreGitPath | Should -Be $False;
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -43,6 +43,7 @@ execution:
 # Configure input options
 input:
   format: Yaml
+  ignoreGitPath: false
   objectPath: items
   pathIgnore:
   - '*.Designer.cs'


### PR DESCRIPTION
## PR Summary

- Exclude `.git` sub-directory by default for recursive scans. #697

Fixes #697 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
