### PR TITLE
Add pre-release constraint flag #717

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Output.Outcome](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputoutcome)
   - [Output.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputpath)
   - [Output.Style](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputstyle)
+  - [Requires](docs/concepts/PSRule/en-US/about_PSRule_Options.md#requires)
   - [Rule.Include](docs/concepts/PSRule/en-US/about_PSRule_Options.md#ruleinclude)
   - [Rule.Exclude](docs/concepts/PSRule/en-US/about_PSRule_Options.md#ruleexclude)
   - [Rule.Tag](docs/concepts/PSRule/en-US/about_PSRule_Options.md#ruletag)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -15,6 +15,7 @@ What's changed since pre-release v1.4.0-B2105004:
 - General improvements:
   - Improved support for version constraints by:
     - Constraints can include prerelease versions of other matching versions. [#714](https://github.com/microsoft/PSRule/issues/714)
+    - Constraints support using a `@prerelease` or `@pre` to include prerelease versions. [#717](https://github.com/microsoft/PSRule/issues/717)
     - Constraint sets allow multiple constraints to be joined together. [#715](https://github.com/microsoft/PSRule/issues/715)
     - See [about_PSRule_Assert] for details.
 - Bug fixes:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -1212,17 +1212,18 @@ By example:
   - Pass: `1.2.3`, `3.4.5`, `3.5.0`, `4.9.9`.
   - Fail: `3.0.0`, `5.0.0`.
 
-Handling for pre-release versions:
+Handling for prerelease versions:
 
-- Constraints and versions containing pre-release identifiers are supported.
+- Constraints and versions containing prerelease identifiers are supported.
 i.e. `>=1.2.3-build.1` or `1.2.3-build.1`.
-- A version containing a pre-release identifer follows semantic versioning rules.
+- A version containing a prerelease identifer follows semantic versioning rules.
 i.e. `1.2.3-alpha` < `1.2.3-alpha.1` < `1.2.3-alpha.beta` < `1.2.3-beta` < `1.2.3-beta.2` < `1.2.3-beta.11` < `1.2.3-rc.1` < `1.2.3`.
-- A constraint without a pre-release identifer will only match a stable version by default.
+- A constraint without a prerelease identifer will only match a stable version by default.
 Set `includePrerelease` to `$True` to include prerelease versions.
-- Constraints with a pre-release identifer will only match:
-  - Matching pre-release versions of the same major.minor.patch version by default.
+- Constraints with a prerelease identifer will only match:
+  - Matching prerelease versions of the same major.minor.patch version by default.
   Set `includePrerelease` to `$True` to include prerelease versions of all matching versions.
+  Alternatively use the `@pre` or `@prerelease` flag in a constraint.
   - Matching stable versions.
 
 By example:
@@ -1239,6 +1240,11 @@ By example:
 - `<1.2.3-0` results in:
   - Pass: `1.2.2`, `1.0.0`.
   - Fail: `1.0.0-build.1`, `1.2.3-build.1`.
+- `@pre >=1.2.3` results in:
+  - Pass: `1.2.3`, `9.9.9`, `9.9.9-build.1`
+  - Fail: `1.2.3-build.1`.
+- `@pre >=1.2.3-0` results in:
+  - Pass: `1.2.3`, `1.2.3-build.1`, `9.9.9`, `9.9.9-build.1`.
 
 Reasons include:
 
@@ -1257,6 +1263,14 @@ Rule 'ValidVersion' {
 
 Rule 'MinimumVersion' {
     $Assert.Version($TargetObject, 'version', '>=1.2.3')
+}
+
+Rule 'MinimumVersionWithPrerelease' {
+    $Assert.Version($TargetObject, 'version', '>=1.2.3-0', $True)
+}
+
+Rule 'MinimumVersionWithFlag' {
+    $Assert.Version($TargetObject, 'version', '@pre >=1.2.3-0')
 }
 ```
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1721,8 +1721,9 @@ $option = New-PSRuleOption -Option @{ 'Requires.PSRule' = '>=1.0.0' };
 ```yaml
 # YAML: Using the requires property
 requires:
-  PSRule: '>=1.0.0'              # Require v1.0.0 or greater.
-  PSRule.Rules.Azure: '>=1.0.0'  # Require v1.0.0 or greater.
+  PSRule: '>=1.0.0'                 # Require v1.0.0 or greater.
+  PSRule.Rules.Azure: '>=1.0.0'     # Require v1.0.0 or greater.
+  PSRule.Rules.CAF: '@pre >=0.1.0'  # Require stable or pre-releases v0.1.0 or greater.
 ```
 
 This option can be configured using environment variables.
@@ -1733,6 +1734,7 @@ When the module name includes a dot (`.`) use an underscore (`_`) instead.
 # Bash: Using environment variable
 export PSRULE_REQUIRES_PSRULE='>=1.0.0'
 export PSRULE_REQUIRES_PSRULE_RULES_AZURE='>=1.0.0'
+export PSRULE_REQUIRES_PSRULE_RULES_CAF='@pre >=0.1.0'
 ```
 
 ```yaml
@@ -1740,6 +1742,7 @@ export PSRULE_REQUIRES_PSRULE_RULES_AZURE='>=1.0.0'
 env:
   PSRULE_REQUIRES_PSRULE: '>=1.0.0'
   PSRULE_REQUIRES_PSRULE_RULES_AZURE: '>=1.0.0'
+  PSRULE_REQUIRES_PSRULE_RULES_CAF: '@pre >=0.1.0'
 ```
 
 ```yaml
@@ -1749,6 +1752,8 @@ variables:
   value: '>=1.0.0'
 - name: PSRULE_REQUIRES_PSRULE_RULES_AZURE
   value: '>=1.0.0'
+- name: PSRULE_REQUIRES_PSRULE_RULES_CAF
+  value: '@pre >=0.1.0'
 ```
 
 ### Rule.Include

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -164,19 +164,7 @@ namespace PSRule
                 }
                 parser.Require<MappingEnd>();
                 parser.MoveNext();
-                //values.Add(result);
             }
-            //else if (parser.TryConsume<SequenceStart>(out _))
-            //{
-            //    while (!(parser.Current is SequenceEnd))
-            //    {
-            //        if (ReadYaml(parser, typeof(PSObject)) is PSObject o)
-            //            values.Add(o);
-            //    }
-            //    parser.Require<SequenceEnd>();
-            //    parser.MoveNext();
-            //}
-
             return result;
         }
 

--- a/src/PSRule/Runtime/SemanticVersion.cs
+++ b/src/PSRule/Runtime/SemanticVersion.cs
@@ -596,22 +596,21 @@ namespace PSRule.Runtime
                 return true;
             }
 
-            internal bool Build(out string label)
+            internal void Build(out string label)
             {
                 label = string.Empty;
                 if (EOF || _Current != PLUS)
-                    return true;
+                    return;
 
                 Next();
                 var start = _Position;
                 if (_Current == ZERO)
-                    return false;
+                    return;
 
                 while (!EOF && IsBuildChar(_Current))
                     Next();
 
                 label = _Value.Substring(start, _Position - start);
-                return label.Length > 0;
             }
 
             /// <summary>

--- a/src/PSRule/Runtime/SemanticVersion.cs
+++ b/src/PSRule/Runtime/SemanticVersion.cs
@@ -26,9 +26,13 @@ namespace PSRule.Runtime
         private const char ZERO = '0';
         private const char PIPE = '|';
         private const char SPACE = ' ';
+        private const char AT = '@';
+
+        private const string FLAG_PRERELEASE = "@prerelease ";
+        private const string FLAG_PRE = "@pre ";
 
         [Flags]
-        internal enum CompareFlag
+        internal enum ComparisonOperatorFlags
         {
             None = 0,
 
@@ -54,9 +58,17 @@ namespace PSRule.Runtime
 
         internal enum JoinOperator
         {
-            None,
-            And,
-            Or
+            None = 0,
+            And = 1,
+            Or = 2
+        }
+
+        [Flags]
+        internal enum ConstraintFlags
+        {
+            None = 0,
+
+            Prerelease = 1
         }
 
         internal interface IConstraint
@@ -105,7 +117,7 @@ namespace PSRule.Runtime
                 return false;
             }
 
-            internal void Join(int major, int minor, int patch, PR prid, CompareFlag flag, JoinOperator join, bool includePrerelease)
+            internal void Join(int major, int minor, int patch, PR prid, ComparisonOperatorFlags flag, JoinOperator join, bool includePrerelease)
             {
                 if (_Constraints == null)
                     _Constraints = new List<ConstraintExpression>();
@@ -125,16 +137,16 @@ namespace PSRule.Runtime
         [DebuggerDisplay("{_Major}.{_Minor}.{_Patch}")]
         internal sealed class ConstraintExpression : IConstraint
         {
-            private readonly CompareFlag _Flag;
+            private readonly ComparisonOperatorFlags _Flag;
             private readonly int _Major;
             private readonly int _Minor;
             private readonly int _Patch;
             private readonly PR _PRID;
             private readonly bool _IncludePrerelease;
 
-            internal ConstraintExpression(int major, int minor, int patch, PR prid, CompareFlag flag, JoinOperator join, bool includePrerelease)
+            internal ConstraintExpression(int major, int minor, int patch, PR prid, ComparisonOperatorFlags flag, JoinOperator join, bool includePrerelease)
             {
-                _Flag = flag == CompareFlag.None ? CompareFlag.Equals : flag;
+                _Flag = flag == ComparisonOperatorFlags.None ? ComparisonOperatorFlags.Equals : flag;
                 _Major = major;
                 _Minor = minor;
                 _Patch = patch;
@@ -164,7 +176,7 @@ namespace PSRule.Runtime
 
             public bool Equals(int major, int minor, int patch, PR prid)
             {
-                if (_Flag == CompareFlag.Equals)
+                if (_Flag == ComparisonOperatorFlags.Equals)
                     return EQ(major, minor, patch, prid);
 
                 // Fail when pre-release should not be included
@@ -204,37 +216,37 @@ namespace PSRule.Runtime
 
             private bool GuardLessOrEqual(int major, int minor, int patch, PR prid)
             {
-                return _Flag == (CompareFlag.LessThan | CompareFlag.Equals) && !(LT(major, minor, patch, prid) || EQ(major, minor, patch, prid));
+                return _Flag == (ComparisonOperatorFlags.LessThan | ComparisonOperatorFlags.Equals) && !(LT(major, minor, patch, prid) || EQ(major, minor, patch, prid));
             }
 
             private bool GaurdLess(int major, int minor, int patch, PR prid)
             {
-                return _Flag == CompareFlag.LessThan && !LT(major, minor, patch, prid);
+                return _Flag == ComparisonOperatorFlags.LessThan && !LT(major, minor, patch, prid);
             }
 
             private bool GuardGreaterOrEqual(int major, int minor, int patch, PR prid)
             {
-                return _Flag == (CompareFlag.GreaterThan | CompareFlag.Equals) && !(GT(major, minor, patch, prid) || EQ(major, minor, patch, prid));
+                return _Flag == (ComparisonOperatorFlags.GreaterThan | ComparisonOperatorFlags.Equals) && !(GT(major, minor, patch, prid) || EQ(major, minor, patch, prid));
             }
 
             private bool GuardGreater(int major, int minor, int patch, PR prid)
             {
-                return _Flag == CompareFlag.GreaterThan && !GT(major, minor, patch, prid);
+                return _Flag == ComparisonOperatorFlags.GreaterThan && !GT(major, minor, patch, prid);
             }
 
             private bool GuardMinor(int minor, int patch)
             {
-                return _Flag == CompareFlag.MinorUplift && (minor < _Minor || (minor == _Minor && patch < _Patch));
+                return _Flag == ComparisonOperatorFlags.MinorUplift && (minor < _Minor || (minor == _Minor && patch < _Patch));
             }
 
             private bool GuardPatch(int minor, int patch)
             {
-                return _Flag == CompareFlag.PatchUplift && (minor != _Minor || patch < _Patch);
+                return _Flag == ComparisonOperatorFlags.PatchUplift && (minor != _Minor || patch < _Patch);
             }
 
             private bool GuardMajor(int major)
             {
-                return (_Flag == CompareFlag.MinorUplift || _Flag == CompareFlag.PatchUplift) && major != _Major;
+                return (_Flag == ComparisonOperatorFlags.MinorUplift || _Flag == ComparisonOperatorFlags.PatchUplift) && major != _Major;
             }
 
             private bool GuardPRID(PR prid)
@@ -456,30 +468,55 @@ namespace PSRule.Runtime
 
             internal void Next()
             {
-                if (EOF || ++_Position >= _Value.Length)
+                Next(1);
+            }
+
+            private void Next(int count)
+            {
+                _Position += count;
+                if (EOF || _Position >= _Value.Length)
                     return;
 
                 _Current = _Value[_Position];
             }
 
-            internal void GetConstraintFlag(out CompareFlag flag)
+            internal void Operator(out ComparisonOperatorFlags comparison)
             {
-                flag = CompareFlag.None;
+                comparison = ComparisonOperatorFlags.None;
                 while (!EOF && IsConstraint(_Current))
                 {
                     if (_Current == MINOR)
-                        flag = CompareFlag.MinorUplift;
+                        comparison = ComparisonOperatorFlags.MinorUplift;
                     else if (_Current == PATCH)
-                        flag = CompareFlag.PatchUplift;
+                        comparison = ComparisonOperatorFlags.PatchUplift;
                     else if (_Current == EQUAL)
-                        flag |= CompareFlag.Equals;
+                        comparison |= ComparisonOperatorFlags.Equals;
                     else if (_Current == GREATER)
-                        flag |= CompareFlag.GreaterThan;
+                        comparison |= ComparisonOperatorFlags.GreaterThan;
                     else if (_Current == LESS)
-                        flag |= CompareFlag.LessThan;
+                        comparison |= ComparisonOperatorFlags.LessThan;
 
                     Next();
                 }
+            }
+
+            internal void Flags(out ConstraintFlags flag)
+            {
+                flag = ConstraintFlags.None;
+                if (EOF || _Current != AT)
+                    return;
+
+                if (HasFlag(FLAG_PRE) || HasFlag(FLAG_PRERELEASE))
+                    flag |= ConstraintFlags.Prerelease;
+            }
+
+            private bool HasFlag(string value)
+            {
+                if (string.Compare(_Value, _Position, value, 0, value.Length, false) != 0)
+                    return false;
+
+                Next(value.Length);
+                return true;
             }
 
             private void SkipLeading()
@@ -532,7 +569,7 @@ namespace PSRule.Runtime
                 return segmentIndex > 0;
             }
 
-            internal bool ConsumePrerelease(out PR identifier)
+            internal bool Prerelease(out PR identifier)
             {
                 identifier = PR.Empty;
                 if (EOF || _Current != DASH)
@@ -559,7 +596,7 @@ namespace PSRule.Runtime
                 return true;
             }
 
-            internal bool ConsumeBuild(out string label)
+            internal bool Build(out string label)
             {
                 label = string.Empty;
                 if (EOF || _Current != PLUS)
@@ -674,16 +711,20 @@ namespace PSRule.Runtime
                 return true;
 
             var stream = new VersionStream(value);
+            stream.Flags(out ConstraintFlags flags);
+            if (flags.HasFlag(ConstraintFlags.Prerelease))
+                includePrerelease = true;
+
             while (!stream.EOF)
             {
-                stream.GetConstraintFlag(out CompareFlag flag);
+                stream.Operator(out ComparisonOperatorFlags comparison);
                 if (!stream.TrySegments(out int[] segments))
                     return false;
 
-                stream.ConsumePrerelease(out PR prerelease);
-                stream.ConsumeBuild(out _);
+                stream.Prerelease(out PR prerelease);
+                stream.Build(out _);
 
-                c.Join(segments[0], segments[1], segments[2], prerelease, flag, stream.GetJoin(), includePrerelease);
+                c.Join(segments[0], segments[1], segments[2], prerelease, comparison, stream.GetJoin(), includePrerelease);
             }
             return true;
         }
@@ -698,10 +739,10 @@ namespace PSRule.Runtime
             if (!stream.TrySegments(out int[] segments))
                 return false;
 
-            if (!stream.ConsumePrerelease(out PR prerelease))
+            if (!stream.Prerelease(out PR prerelease))
                 return false;
 
-            stream.ConsumeBuild(out string build);
+            stream.Build(out string build);
             version = new Version(segments[0], segments[1], segments[2], prerelease, build);
             return true;
         }

--- a/tests/PSRule.Tests/SemanticVersionTests.cs
+++ b/tests/PSRule.Tests/SemanticVersionTests.cs
@@ -63,6 +63,8 @@ namespace PSRule
             Assert.True(Runtime.SemanticVersion.TryParseConstraint("1.2.3||3.4.5", out Runtime.SemanticVersion.IConstraint actual17));
             Assert.True(Runtime.SemanticVersion.TryParseConstraint(">=1.2.3", out Runtime.SemanticVersion.IConstraint actual18, includePrerelease: true));
             Assert.True(Runtime.SemanticVersion.TryParseConstraint("<=3.4.5-0", out Runtime.SemanticVersion.IConstraint actual19, includePrerelease: true));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("@pre >=1.2.3", out Runtime.SemanticVersion.IConstraint actual20));
+            Assert.True(Runtime.SemanticVersion.TryParseConstraint("@prerelease <=3.4.5-0", out Runtime.SemanticVersion.IConstraint actual21));
 
             // Version1 - 1.2.3
             Assert.True(actual1.Equals(version1));
@@ -84,6 +86,8 @@ namespace PSRule
             Assert.True(actual17.Equals(version1));
             Assert.True(actual18.Equals(version1));
             Assert.True(actual19.Equals(version1));
+            Assert.True(actual20.Equals(version1));
+            Assert.True(actual21.Equals(version1));
 
             // Version2 - 1.2.3-alpha.3+7223b39
             Assert.False(actual1.Equals(version2));
@@ -105,6 +109,8 @@ namespace PSRule
             Assert.False(actual17.Equals(version2));
             Assert.False(actual18.Equals(version2));
             Assert.True(actual19.Equals(version2));
+            Assert.False(actual20.Equals(version2));
+            Assert.True(actual21.Equals(version2));
 
             // Version3 - 3.4.5-alpha.9
             Assert.False(actual1.Equals(version3));
@@ -126,6 +132,8 @@ namespace PSRule
             Assert.False(actual17.Equals(version3));
             Assert.True(actual18.Equals(version3));
             Assert.False(actual19.Equals(version3));
+            Assert.True(actual20.Equals(version3));
+            Assert.False(actual21.Equals(version3));
 
             // Version4 - 3.4.5
             Assert.False(actual1.Equals(version4));
@@ -147,6 +155,8 @@ namespace PSRule
             Assert.True(actual17.Equals(version4));
             Assert.True(actual18.Equals(version4));
             Assert.False(actual19.Equals(version4));
+            Assert.True(actual20.Equals(version4));
+            Assert.False(actual21.Equals(version4));
         }
 
         [Fact]


### PR DESCRIPTION
## PR Summary

- Constraints support using a `@prerelease` or `@pre` to include prerelease versions. #717

Fixes #717 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
