### PR TITLE
Added VSCode support and style detection #731 #732

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,17 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.4.0-B2105032:
+
+- General improvements:
+  - Source location of objects from the pipeline are read from properties. [#729](https://github.com/microsoft/PSRule/issues/729)
+  - Assert output improvements:
+    - Added support for Visual Studio Code with `VisualStudioCode` style. [#731](https://github.com/microsoft/PSRule/issues/731)
+      - Updated output format provides support for problem matchers in task output.
+    - Automatically detect output style from environment variables. [#732](https://github.com/microsoft/PSRule/issues/732)
+      - _Assert-PSRule_ now defaults to `Detect` instead of `Client`.
+    - See [about_PSRule_Options] for details.
+
 ## v1.4.0-B2105032 (pre-release)
 
 What's changed since pre-release v1.4.0-B2105019:
@@ -24,7 +35,6 @@ What's changed since pre-release v1.4.0-B2105004:
 - General improvements:
   - Source location of objects are included in results.
     - Source location of objects from JSON and YAML input files are read automatically. [#624](https://github.com/microsoft/PSRule/issues/624)
-    - Source location of objects from the pipeline are read from properties. [#729](https://github.com/microsoft/PSRule/issues/729)
   - Improved support for version constraints by:
     - Constraints can include prerelease versions of other matching versions. [#714](https://github.com/microsoft/PSRule/issues/714)
     - Constraints support using a `@prerelease` or `@pre` to include prerelease versions. [#717](https://github.com/microsoft/PSRule/issues/717)

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -360,10 +360,21 @@ Configures the style that results will be presented in.
 
 The following styles are available:
 
-- Client - Output is written to the host directly in green/ red to indicate outcome. This is the default.
-- Plain - Output is written to the host as a plain string.
-- AzurePipelines - Output is written with commands that can be interpreted by Azure Pipelines.
-- GitHubActions - Output is written with commands that can be interpreted by GitHub Actions.
+- Client - Output is written to the host directly in green/ red to indicate outcome.
+- Plain - Output is written as an unformatted string.
+This option can be redirected to a file.
+- AzurePipelines - Output is written for integration Azure Pipelines.
+- GitHubActions - Output is written for integration GitHub Actions.
+- VisualStudioCode - Output is written for integration with Visual Studio Code.
+- Detect - Output style will be detected by checking the environment variables.
+This is the default.
+
+Detect uses the following logic:
+
+1. If the `TF_BUILD` environment variable is set to `true`, `AzurePipelines` will be used.
+2. If the `GITHUB_ACTIONS` environment variable is set to `true`, `GitHubActions` will be used.
+3. If the `TERM_PROGRAM` environment variable is set to `vscode`, `VisualStudioCode` will be used.
+4. Use `Client`.
 
 Each of these styles outputs to the host. To capture output as a string redirect the information stream.
 For example: `6>&1`
@@ -372,7 +383,7 @@ For example: `6>&1`
 Type: OutputStyle
 Parameter Sets: (All)
 Aliases:
-Accepted values: Client, Plain, AzurePipelines, GitHubActions
+Accepted values: Client, Plain, AzurePipelines, GitHubActions, VisualStudioCode, Detect
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -25,8 +25,9 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
  [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
  [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -41,8 +42,9 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
  [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
  [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -56,8 +58,9 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
  [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
  [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -589,6 +592,24 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputBanner
+
+Sets the option `Output.Banner`.
+The `Output.Banner` option configure information displayed with PSRule banner.
+This option is only applicable when using `Assert-PSRule` cmdlet.
+
+```yaml
+Type: BannerFormat
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -21,9 +21,10 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-NotProcessedWarning <Boolean>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
  [-ObjectPath <String>] [-InputPathIgnore <String[]>] [-InputTargetType <String[]>]
  [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -489,6 +490,24 @@ Accepted values: Detail, Summary
 Required: False
 Position: Named
 Default value: Detail
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputBanner
+
+Sets the option `Output.Banner`.
+The `Output.Banner` option configure information displayed with PSRule banner.
+This option is only applicable when using `Assert-PSRule` cmdlet.
+
+```yaml
+Type: BannerFormat
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Default
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1653,10 +1653,21 @@ If specified, the `-Style` parameter takes precedence, over this option.
 
 The following styles are available:
 
-- Client - Output is written to the host directly in green/ red to indicate outcome. This is the default.
-- Plain - Output is written as an unformatted string. This option can be redirected to a file.
-- AzurePipelines - Output is written with commands that can be interpreted by Azure Pipelines.
-- GitHubActions - Output is written with commands that can be interpreted by GitHub Actions.
+- Client - Output is written to the host directly in green/ red to indicate outcome.
+- Plain - Output is written as an unformatted string.
+This option can be redirected to a file.
+- AzurePipelines - Output is written for integration Azure Pipelines.
+- GitHubActions - Output is written for integration GitHub Actions.
+- VisualStudioCode - Output is written for integration with Visual Studio Code.
+- Detect - Output style will be detected by checking the environment variables.
+This is the default.
+
+Detect uses the following logic:
+
+1. If the `TF_BUILD` environment variable is set to `true`, `AzurePipelines` will be used.
+2. If the `GITHUB_ACTIONS` environment variable is set to `true`, `GitHubActions` will be used.
+3. If the `TERM_PROGRAM` environment variable is set to `vscode`, `VisualStudioCode` will be used.
+4. Use `Client`.
 
 This option can be specified using:
 
@@ -2067,7 +2078,7 @@ output:
   encoding: Default
   format: None
   outcome: Processed
-  style: Client
+  style: Detect
 
 # Configure rule suppression
 suppression: { }

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -2,7 +2,56 @@
 
 This document contains notes to help upgrade from previous versions of PSRule.
 
-## Upgrade to v0.22.0 from v1.0.0
+## Upgrading to v1.4.0
+
+Follow these notes to upgrade from PSRule version _v1.3.0_ to _v1.4.0_.
+
+### Change in default output styles
+
+Previously in PSRule _v1.3.0_ and prior the default style when using `Assert-PSRule` was `Client`.
+From _v1.4.0_ PSRule now defaults to `Detect`.
+
+The `Detect` output style falls back to `Client` however may detect one of the following styles instead:
+
+- `AzurePipelines` - Output is written for integration Azure Pipelines.
+- `GitHubActions` - Output is written for integration GitHub Actions.
+- `VisualStudioCode` - Output is written for integration with Visual Studio Code.
+
+Detect uses the following logic:
+
+1. If the `TF_BUILD` environment variable is set to `true`, `AzurePipelines` will be used.
+2. If the `GITHUB_ACTIONS` environment variable is set to `true`, `GitHubActions` will be used.
+3. If the `TERM_PROGRAM` environment variable is set to `vscode`, `VisualStudioCode` will be used.
+4. Use `Client`.
+
+To force usage of the `Client` output style set the `Output.Style` option.
+For example:
+
+```yaml
+# YAML: Using the output/style property
+output:
+  style: Client
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_OUTPUT_STYLE=Client
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_OUTPUT_STYLE: Client
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_OUTPUT_STYLE
+  value: Client
+```
+
+## Upgrading to v1.0.0
 
 Follow these notes to upgrade from PSRule version _v0.22.0_ to _v1.0.0_.
 

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -421,15 +421,17 @@
                 "style": {
                     "type": "string",
                     "title": "Output Style",
-                    "description": "The style that results will be presented in. The default is Client.",
-                    "markdownDescription": "The style that results will be presented in. The default is `Client`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputstyle)",
+                    "description": "The style that results will be presented in. The default is Detect.",
+                    "markdownDescription": "The style that results will be presented in. The default is `Detect`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputstyle)",
                     "enum": [
                         "Client",
                         "Plain",
                         "AzurePipelines",
-                        "GitHubActions"
+                        "GitHubActions",
+                        "VisualStudioCode",
+                        "Detect"
                     ],
-                    "default": "Client"
+                    "default": "Detect"
                 }
             },
             "additionalProperties": false

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -220,7 +220,7 @@ namespace PSRule
             if (bindTargetInfo)
             {
                 result.UseTargetInfo(out PSRuleTargetInfo info);
-                info.WithSource(lineNumber, linePosition);
+                info.SetSource(lineNumber, linePosition);
             }
             return result;
         }

--- a/src/PSRule/Common/StringExtensions.cs
+++ b/src/PSRule/Common/StringExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 
 namespace PSRule
 {
@@ -10,6 +11,62 @@ namespace PSRule
         public static bool IsUri(this string s)
         {
             return s.StartsWith("http://", StringComparison.OrdinalIgnoreCase) || s.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static string[] SplitSemantic(this string s, int width = 80)
+        {
+            if (s == null)
+                return null;
+
+            if (s.Length <= 80)
+                return new string[] { s };
+
+            var result = new List<string>();
+            var pos = 0;
+            while (pos < s.Length)
+            {
+                var i = pos + width - 1;
+                if (i >= s.Length)
+                    i = s.Length - 1;
+
+                var breaks = s.IndexOfAny(new char[] { '\r', '\n' }, pos, i - pos);
+                if (breaks > -1)
+                    i = breaks;
+                else
+                {
+                    while (!IsSemanticStopChar(s[i]) && i > pos)
+                        i--;
+                }
+
+                if (i == pos)
+                {
+                    // move forward
+                }
+                if (char.IsPunctuation(s[i]))
+                    i++;
+
+                while (i > pos && i < s.Length && IsLineBreak(s[i]))
+                    i--;
+
+                if (pos != i)
+                    result.Add(s.Substring(pos, i - pos));
+
+                while (i < s.Length && IsLineBreak(s[i]))
+                    i++;
+
+                pos = i + 1;
+            }
+            return result.ToArray();
+        }
+
+        private static bool IsSemanticStopChar(char c)
+        {
+            return char.IsWhiteSpace(c) || (char.IsPunctuation(c) && char.GetUnicodeCategory(c) != System.Globalization.UnicodeCategory.DashPunctuation);
+        }
+
+        private static bool IsLineBreak(char c)
+        {
+            return char.GetUnicodeCategory(c) == System.Globalization.UnicodeCategory.LineSeparator;
         }
     }
 }

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -665,7 +665,7 @@ namespace PSRule
                 if (value is PSObject pso)
                 {
                     pso.UseTargetInfo(out PSRuleTargetInfo info);
-                    info.WithSource(lineNumber, linePosition);
+                    info.SetSource(lineNumber, linePosition);
                     value = new PSObject[] { pso };
                     return true;
                 }

--- a/src/PSRule/Configuration/OutputOption.cs
+++ b/src/PSRule/Configuration/OutputOption.cs
@@ -14,11 +14,11 @@ namespace PSRule.Configuration
     public sealed class OutputOption : IEquatable<OutputOption>
     {
         private const ResultFormat DEFAULT_AS = ResultFormat.Detail;
+        private const BannerFormat DEFAULT_BANNER = BannerFormat.Default;
         private const OutputEncoding DEFAULT_ENCODING = OutputEncoding.Default;
         private const OutputFormat DEFAULT_FORMAT = OutputFormat.None;
         private const RuleOutcome DEFAULT_OUTCOME = RuleOutcome.Processed;
-        private const OutputStyle DEFAULT_STYLE = OutputStyle.Client;
-        private const BannerFormat DEFAULT_BANNER = BannerFormat.Default;
+        private const OutputStyle DEFAULT_STYLE = OutputStyle.Detect;
 
         internal static readonly OutputOption Default = new OutputOption
         {

--- a/src/PSRule/Configuration/OutputStyle.cs
+++ b/src/PSRule/Configuration/OutputStyle.cs
@@ -30,6 +30,16 @@ namespace PSRule.Configuration
         /// <summary>
         /// Text written to output stream, with fails marked for GitHub Actions.
         /// </summary>
-        GitHubActions = 3
+        GitHubActions = 3,
+
+        /// <summary>
+        /// Text is written to output stream formatted for Visual Studio Code.
+        /// </summary>
+        VisualStudioCode = 4,
+
+        /// <summary>
+        /// Automatically detect the style to use.
+        /// </summary>
+        Detect = 255
     }
 }

--- a/src/PSRule/PSRule.csproj
+++ b/src/PSRule/PSRule.csproj
@@ -25,6 +25,18 @@ This project uses GitHub Issues to track bugs and feature requests. See GitHub p
     <DefineConstants>Windows</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Manatee.Json" Version="13.0.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -476,8 +476,8 @@ function Assert-PSRule {
         [String[]]$Convention,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions')]
-        [PSRule.Configuration.OutputStyle]$Style = [PSRule.Configuration.OutputStyle]::Client,
+        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
+        [PSRule.Configuration.OutputStyle]$Style = [PSRule.Configuration.OutputStyle]::Detect,
 
         [Parameter(Mandatory = $False)]
         [PSRule.Rules.RuleOutcome]$Outcome = [PSRule.Rules.RuleOutcome]::Processed,
@@ -1139,8 +1139,8 @@ function New-PSRuleOption {
 
         # Sets the Output.Style option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions')]
-        [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Client
+        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
+        [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Detect
     )
 
     begin {
@@ -1359,8 +1359,8 @@ function Set-PSRuleOption {
 
         # Sets the Output.Style option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions')]
-        [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Client
+        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
+        [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Detect
     )
     begin {
         Write-Verbose -Message "[Set-PSRuleOption] BEGIN::";
@@ -1989,8 +1989,8 @@ function SetOptions {
 
         # Sets the Output.Style option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions')]
-        [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Client
+        [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
+        [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Detect
     )
     process {
         # Options

--- a/src/PSRule/Pipeline/InvokeResult.cs
+++ b/src/PSRule/Pipeline/InvokeResult.cs
@@ -42,6 +42,28 @@ namespace PSRule.Pipeline
 
         internal RuleOutcome Outcome => _Outcome;
 
+        internal string TargetName
+        {
+            get
+            {
+                if (_Record == null || _Record.Count == 0)
+                    return null;
+
+                return _Record[0].TargetName;
+            }
+        }
+
+        internal string TargetType
+        {
+            get
+            {
+                if (_Record == null || _Record.Count == 0)
+                    return null;
+
+                return _Record[0].TargetType;
+            }
+        }
+
         /// <summary>
         /// Get the individual records for the target object.
         /// </summary>

--- a/src/PSRule/Pipeline/PipelineReciever.cs
+++ b/src/PSRule/Pipeline/PipelineReciever.cs
@@ -342,7 +342,7 @@ namespace PSRule.Pipeline
                 return;
 
             value.UseTargetInfo(out PSRuleTargetInfo targetInfo);
-            targetInfo.WithSource(source);
+            targetInfo.UpdateSource(source);
         }
 
         private static JsonTextReader AsJsonTextReader(TextReader reader)

--- a/src/PSRule/Resources/FormatterStrings.Designer.cs
+++ b/src/PSRule/Resources/FormatterStrings.Designer.cs
@@ -106,15 +106,6 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     | - .
-        /// </summary>
-        internal static string HelpLinkPrefix {
-            get {
-                return ResourceManager.GetString("HelpLinkPrefix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0}: {1}.
         /// </summary>
         internal static string HelpModule {
@@ -129,15 +120,6 @@ namespace PSRule.Resources {
         internal static string Message {
             get {
                 return ResourceManager.GetString("Message", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to     | .
-        /// </summary>
-        internal static string MessagePrefix {
-            get {
-                return ResourceManager.GetString("MessagePrefix", resourceCulture);
             }
         }
         
@@ -178,15 +160,6 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     | - .
-        /// </summary>
-        internal static string ReasonPrefix {
-            get {
-                return ResourceManager.GetString("ReasonPrefix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to     | RECOMMEND:.
         /// </summary>
         internal static string Recommend {
@@ -196,16 +169,7 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     | .
-        /// </summary>
-        internal static string RecommendPrefix {
-            get {
-                return ResourceManager.GetString("RecommendPrefix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to     [ERROR] {0}.
+        ///   Looks up a localized string similar to     [ERROR] .
         /// </summary>
         internal static string Result_Error {
             get {
@@ -223,7 +187,7 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     [FAIL] {0}.
+        ///   Looks up a localized string similar to     [FAIL] .
         /// </summary>
         internal static string Result_Fail {
             get {
@@ -241,7 +205,7 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     [PASS] {0}.
+        ///   Looks up a localized string similar to     [PASS] .
         /// </summary>
         internal static string Result_Pass {
             get {
@@ -250,11 +214,20 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to     [WARN] {0}.
+        ///   Looks up a localized string similar to     [WARN] .
         /// </summary>
         internal static string Result_Warning {
             get {
                 return ResourceManager.GetString("Result_Warning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to At.
+        /// </summary>
+        internal static string SourceAt {
+            get {
+                return ResourceManager.GetString("SourceAt", resourceCulture);
             }
         }
         
@@ -268,11 +241,101 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to  -&gt; .
+        /// </summary>
+        internal static string StartObjectPrefix {
+            get {
+                return ResourceManager.GetString("StartObjectPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rules processed: {0}, failed: {1}, errored: {2}.
         /// </summary>
         internal static string Summary {
             get {
                 return ResourceManager.GetString("Summary", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to     | SYNOPSIS: .
+        /// </summary>
+        internal static string SynopsisPrefix {
+            get {
+                return ResourceManager.GetString("SynopsisPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  ERROR .
+        /// </summary>
+        internal static string VSCode_Error {
+            get {
+                return ResourceManager.GetString("VSCode_Error", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  FAIL .
+        /// </summary>
+        internal static string VSCode_Fail {
+            get {
+                return ResourceManager.GetString("VSCode_Fail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   Help:.
+        /// </summary>
+        internal static string VSCode_Help {
+            get {
+                return ResourceManager.GetString("VSCode_Help", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  PASS .
+        /// </summary>
+        internal static string VSCode_Pass {
+            get {
+                return ResourceManager.GetString("VSCode_Pass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   Reason:.
+        /// </summary>
+        internal static string VSCode_Reason {
+            get {
+                return ResourceManager.GetString("VSCode_Reason", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   Recommend:.
+        /// </summary>
+        internal static string VSCode_Recommend {
+            get {
+                return ResourceManager.GetString("VSCode_Recommend", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &gt; .
+        /// </summary>
+        internal static string VSCode_StartObjectPrefix {
+            get {
+                return ResourceManager.GetString("VSCode_StartObjectPrefix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  WARN .
+        /// </summary>
+        internal static string VSCode_Warning {
+            get {
+                return ResourceManager.GetString("VSCode_Warning", resourceCulture);
             }
         }
     }

--- a/src/PSRule/Resources/FormatterStrings.resx
+++ b/src/PSRule/Resources/FormatterStrings.resx
@@ -132,17 +132,11 @@
   <data name="HelpIssues" xml:space="preserve">
     <value>Report issues: https://github.com/microsoft/PSRule/issues</value>
   </data>
-  <data name="HelpLinkPrefix" xml:space="preserve">
-    <value>    | - </value>
-  </data>
   <data name="HelpModule" xml:space="preserve">
     <value>{0}: {1}</value>
   </data>
   <data name="Message" xml:space="preserve">
     <value>    | MESSAGE:</value>
-  </data>
-  <data name="MessagePrefix" xml:space="preserve">
-    <value>    | </value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
     <value>Using {0} v{1}</value>
@@ -157,38 +151,65 @@
     <value>    | REASON:</value>
     <comment>Reason output header</comment>
   </data>
-  <data name="ReasonPrefix" xml:space="preserve">
-    <value>    | - </value>
-  </data>
   <data name="Recommend" xml:space="preserve">
     <value>    | RECOMMEND:</value>
     <comment>Recommendation output header</comment>
   </data>
-  <data name="RecommendPrefix" xml:space="preserve">
-    <value>    | </value>
-  </data>
   <data name="Result_Error" xml:space="preserve">
-    <value>    [ERROR] {0}</value>
+    <value>    [ERROR] </value>
   </data>
   <data name="Result_ErrorDetail" xml:space="preserve">
     <value>{0} failed {1} with the error '{2}'.</value>
   </data>
   <data name="Result_Fail" xml:space="preserve">
-    <value>    [FAIL] {0}</value>
+    <value>    [FAIL] </value>
   </data>
   <data name="Result_FailDetail" xml:space="preserve">
     <value>{0} failed {1}. {2}</value>
   </data>
   <data name="Result_Pass" xml:space="preserve">
-    <value>    [PASS] {0}</value>
+    <value>    [PASS] </value>
   </data>
   <data name="Result_Warning" xml:space="preserve">
-    <value>    [WARN] {0}</value>
+    <value>    [WARN] </value>
+  </data>
+  <data name="SourceAt" xml:space="preserve">
+    <value>At</value>
   </data>
   <data name="StackTrace" xml:space="preserve">
     <value>    | STACK TRACE:</value>
   </data>
+  <data name="StartObjectPrefix" xml:space="preserve">
+    <value> -&gt; </value>
+  </data>
   <data name="Summary" xml:space="preserve">
     <value>Rules processed: {0}, failed: {1}, errored: {2}</value>
+  </data>
+  <data name="SynopsisPrefix" xml:space="preserve">
+    <value>    | SYNOPSIS: </value>
+  </data>
+  <data name="VSCode_Error" xml:space="preserve">
+    <value> ERROR </value>
+  </data>
+  <data name="VSCode_Fail" xml:space="preserve">
+    <value> FAIL </value>
+  </data>
+  <data name="VSCode_Help" xml:space="preserve">
+    <value>  Help:</value>
+  </data>
+  <data name="VSCode_Pass" xml:space="preserve">
+    <value> PASS </value>
+  </data>
+  <data name="VSCode_Reason" xml:space="preserve">
+    <value>  Reason:</value>
+  </data>
+  <data name="VSCode_Recommend" xml:space="preserve">
+    <value>  Recommend:</value>
+  </data>
+  <data name="VSCode_StartObjectPrefix" xml:space="preserve">
+    <value>&gt; </value>
+  </data>
+  <data name="VSCode_Warning" xml:space="preserve">
+    <value> WARN </value>
   </data>
 </root>

--- a/src/PSRule/Rules/RuleHelpInfo.cs
+++ b/src/PSRule/Rules/RuleHelpInfo.cs
@@ -64,7 +64,7 @@ namespace PSRule.Rules
         public string Synopsis { get; internal set; }
 
         /// <summary>
-        /// An extented description of the rule.
+        /// An extended description of the rule.
         /// </summary>
         [JsonProperty(PropertyName = "description")]
         public string Description { get; internal set; }

--- a/src/PSRule/Runtime/PSRuleMemberInfo.cs
+++ b/src/PSRule/Runtime/PSRuleMemberInfo.cs
@@ -73,6 +73,14 @@ namespace PSRule.Runtime
             if (source == null)
                 return;
 
+            Source.Add(source);
+        }
+
+        internal void UpdateSource(TargetSourceInfo source)
+        {
+            if (source == null)
+                return;
+
             if (Source.Count == 0)
             {
                 Source.Add(source);
@@ -83,7 +91,7 @@ namespace PSRule.Runtime
                 Source[0].File = source.File;
         }
 
-        internal void WithSource(int lineNumber, int linePosition)
+        internal void SetSource(int lineNumber, int linePosition)
         {
             if (Source.Count > 0)
                 return;

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -1208,7 +1208,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     Context 'Read Output.Style' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
-            $option.Output.Style | Should -Be 'Client';
+            $option.Output.Style | Should -Be 'Detect';
         }
 
         It 'from Hashtable' {

--- a/tests/PSRule.Tests/SemanticBreakTests.cs
+++ b/tests/PSRule.Tests/SemanticBreakTests.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class SemanticBreakTests
+    {
+        [Fact]
+        public void BreakShort()
+        {
+            var original = "Consider using Hybrid Use Benefit for eligible workloads.";
+            var actual = original.SplitSemantic();
+            Assert.Single(actual);
+            Assert.Equal(original, actual[0]);
+        }
+
+        [Fact]
+        public void BreakLong()
+        {
+            var original = "Use a minimum of Standard for production container registries. Basic container registries are only recommended for non-production deployments. Consider upgrading ACR to Premium and enabling geo-replication between Azure regions to provide an in region registry to complement high availability or disaster recovery for container environments.";
+            var actual = original.SplitSemantic();
+            Assert.Equal("Use a minimum of Standard for production container registries. Basic container", actual[0]);
+            Assert.Equal("registries are only recommended for non-production deployments. Consider", actual[1]);
+            Assert.Equal("upgrading ACR to Premium and enabling geo-replication between Azure regions to", actual[2]);
+            Assert.Equal("provide an in region registry to complement high availability or disaster", actual[3]);
+            Assert.Equal("recovery for container environments.", actual[4]);
+            Assert.Equal(5, actual.Length);
+        }
+
+        [Fact]
+        public void BreakDash()
+        {
+            var original = "Consider configuring NSGs rules to block outbound management traffic from non-management hosts.";
+            var actual = original.SplitSemantic();
+            Assert.Equal("Consider configuring NSGs rules to block outbound management traffic from", actual[0]);
+            Assert.Equal("non-management hosts.", actual[1]);
+            Assert.Equal(2, actual.Length);
+        }
+
+        [Fact]
+        public void BreakNewLine()
+        {
+            var original = "Use a minimum of Standard for production container registries. Basic container registries are only recommended for non-production deployments.\r\nConsider upgrading ACR to Premium and enabling geo-replication between Azure regions to provide an in region registry to complement high availability or disaster recovery for container environments.";
+            var actual = original.SplitSemantic();
+            Assert.Equal("Use a minimum of Standard for production container registries. Basic container", actual[0]);
+            Assert.Equal("registries are only recommended for non-production deployments.", actual[1]);
+            Assert.Equal("Consider upgrading ACR to Premium and enabling geo-replication between Azure", actual[2]);
+            Assert.Equal("regions to provide an in region registry to complement high availability or", actual[3]);
+            Assert.Equal("disaster recovery for container environments.", actual[4]);
+            Assert.Equal(5, actual.Length);
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added support for Visual Studio Code with `VisualStudioCode` style. #731
  - Updated output format provides support for problem matchers in task output.
- Automatically detect output style from environment variables. #732
  - _Assert-PSRule_ now defaults to `Detect` instead of `Client`.

Fixes #731 
Fixes #732 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
