### PR TITLE
Add source location of pipeline objects #729

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -22,8 +22,9 @@ What's changed since pre-release v1.4.0-B2105019:
 What's changed since pre-release v1.4.0-B2105004:
 
 - General improvements:
-  - Source location of object from input files are included in rule records. [#624](https://github.com/microsoft/PSRule/issues/624)
-    - Currently only JSON and YAML files support source locations.
+  - Source location of objects are included in results.
+    - Source location of objects from JSON and YAML input files are read automatically. [#624](https://github.com/microsoft/PSRule/issues/624)
+    - Source location of objects from the pipeline are read from properties. [#729](https://github.com/microsoft/PSRule/issues/729)
   - Improved support for version constraints by:
     - Constraints can include prerelease versions of other matching versions. [#714](https://github.com/microsoft/PSRule/issues/714)
     - Constraints support using a `@prerelease` or `@pre` to include prerelease versions. [#717](https://github.com/microsoft/PSRule/issues/717)

--- a/src/PSRule/Data/TargetSourceInfo.cs
+++ b/src/PSRule/Data/TargetSourceInfo.cs
@@ -4,11 +4,16 @@
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using System.Management.Automation;
 
 namespace PSRule.Data
 {
     public sealed class TargetSourceInfo
     {
+        private const string PROPERTY_FILE = "file";
+        private const string PROPERTY_LINE = "line";
+        private const string PROPERTY_POSITION = "position";
+
         public TargetSourceInfo()
         {
             // Do nothing
@@ -29,13 +34,13 @@ namespace PSRule.Data
             File = uri.AbsoluteUri;
         }
 
-        [JsonProperty(PropertyName = "file")]
+        [JsonProperty(PropertyName = PROPERTY_FILE)]
         public string File { get; internal set; }
 
-        [JsonProperty(PropertyName = "line")]
+        [JsonProperty(PropertyName = PROPERTY_LINE)]
         public int? Line { get; internal set; }
 
-        [JsonProperty(PropertyName = "position")]
+        [JsonProperty(PropertyName = PROPERTY_POSITION)]
         public int? Position { get; internal set; }
 
         public bool Equals(TargetSourceInfo other)
@@ -56,6 +61,29 @@ namespace PSRule.Data
                 hash = hash * 23 + (Position.HasValue ? Position.Value.GetHashCode() : 0);
                 return hash;
             }
+        }
+
+        public static TargetSourceInfo Create(object o)
+        {
+            if (o is PSObject pso)
+                return Create(pso);
+
+            return null;
+        }
+
+        public static TargetSourceInfo Create(PSObject o)
+        {
+            var result = new TargetSourceInfo();
+            if (o.TryProperty(PROPERTY_FILE, out string file))
+                result.File = file;
+
+            if (o.TryProperty(PROPERTY_LINE, out int line))
+                result.Line = line;
+
+            if (o.TryProperty(PROPERTY_POSITION, out int position))
+                result.Position = position;
+
+            return result;
         }
     }
 }

--- a/src/PSRule/Pipeline/PipelineReader.cs
+++ b/src/PSRule/Pipeline/PipelineReader.cs
@@ -32,6 +32,7 @@ namespace PSRule.Pipeline
 
             if (_Input == null || skipExpansion)
             {
+                sourceObject.ConvertTargetInfoProperty();
                 _Queue.Enqueue(sourceObject);
                 return;
             }
@@ -42,7 +43,10 @@ namespace PSRule.Pipeline
                 return;
 
             foreach (var item in input)
+            {
+                sourceObject.ConvertTargetInfoProperty();
                 _Queue.Enqueue(item);
+            }
         }
 
         public bool TryDequeue(out PSObject sourceObject)

--- a/src/PSRule/Runtime/PSRuleMemberInfo.cs
+++ b/src/PSRule/Runtime/PSRuleMemberInfo.cs
@@ -70,6 +70,9 @@ namespace PSRule.Runtime
 
         internal void WithSource(TargetSourceInfo source)
         {
+            if (source == null)
+                return;
+
             if (Source.Count == 0)
             {
                 Source.Add(source);

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -36,6 +36,15 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
         $testObject = [PSCustomObject]@{
             Name = 'TestObject1'
             Value = 1
+            '_PSRule' = [PSCustomObject]@{
+                source = @(
+                    [PSCustomObject]@{
+                        file = 'source.json'
+                        Line = 100
+                        Position = 1000
+                    }
+                )
+            }
         }
         $testObject.PSObject.TypeNames.Insert(0, 'TestType');
 
@@ -48,6 +57,10 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $result.TargetName | Should -Be 'TestObject1';
                 $result.Info.Annotations.culture | Should -Be 'en-ZZ';
                 $result.Recommendation | Should -Be 'This is a recommendation.';
+                $result.Source | Should -Not -BeNullOrEmpty;
+                $result.Source[0].File | Should -Be 'source.json';
+                $result.Source[0].Line | Should -Be 100;
+                $result.Source[0].Position | Should -Be 1000;
                 Assert-VerifiableMock;
             }
             finally {

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -95,6 +95,7 @@ namespace PSRule
             var builder = PipelineBuilder.Invoke(GetSource(), option, null, null);
             builder.InputPath(new string[] { "./**/ObjectFromFile.json" });
             var pipeline = builder.Build();
+            Assert.NotNull(pipeline);
             pipeline.Begin();
             pipeline.End();
         }

--- a/tests/PSRule.Tests/SourceTests.cs
+++ b/tests/PSRule.Tests/SourceTests.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class SourceTests
+    {
+        [Fact]
+        public void TargetSourceInfo()
+        {
+            var source = new PSObject();
+            source.Properties.Add(new PSNoteProperty("file", "file.json"));
+            source.Properties.Add(new PSNoteProperty("line", 100));
+            source.Properties.Add(new PSNoteProperty("position", 1000));
+            var info = new PSObject();
+            info.Properties.Add(new PSNoteProperty("source", new PSObject[] { source }));
+            var o = new PSObject();
+            o.Properties.Add(new PSNoteProperty("_PSRule", info));
+            o.ConvertTargetInfoProperty();
+
+            var actual = o.GetSourceInfo();
+            Assert.NotNull(actual);
+            Assert.Equal("file.json", actual[0].File);
+            Assert.Equal(100, actual[0].Line);
+            Assert.Equal(1000, actual[0].Position);
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added support for source location of pipeline objects. #729

Fixes #729 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
