### PR TITLE
Automatically include default path #742

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,8 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.LanguageMode](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionlanguagemode)
   - [Execution.InconclusiveWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executioninconclusivewarning)
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionnotprocessedwarning)
+  - [Include.Module](docs/concepts/PSRule/en-US/about_PSRule_Options.md#includemodule)
+  - [Include.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#includepath)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
   - [Input.IgnoreGitPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputignoregitpath)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,9 @@ What's changed since v1.5.0:
 
 - General improvements:
   - Added support for object source location in validation. [#757](https://github.com/microsoft/PSRule/issues/757)
+  - Default rule source location `.ps-rule/` is automatically included. [#742](https://github.com/microsoft/PSRule/issues/742)
+    - Added `Include.Path` and `Include.Module` options to automatically include rule sources.
+    - See [about_PSRule_Options] for details.
 
 ## v1.5.0
 
@@ -62,9 +65,9 @@ What's changed since v1.3.0:
 
 - General improvements:
   - PSRule banner can be configured in output when using `Assert-PSRule`. [#708](https://github.com/microsoft/PSRule/issues/708)
-  - Source location of objects are included in results.
-    - Source location of objects from JSON and YAML input files are read automatically. [#624](https://github.com/microsoft/PSRule/issues/624)
-    - Source location of objects from the pipeline are read from properties. [#729](https://github.com/microsoft/PSRule/issues/729)
+  - Input source location of objects are included in results.
+    - Input source location of objects from JSON and YAML input files are read automatically. [#624](https://github.com/microsoft/PSRule/issues/624)
+    - Input source location of objects from the pipeline are read from properties. [#729](https://github.com/microsoft/PSRule/issues/729)
   - Assert output improvements:
     - Added support for Visual Studio Code with `VisualStudioCode` style. [#731](https://github.com/microsoft/PSRule/issues/731)
       - Updated output format provides support for problem matchers in task output.

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -210,9 +210,7 @@ Accept wildcard characters: False
 ### -Module
 
 Search for rule definitions within a module.
-When specified without the `-Path` parameter, only rule definitions in the module will be discovered.
-
-When both `-Path` and `-Module` are specified, rule definitions from both are discovered.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -435,10 +433,7 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for rule definitions within.
-
-If this parameter is not specified the current working path will be used, unless the `-Module` parameter is used.
-
-If the `-Module` parameter is used, rule definitions from the currently working path will not be included by default.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -106,10 +106,7 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for rule definitions within.
-
-If this parameter is not specified the current working path will be used, unless the `-Module` parameter is used.
-
-If the `-Module` parameter is used, rule definitions from the currently working path will not be included by default.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -187,9 +184,7 @@ Accept wildcard characters: False
 ### -Module
 
 Search for rule definitions within a module.
-When specified without the `-Path` parameter, only rule definitions in the module will be discovered.
-
-When both `-Path` and `-Module` are specified, rule definitions from both are discovered.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]

--- a/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
@@ -37,9 +37,7 @@ Get a list of baselines from the current working path.
 ### -Module
 
 Search for baselines definitions within a module.
-When specified without the `-Path` parameter, only baseline definitions in the module will be discovered.
-
-When both `-Path` and `-Module` are specified, baseline definitions from both are discovered.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -74,10 +72,7 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for baselines within.
-
-If this parameter is not specified the current working path will be used, unless the `-Module` parameter is used.
-
-If the `-Module` parameter is used, baselines from the currently working path will not be included by default.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -147,10 +147,7 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for rule definitions within.
-
-If this parameter is not specified the current working path will be used, unless the `-Module` parameter is used.
-
-If the `-Module` parameter is used, rule definitions from the currently working path will not be included by default.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -397,9 +394,7 @@ Accept wildcard characters: False
 ### -Module
 
 Search for rule definitions within a module.
-When specified without the `-Path` parameter, only rule definitions in the module will be discovered.
-
-When both `-Path` and `-Module` are specified, rule definitions from both are discovered.
+If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -21,13 +21,13 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -38,13 +38,13 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-Format <InputFormat>]
- [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -55,12 +55,12 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>]
  [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
  [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -416,6 +416,40 @@ See about_PSRule_Options for more information.
 Type: Boolean
 Parameter Sets: (All)
 Aliases: ExecutionNotProcessedWarning
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeModule
+
+Sets the `Include.Module` option to include additional module sources.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludePath
+
+Sets the `Include.Path` option to include additional standalone sources.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -18,13 +18,13 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>] [-BindingNameSeparator <String>]
  [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-InconclusiveWarning <Boolean>]
- [-NotProcessedWarning <Boolean>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-ObjectPath <String>] [-InputPathIgnore <String[]>] [-InputTargetType <String[]>]
- [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-NotProcessedWarning <Boolean>] [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>]
+ [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
+ [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -320,6 +320,40 @@ Aliases: ExecutionNotProcessedWarning
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeModule
+
+Sets the `Include.Module` option to include additional module sources.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludePath
+
+Sets the `Include.Path` option to include additional standalone sources.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -17,6 +17,8 @@ The following workspace options are available for use:
 - [Execution.LanguageMode](#executionlanguagemode)
 - [Execution.InconclusiveWarning](#executioninconclusivewarning)
 - [Execution.NotProcessedWarning](#executionnotprocessedwarning)
+- [Include.Module](#includemodule)
+- [Include.Path](#includepath)
 - [Input.Format](#inputformat)
 - [Input.IgnoreGitPath](#inputignoregitpath)
 - [Input.ObjectPath](#inputobjectpath)
@@ -801,6 +803,115 @@ env:
 variables:
 - name: PSRULE_EXECUTION_NOTPROCESSEDWARNING
   value: false
+```
+
+### Include.Module
+
+Automatically include rules and resources from the specified module.
+To automatically import and include a module specify the module by name.
+The module must already be installed on the system.
+
+When `$PSModuleAutoLoadingPreference` is set to a value other then `All` the module must be imported.
+
+This option is equivalent to using the `-Module` parameter on PSRule cmdlets, with the following addition:
+
+- Modules specified with `Include.Module` are combined with `-Module`.
+  Both sets of modules will be imported and used using execution.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the IncludeModule parameter
+$option = New-PSRuleOption -IncludeModule 'TestModule1', 'TestModule2';
+```
+
+```powershell
+# PowerShell: Using the Include.Module hashtable key
+$option = New-PSRuleOption -Option @{ 'Include.Module' = 'TestModule1', 'TestModule2' };
+```
+
+```powershell
+# PowerShell: Using the IncludeModule parameter to set YAML
+Set-PSRuleOption -IncludeModule 'TestModule1', 'TestModule2';
+```
+
+```yaml
+# YAML: Using the include/module property
+include:
+  module:
+  - TestModule1
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_INCLUDE_MODULE=TestModule1;TestModule2
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_INCLUDE_MODULE: TestModule1;TestModule2
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_INCLUDE_MODULE
+  value: TestModule1;TestModule2
+```
+
+### Include.Path
+
+Automatically include rules and resources from the specified path.
+By default, `.ps-rule/` is included.
+
+This option is equivalent to using the `-Path` parameter on PSRule cmdlets, with the following additions:
+
+- Paths specified with `Include.Path` are combined with `-Path`.
+  Both sets of paths will be imported and used using execution.
+- The `Include.Path` option defaults to `.ps-rule/`.
+  To override this default, specify one or more alternative paths or an empty array.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the IncludePath parameter
+$option = New-PSRuleOption -IncludePath '.ps-rule/', 'custom-rules/';
+```
+
+```powershell
+# PowerShell: Using the Include.Path hashtable key
+$option = New-PSRuleOption -Option @{ 'Include.Path' = '.ps-rule/', 'custom-rules/' };
+```
+
+```powershell
+# PowerShell: Using the IncludePath parameter to set YAML
+Set-PSRuleOption -IncludePath '.ps-rule/', 'custom-rules/';
+```
+
+```yaml
+# YAML: Using the include/path property
+include:
+  path:
+  - custom-rules/
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_INCLUDE_PATH=.ps-rule/;custom-rules/
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_INCLUDE_PATH: .ps-rule/;custom-rules/
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_INCLUDE_PATH
+  value: .ps-rule/;custom-rules/
 ```
 
 ### Input.Format
@@ -1721,6 +1832,7 @@ Module version constraints a not enforced prior to PSRule v0.19.0.
 
 The version constraint for a rule module is enforced when the module is included with `-Module`.
 A version constraint does not require a rule module to be included.
+Use the `Include.Module` option to automatically include a rule module.
 
 This option can be specified using:
 
@@ -1962,6 +2074,12 @@ execution:
   inconclusiveWarning: false
   notProcessedWarning: false
 
+# Configure include options
+include:
+  module:
+  - 'PSRule.Rules.Azure'
+  path: [ ]
+
 # Configures input options
 input:
   format: Yaml
@@ -2055,6 +2173,12 @@ execution:
   languageMode: FullLanguage
   inconclusiveWarning: true
   notProcessedWarning: true
+
+# Configure include options
+include:
+  module: [ ]
+  path:
+  - '.ps-rule/'
 
 # Configures input options
 input:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -13,3 +13,6 @@ input:
   pathIgnore:
   - '*.Designer.cs'
   - '*.md'
+
+include:
+  path: []

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -139,6 +139,40 @@
             },
             "additionalProperties": false
         },
+        "include-option": {
+            "type": "object",
+            "title": "Include options",
+            "description": "Options that affect source locations imported for execution.",
+            "properties": {
+                "module": {
+                    "type": "array",
+                    "title": "Include module",
+                    "description": "Automatically include rules and resources from the specified modules.",
+                    "markdownDescription": "Automatically include rules and resources from the specified modules. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includemodule)",
+                    "items": {
+                        "type": "string",
+                        "title": "Include module",
+                        "description": "Automatically include rules and resources from the specified modules.",
+                        "markdownDescription": "Automatically include rules and resources from the specified modules. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includemodule)"
+                    },
+                    "uniqueItems": true
+                },
+                "path": {
+                    "type": "array",
+                    "title": "Include path",
+                    "description": "Automatically include rules and resources from the specified paths.",
+                    "markdownDescription": "Automatically include rules and resources from the specified paths. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includepath)",
+                    "items": {
+                        "type": "string",
+                        "title": "Include path",
+                    "description": "Automatically include rules and resources from the specified paths.",
+                    "markdownDescription": "Automatically include rules and resources from the specified paths. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includepath)"
+                    },
+                    "uniqueItems": true
+                }
+            },
+            "additionalProperties": false
+        },
         "input-option": {
             "type": "object",
             "title": "Input options",
@@ -465,6 +499,10 @@
                             "$ref": "#/definitions/execution-option"
                         }
                     ]
+                },
+                "include": {
+                    "type": "object",
+                    "$ref": "#/definitions/include-option"
                 },
                 "input": {
                     "type": "object",

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -7,6 +7,9 @@ using System.ComponentModel;
 
 namespace PSRule.Configuration
 {
+    /// <summary>
+    /// Options that configure the execution sandbox.
+    /// </summary>
     public sealed class ExecutionOption : IEquatable<ExecutionOption>
     {
         private const LanguageMode DEFAULT_LANGUAGEMODE = Configuration.LanguageMode.FullLanguage;

--- a/src/PSRule/Configuration/IncludeOption.cs
+++ b/src/PSRule/Configuration/IncludeOption.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// Options that affect source locations imported for execution.
+    /// </summary>
+    public sealed class IncludeOption : IEquatable<IncludeOption>
+    {
+        private const string[] DEFAULT_MODULE = null;
+        private const string[] DEFAULT_PATH = null;
+
+        internal static readonly IncludeOption Default = new IncludeOption
+        {
+            Path = DEFAULT_PATH,
+            Module = DEFAULT_MODULE,
+        };
+
+        public IncludeOption()
+        {
+            Path = null;
+            Module = null;
+        }
+
+        public IncludeOption(IncludeOption option)
+        {
+            if (option == null)
+                return;
+
+            Path = option.Path;
+            Module = option.Module;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IncludeOption option && Equals(option);
+        }
+
+        public bool Equals(IncludeOption other)
+        {
+            return other != null &&
+                Path == other.Path &&
+                Module == other.Module;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine
+            {
+                int hash = 17;
+                hash = hash * 23 + (Path != null ? Path.GetHashCode() : 0);
+                hash = hash * 23 + (Module != null ? Module.GetHashCode() : 0);
+                return hash;
+            }
+        }
+
+        internal static IncludeOption Combine(IncludeOption o1, IncludeOption o2)
+        {
+            var result = new IncludeOption(o1)
+            {
+                Path = o1.Path ?? o2.Path,
+                Module = o1.Module ?? o2.Module
+            };
+            return result;
+        }
+
+        /// <summary>
+        /// Include additional module sources.
+        /// </summary>
+        [DefaultValue(null)]
+        public string[] Path { get; set; }
+
+        /// <summary>
+        /// Include additional standalone sources.
+        /// </summary>
+        [DefaultValue(null)]
+        public string[] Module { get; set; }
+
+        internal void Load(EnvironmentHelper env)
+        {
+            if (env.TryStringArray("PSRULE_INCLUDE_PATH", out string[] path))
+                Path = path;
+
+            if (env.TryStringArray("PSRULE_INCLUDE_MODULE", out string[] module))
+                Module = module;
+        }
+
+        internal void Load(Dictionary<string, object> index)
+        {
+            if (index.TryPopStringArray("Include.Path", out string[] path))
+                Path = path;
+
+            if (index.TryPopStringArray("Include.Module", out string[] module))
+                Module = module;
+        }
+    }
+
+}

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -36,6 +36,7 @@ namespace PSRule.Configuration
             Binding = BindingOption.Default,
             Convention = ConventionOption.Default,
             Execution = ExecutionOption.Default,
+            Include = IncludeOption.Default,
             Input = InputOption.Default,
             Logging = LoggingOption.Default,
             Output = OutputOption.Default
@@ -58,6 +59,7 @@ namespace PSRule.Configuration
             Configuration = new ConfigurationOption();
             Convention = new ConventionOption();
             Execution = new ExecutionOption();
+            Include = new IncludeOption();
             Input = new InputOption();
             Logging = new LoggingOption();
             Output = new OutputOption();
@@ -76,6 +78,7 @@ namespace PSRule.Configuration
             Configuration = new ConfigurationOption(option?.Configuration);
             Convention = new ConventionOption(option?.Convention);
             Execution = new ExecutionOption(option?.Execution);
+            Include = new IncludeOption(option?.Include);
             Input = new InputOption(option?.Input);
             Logging = new LoggingOption(option?.Logging);
             Output = new OutputOption(option?.Output);
@@ -98,9 +101,14 @@ namespace PSRule.Configuration
         public ConventionOption Convention { get; set; }
 
         /// <summary>
-        /// Options that affect script execution.
+        /// Options that configure the execution sandbox.
         /// </summary>
         public ExecutionOption Execution { get; set; }
+
+        /// <summary>
+        /// Options that affect source locations imported for execution.
+        /// </summary>
+        public IncludeOption Include { get; set; }
 
         /// <summary>
         /// Options that affect how input types are processed.
@@ -166,6 +174,7 @@ namespace PSRule.Configuration
             result.Configuration = ConfigurationOption.Combine(result.Configuration, o2?.Configuration);
             result.Convention = ConventionOption.Combine(result.Convention, o2?.Convention);
             result.Execution = ExecutionOption.Combine(result.Execution, o2?.Execution);
+            result.Include = IncludeOption.Combine(result.Include, o2?.Include);
             result.Input = InputOption.Combine(result.Input, o2?.Input);
             result.Logging = LoggingOption.Combine(result.Logging, o2?.Logging);
             result.Output = OutputOption.Combine(result.Output, o2?.Output);
@@ -268,6 +277,7 @@ namespace PSRule.Configuration
             var env = EnvironmentHelper.Default;
             option.Convention.Load(env);
             option.Execution.Load(env);
+            option.Include.Load(env);
             option.Input.Load(env);
             option.Logging.Load(env);
             option.Output.Load(env);
@@ -286,6 +296,7 @@ namespace PSRule.Configuration
             var index = BuildIndex(hashtable);
             option.Convention.Load(index);
             option.Execution.Load(index);
+            option.Include.Load(index);
             option.Input.Load(index);
             option.Logging.Load(index);
             option.Output.Load(index);
@@ -368,6 +379,7 @@ namespace PSRule.Configuration
                 Configuration == other.Configuration &&
                 Convention == other.Convention &&
                 Execution == other.Execution &&
+                Include == other.Include &&
                 Input == other.Input &&
                 Logging == other.Logging &&
                 Output == other.Output &&
@@ -385,6 +397,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (Configuration != null ? Configuration.GetHashCode() : 0);
                 hash = hash * 23 + (Convention != null ? Convention.GetHashCode() : 0);
                 hash = hash * 23 + (Execution != null ? Execution.GetHashCode() : 0);
+                hash = hash * 23 + (Include != null ? Include.GetHashCode() : 0);
                 hash = hash * 23 + (Input != null ? Input.GetHashCode() : 0);
                 hash = hash * 23 + (Logging != null ? Logging.GetHashCode() : 0);
                 hash = hash * 23 + (Output != null ? Output.GetHashCode() : 0);

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1334,7 +1334,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
 
 Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
     $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
-    $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
+    $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests8.yml');
 
     Context 'With defaults' {
         # Get a list of rules
@@ -1453,6 +1453,41 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
                 $Null = New-Item -Path $emptyPath -ItemType Directory -Force;
             }
             $Null = Get-PSRule -Path $emptyPath;
+        }
+
+        It 'Uses rules with include option' {
+            Push-Location -Path (Join-Path -Path $here -ChildPath 'rules/')
+            try {
+                $result = @(Get-PSRule)
+                $result.Length | Should -Be 4;
+
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/' })
+                $result.Length | Should -Be 1;
+
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/', 'extra/' })
+                $result.Length | Should -Be 2;
+
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = '.' })
+                $result.Length | Should -Be 4;
+
+                $result = @(Get-PSRule -Path 'main/')
+                $result.Length | Should -Be 2;
+
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = @() })
+                $result.Length | Should -Be 1;
+
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/' })
+                $result.Length | Should -Be 2;
+
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/', '.ps-rule/' })
+                $result.Length | Should -Be 3;
+
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'main/' })
+                $result.Length | Should -Be 1;
+            }
+            finally {
+                Pop-Location;
+            }
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -655,6 +655,84 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Include.Path' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Include.Path | Should -BeNullOrEmpty;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Include.Path' = 'out/' };
+            $option.Include.Path.Length | Should -Be 1;
+            $option.Include.Path | Should -BeIn 'out/';
+
+            $option = New-PSRuleOption -Option @{ 'Include.Path' = 'out/','.ps-rule/' };
+            $option.Include.Path.Length | Should -Be 2;
+            $option.Include.Path | Should -BeIn 'out/', '.ps-rule/';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests7.yml');
+            $option.Include.Path.Length | Should -Be 2;
+            $option.Include.Path | Should -BeIn 'out/', '.ps-rule/';
+        }
+
+        It 'from Environment' {
+            try {
+                $Env:PSRULE_INCLUDE_PATH = 'out/;.ps-rule/';
+                $option = New-PSRuleOption;
+                $option.Include.Path | Should -BeIn 'out/', '.ps-rule/';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_INCLUDE_PATH' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -IncludePath 'out/', '.ps-rule/' -Path $emptyOptionsFilePath;
+            $option.Include.Path | Should -BeIn 'out/', '.ps-rule/';
+        }
+    }
+
+    Context 'Read Include.Module' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Include.Module | Should -BeNullOrEmpty;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Include.Module' = 'TestModule' };
+            $option.Include.Module.Length | Should -Be 1;
+            $option.Include.Module | Should -BeIn 'TestModule';
+
+            $option = New-PSRuleOption -Option @{ 'Include.Module' = 'TestModule','TestModule2' };
+            $option.Include.Module.Length | Should -Be 2;
+            $option.Include.Module | Should -BeIn 'TestModule', 'TestModule2';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests7.yml');
+            $option.Include.Module.Length | Should -Be 2;
+            $option.Include.Module | Should -BeIn 'TestModule', 'TestModule2';
+        }
+
+        It 'from Environment' {
+            try {
+                $Env:PSRULE_INCLUDE_MODULE = 'TestModule;TestModule2';
+                $option = New-PSRuleOption;
+                $option.Include.Module | Should -BeIn 'TestModule', 'TestModule2';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_INCLUDE_MODULE' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -IncludeModule 'TestModule', 'TestModule2' -Path $emptyOptionsFilePath;
+            $option.Include.Module | Should -BeIn 'TestModule', 'TestModule2';
+        }
+    }
+
     Context 'Read Input.Format' {
         It 'from default' {
             $option = New-PSRuleOption -Default;

--- a/tests/PSRule.Tests/PSRule.Tests7.yml
+++ b/tests/PSRule.Tests/PSRule.Tests7.yml
@@ -1,0 +1,10 @@
+# These are options for unit tests
+
+# Configure include options
+include:
+  path:
+  - out/
+  - .ps-rule/
+  module:
+  - TestModule
+  - TestModule2

--- a/tests/PSRule.Tests/PSRule.Tests8.yml
+++ b/tests/PSRule.Tests/PSRule.Tests8.yml
@@ -1,0 +1,4 @@
+# These are options for unit tests
+
+include:
+  path: []

--- a/tests/PSRule.Tests/rules/.ps-rule/Common.Rule.ps1
+++ b/tests/PSRule.Tests/rules/.ps-rule/Common.Rule.ps1
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Pester unit test rules
+#
+
+Rule 'Local.Common.1' {
+    $Assert.Pass();
+}

--- a/tests/PSRule.Tests/rules/Test.Rule.ps1
+++ b/tests/PSRule.Tests/rules/Test.Rule.ps1
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Pester unit test rules
+#
+
+Rule 'Local.Test.1' {
+    $Assert.Pass();
+}

--- a/tests/PSRule.Tests/rules/extra/Extra.Rule.ps1
+++ b/tests/PSRule.Tests/rules/extra/Extra.Rule.ps1
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Pester unit test rules
+#
+
+Rule 'Local.Extra.1' {
+    $Assert.Pass();
+}

--- a/tests/PSRule.Tests/rules/main/Main.Rule.ps1
+++ b/tests/PSRule.Tests/rules/main/Main.Rule.ps1
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Pester unit test rules
+#
+
+Rule 'Local.Main.1' {
+    $Assert.Pass();
+}


### PR DESCRIPTION
## PR Summary

- Default rule source location `.ps-rule/` is automatically included. #742
  - Added `Include.Path` and `Include.Module` options to automatically include rule sources.

Fixes #742 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
