### PR TITLE
Fixed null reference in convention #725

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.4.0-B2105019:
+
+- Bug fixes:
+  - Fixed null reference in convention for nested exceptions. [#725](https://github.com/microsoft/PSRule/issues/725)
+
 ## v1.4.0-B2105019 (pre-release)
 
 What's changed since pre-release v1.4.0-B2105004:

--- a/src/PSRule/Commands/InvokeConventionCommand.cs
+++ b/src/PSRule/Commands/InvokeConventionCommand.cs
@@ -50,8 +50,7 @@ namespace PSRule.Commands
                 {
                     // Evaluate script block
                     context.PushScope(Scope);
-                    var invokeResult = RuleConditionHelper.Create(Body.Invoke());
-                    WriteObject(invokeResult);
+                    Body.Invoke();
                 }
                 finally
                 {

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -417,6 +417,11 @@ namespace PSRule.Runtime
             var scriptStackTrace = errorRecord != null ? GetStackTrace(errorRecord) : null;
             var category = errorRecord != null ? errorRecord.CategoryInfo.Category : ErrorCategory.NotSpecified;
             var errorId = errorRecord != null ? GetErrorId(errorRecord) : null;
+            if (RuleRecord == null)
+            {
+                Writer.WriteError(errorRecord);
+                return;
+            }
             RuleRecord.Outcome = RuleOutcome.Error;
             RuleRecord.Error = new ErrorInfo(
                 message: ex.Message,

--- a/tests/PSRule.Tests/FromFileConventions.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileConventions.Rule.ps1
@@ -43,6 +43,11 @@ Export-PSRuleConvention 'Convention.Expansion' -If { $TargetObject.Name -eq 'Tes
     $PSRule.Import(@($newObject, $newObject));
 }
 
+# Synopsis: A convention for unit testing
+Export-PSRuleConvention 'Convention.WithException' -Begin {
+    throw 'Some exception';
+}
+
 # Synopsis: A rule for testing conventions
 Rule 'ConventionTest' {
     $Assert.HasFieldValue($PSRule.Data, 'count', 1);

--- a/tests/PSRule.Tests/PSRule.Conventions.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Conventions.Tests.ps1
@@ -26,7 +26,7 @@ $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Conven
 Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
 $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 
-Describe 'PSRule -- Conventions' -Tag 'Conventions' {
+Describe 'PSRule -- Conventions' -Tag 'Convention' {
     $rulePath = Join-Path -Path $here -ChildPath 'FromFileConventions.Rule.ps1';
 
     Context 'With -Convention' {
@@ -90,6 +90,12 @@ Describe 'PSRule -- Conventions' -Tag 'Conventions' {
             $result.Length | Should -Be 4;
             $result[0].TargetName | Should -Be 'TestObject1';
             $result[1].TargetName | Should -Be 'TestObject2';
+        }
+
+        It 'Handles nested exceptions' {
+            $Null = Invoke-PSRule @invokeParams -Name 'ConventionTest' -Convention 'Convention.WithException' -ErrorVariable errors -ErrorAction SilentlyContinue;
+            $errors | Should -Not -BeNullOrEmpty;
+            $errors.Exception.Message | Should -Be 'Some exception';
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed null reference in convention for nested exceptions. #725

Fixes #725 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
