### PR TITLE
Automatically exclude common repository files #721

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Include.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#includepath)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)
   - [Input.IgnoreGitPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputignoregitpath)
+  - [Input.IgnoreRepositoryCommon](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputignorerepositorycommon)
   - [Input.ObjectPath](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputobjectpath)
   - [Input.PathIgnore](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputpathignore)
   - [Input.TargetType](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputtargettype)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,13 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.6.0:
+
+- General improvements:
+  - Automatically exclude common repository files from input files. [#721](https://github.com/microsoft/PSRule/issues/721)
+    - Added `Input.IgnoreRepositoryCommon` option to change default behavior.
+    - See [about_PSRule_Options] for details.
+
 ## v1.6.0
 
 What's changed since v1.5.0:

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -22,12 +22,13 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-IncludeModule <String[]>]
- [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>]
- [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -39,12 +40,13 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-IncludeModule <String[]>]
- [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>]
- [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -56,11 +58,12 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
  [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
  [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-ObjectPath <String>] [-InputTargetType <String[]>] [-InputPathIgnore <String[]>]
- [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>] [<CommonParameters>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputStyle <OutputStyle>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -489,6 +492,23 @@ Aliases:
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputIgnoreRepositoryCommon
+
+Sets the `Input.IgnoreRepositoryCommon` option to determine if files common repository files are ignored.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -19,12 +19,12 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-InconclusiveWarning <Boolean>]
  [-NotProcessedWarning <Boolean>] [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>]
- [-InputIgnoreGitPath <Boolean>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
- [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>]
+ [-InputPathIgnore <String[]>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -389,6 +389,23 @@ Aliases:
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputIgnoreRepositoryCommon
+
+Sets the `Input.IgnoreRepositoryCommon` option to determine if files common repository files are ignored.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/toc.yml
+++ b/docs/commands/PSRule/en-US/toc.yml
@@ -47,6 +47,10 @@
   href: ../../../concepts/PSRule/en-US/about_PSRule_Docs.md
   topicHref: ../../../concepts/PSRule/en-US/about_PSRule_Docs.md
 
+- name: Expressions
+  href: ../../../concepts/PSRule/en-US/about_PSRule_Expressions.md
+  topicHref: ../../../concepts/PSRule/en-US/about_PSRule_Expressions.md
+
 - name: Keywords
   href: ../../../keywords/PSRule/en-US/about_PSRule_Keywords.md
   topicHref: ../../../keywords/PSRule/en-US/about_PSRule_Keywords.md
@@ -54,6 +58,10 @@
 - name: Options
   href: ../../../concepts/PSRule/en-US/about_PSRule_Options.md
   topicHref: ../../../concepts/PSRule/en-US/about_PSRule_Options.md
+
+- name: Rules
+  href: ../../../concepts/PSRule/en-US/about_PSRule_Rules.md
+  topicHref: ../../../concepts/PSRule/en-US/about_PSRule_Rule.md
 
 - name: Selectors
   href: ../../../concepts/PSRule/en-US/about_PSRule_Selectors.md

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -21,6 +21,7 @@ The following workspace options are available for use:
 - [Include.Path](#includepath)
 - [Input.Format](#inputformat)
 - [Input.IgnoreGitPath](#inputignoregitpath)
+- [Input.IgnoreRepositoryCommon](#inputignorerepositorycommon)
 - [Input.ObjectPath](#inputobjectpath)
 - [Input.PathIgnore](#inputpathignore)
 - [Input.TargetType](#inputtargettype)
@@ -1045,6 +1046,70 @@ env:
 # Azure Pipelines: Using environment variable
 variables:
 - name: PSRULE_INPUT_IGNOREGITPATH
+  value: false
+```
+
+### Input.IgnoreRepositoryCommon
+
+When reading files from an input path, files are discovered recursively.
+A number of files are commonly found within a private and open-source repositories.
+In many cases these files are of no interest for analysis and should be ignored by rules.
+PSRule will ignore the following files by default:
+
+- `README.md`
+- `.DS_Store`
+- `.gitignore`
+- `.gitattributes`
+- `.gitmodules`
+- `LICENSE`
+- `LICENSE.txt`
+- `CODE_OF_CONDUCT.md`
+- `CONTRIBUTING.md`
+- `SECURITY.md`
+- `SUPPORT.md`
+- `.vscode/*.json`
+- `.github/**/*.md`
+- `.github/CODEOWNERS`
+
+To include these files, set this option to `$False`.
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the InputIgnoreRepositoryCommon parameter
+$option = New-PSRuleOption -InputIgnoreRepositoryCommon $False;
+```
+
+```powershell
+# PowerShell: Using the Input.IgnoreRepositoryCommon hashtable key
+$option = New-PSRuleOption -Option @{ 'Input.IgnoreRepositoryCommon' = $False };
+```
+
+```powershell
+# PowerShell: Using the InputIgnoreRepositoryCommon parameter to set YAML
+Set-PSRuleOption -InputIgnoreRepositoryCommon $False;
+```
+
+```yaml
+# YAML: Using the input/ignoreRepositoryCommon property
+input:
+  ignoreRepositoryCommon: false
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_INPUT_IGNOREREPOSITORYCOMMON=false
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_INPUT_IGNOREREPOSITORYCOMMON: false
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_INPUT_IGNOREREPOSITORYCOMMON
   value: false
 ```
 

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -165,8 +165,8 @@
                     "items": {
                         "type": "string",
                         "title": "Include path",
-                    "description": "Automatically include rules and resources from the specified paths.",
-                    "markdownDescription": "Automatically include rules and resources from the specified paths. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includepath)"
+                        "description": "Automatically include rules and resources from the specified paths.",
+                        "markdownDescription": "Automatically include rules and resources from the specified paths. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#includepath)"
                     },
                     "uniqueItems": true
                 }
@@ -198,7 +198,14 @@
                     "type": "boolean",
                     "title": "Ignore .git path",
                     "description": "Determine if files within the .git path are ignored when the -InputPath parameter is used.",
-                    "markdownDescription": "Determine if files within the `.git` path are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#ignoregitpath)",
+                    "markdownDescription": "Determine if files within the `.git` path are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#inputignoregitpath)",
+                    "default": true
+                },
+                "ignoreRepositoryCommon": {
+                    "type": "boolean",
+                    "title": "Ignore common files",
+                    "description": "Determine if common repository files are ignored when the -InputPath parameter is used.",
+                    "markdownDescription": "Determine if common repository files are ignored when the `-InputPath` parameter is used. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#inputignorerepositorycommon)",
                     "default": true
                 },
                 "objectPath": {

--- a/src/PSRule/Configuration/InputOption.cs
+++ b/src/PSRule/Configuration/InputOption.cs
@@ -14,6 +14,7 @@ namespace PSRule.Configuration
     {
         private const InputFormat DEFAULT_FORMAT = PSRule.Configuration.InputFormat.Detect;
         private const bool DEFAULT_IGNOREGITPATH = true;
+        private const bool DEFAULT_IGNOREREPOSITORYCOMMON = true;
         private const string DEFAULT_OBJECTPATH = null;
         private const string[] DEFAULT_PATHIGNORE = null;
         private const string[] DEFAULT_TARGETTYPE = null;
@@ -22,6 +23,7 @@ namespace PSRule.Configuration
         {
             Format = DEFAULT_FORMAT,
             IgnoreGitPath = DEFAULT_IGNOREGITPATH,
+            IgnoreRepositoryCommon = DEFAULT_IGNOREREPOSITORYCOMMON,
             ObjectPath = DEFAULT_OBJECTPATH,
             PathIgnore = DEFAULT_PATHIGNORE,
             TargetType = DEFAULT_TARGETTYPE,
@@ -31,6 +33,7 @@ namespace PSRule.Configuration
         {
             Format = null;
             IgnoreGitPath = null;
+            IgnoreRepositoryCommon = null;
             ObjectPath = null;
             PathIgnore = null;
             TargetType = null;
@@ -43,6 +46,7 @@ namespace PSRule.Configuration
 
             Format = option.Format;
             IgnoreGitPath = option.IgnoreGitPath;
+            IgnoreRepositoryCommon = option.IgnoreRepositoryCommon;
             ObjectPath = option.ObjectPath;
             PathIgnore = option.PathIgnore;
             TargetType = option.TargetType;
@@ -58,6 +62,7 @@ namespace PSRule.Configuration
             return other != null &&
                 Format == other.Format &&
                 IgnoreGitPath == other.IgnoreGitPath &&
+                IgnoreRepositoryCommon == other.IgnoreRepositoryCommon &&
                 ObjectPath == other.ObjectPath &&
                 PathIgnore == other.PathIgnore &&
                 TargetType == other.TargetType;
@@ -70,6 +75,7 @@ namespace PSRule.Configuration
                 int hash = 17;
                 hash = hash * 23 + (Format.HasValue ? Format.Value.GetHashCode() : 0);
                 hash = hash * 23 + (IgnoreGitPath.HasValue ? IgnoreGitPath.Value.GetHashCode() : 0);
+                hash = hash * 23 + (IgnoreRepositoryCommon.HasValue ? IgnoreRepositoryCommon.Value.GetHashCode() : 0);
                 hash = hash * 23 + (ObjectPath != null ? ObjectPath.GetHashCode() : 0);
                 hash = hash * 23 + (PathIgnore != null ? PathIgnore.GetHashCode() : 0);
                 hash = hash * 23 + (TargetType != null ? TargetType.GetHashCode() : 0);
@@ -83,6 +89,7 @@ namespace PSRule.Configuration
             {
                 Format = o1.Format ?? o2.Format,
                 IgnoreGitPath = o1.IgnoreGitPath ?? o2.IgnoreGitPath,
+                IgnoreRepositoryCommon = o1.IgnoreRepositoryCommon ?? o2.IgnoreRepositoryCommon,
                 ObjectPath = o1.ObjectPath ?? o2.ObjectPath,
                 PathIgnore = o1.PathIgnore ?? o2.PathIgnore,
                 TargetType = o1.TargetType ?? o2.TargetType
@@ -101,6 +108,12 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public bool? IgnoreGitPath { get; set; }
+
+        /// <summary>
+        /// Determine if common repository files are ignored.
+        /// </summary>
+        [DefaultValue(null)]
+        public bool? IgnoreRepositoryCommon { get; set; }
 
         /// <summary>
         /// The object path to a property to use instead of the pipeline object.
@@ -128,6 +141,9 @@ namespace PSRule.Configuration
             if (env.TryBool("PSRULE_INPUT_IGNOREGITPATH", out bool ignoreGitPath))
                 IgnoreGitPath = ignoreGitPath;
 
+            if (env.TryBool("PSRULE_INPUT_IGNOREREPOSITORYCOMMON", out bool ignoreRepositoryCommon))
+                IgnoreRepositoryCommon = ignoreRepositoryCommon;
+
             if (env.TryString("PSRULE_INPUT_OBJECTPATH", out string objectPath))
                 ObjectPath = objectPath;
 
@@ -145,6 +161,9 @@ namespace PSRule.Configuration
 
             if (index.TryPopBool("Input.IgnoreGitPath", out bool ignoreGitPath))
                 IgnoreGitPath = ignoreGitPath;
+
+            if (index.TryPopBool("Input.IgnoreRepositoryCommon", out bool ignoreRepositoryCommon))
+                IgnoreRepositoryCommon = ignoreRepositoryCommon;
 
             if (index.TryPopString("Input.ObjectPath", out string objectPath))
                 ObjectPath = objectPath;

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1082,6 +1082,10 @@ function New-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [System.Boolean]$InputIgnoreGitPath = $True,
 
+        # Sets the Input.IgnoreRepositoryCommon option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$InputIgnoreRepositoryCommon = $True,
+
         # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
         [Alias('InputObjectPath')]
@@ -1309,6 +1313,10 @@ function Set-PSRuleOption {
         # Sets the Input.IgnoreGitPath option
         [Parameter(Mandatory = $False)]
         [System.Boolean]$InputIgnoreGitPath = $True,
+
+        # Sets the Input.IgnoreRepositoryCommon option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$InputIgnoreRepositoryCommon = $True,
 
         # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
@@ -1967,6 +1975,10 @@ function SetOptions {
         [Parameter(Mandatory = $False)]
         [System.Boolean]$InputIgnoreGitPath = $True,
 
+        # Sets the Input.IgnoreRepositoryCommon option
+        [Parameter(Mandatory = $False)]
+        [System.Boolean]$InputIgnoreRepositoryCommon = $True,
+
         # Sets the Input.ObjectPath option
         [Parameter(Mandatory = $False)]
         [Alias('InputObjectPath')]
@@ -2106,6 +2118,11 @@ function SetOptions {
         # Sets option Input.IgnoreGitPath
         if ($PSBoundParameters.ContainsKey('InputIgnoreGitPath')) {
             $Option.Input.IgnoreGitPath = $InputIgnoreGitPath;
+        }
+
+        # Sets option Input.IgnoreRepositoryCommon
+        if ($PSBoundParameters.ContainsKey('InputIgnoreRepositoryCommon')) {
+            $Option.Input.IgnoreRepositoryCommon = $InputIgnoreRepositoryCommon;
         }
 
         # Sets option Input.ObjectPath

--- a/src/PSRule/Pipeline/GetTargetPipeline.cs
+++ b/src/PSRule/Pipeline/GetTargetPipeline.cs
@@ -49,7 +49,8 @@ namespace PSRule.Pipeline
 
             var basePath = PSRuleOption.GetWorkingPath();
             var ignoreGitPath = Option.Input.IgnoreGitPath ?? InputOption.Default.IgnoreGitPath.Value;
-            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore, ignoreGitPath);
+            var ignoreRepositoryCommon = Option.Input.IgnoreRepositoryCommon ?? InputOption.Default.IgnoreRepositoryCommon.Value;
+            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore, ignoreGitPath, ignoreRepositoryCommon);
             if (Option.Input.Format == InputFormat.File)
                 filter.UseGitIgnore();
 

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -37,7 +37,8 @@ namespace PSRule.Pipeline
 
             var basePath = PSRuleOption.GetWorkingPath();
             var ignoreGitPath = Option.Input.IgnoreGitPath ?? InputOption.Default.IgnoreGitPath.Value;
-            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore, ignoreGitPath);
+            var ignoreRepositoryCommon = Option.Input.IgnoreRepositoryCommon ?? InputOption.Default.IgnoreRepositoryCommon.Value;
+            var filter = PathFilterBuilder.Create(basePath, Option.Input.PathIgnore, ignoreGitPath, ignoreRepositoryCommon);
             if (Option.Input.Format == InputFormat.File)
                 filter.UseGitIgnore();
 

--- a/src/PSRule/Pipeline/PathFilter.cs
+++ b/src/PSRule/Pipeline/PathFilter.cs
@@ -12,22 +12,43 @@ namespace PSRule.Pipeline
     {
         private const string GitIgnoreFileName = ".gitignore";
 
+        private static readonly string[] CommonFiles = new string[]
+        {
+            "README.md",
+            ".DS_Store",
+            ".gitignore",
+            ".gitattributes",
+            ".gitmodules",
+            "LICENSE",
+            "LICENSE.txt",
+            "CODE_OF_CONDUCT.md",
+            "CONTRIBUTING.md",
+            "SECURITY.md",
+            "SUPPORT.md",
+            ".vscode/*.json",
+            ".github/**/*.md",
+            ".github/CODEOWNERS"
+        };
+
         private readonly string _BasePath;
         private readonly List<string> _Expressions;
         private readonly bool _MatchResult;
 
-        private PathFilterBuilder(string basePath, string[] expressions, bool matchResult, bool ignoreGitPath)
+        private PathFilterBuilder(string basePath, string[] expressions, bool matchResult, bool ignoreGitPath, bool ignoreRepositoryCommon)
         {
             _BasePath = basePath;
             _Expressions = expressions == null || expressions.Length == 0 ? new List<string>() : new List<string>(expressions);
             _MatchResult = matchResult;
+            if (ignoreRepositoryCommon)
+                _Expressions.InsertRange(0, CommonFiles);
+
             if (ignoreGitPath)
                 _Expressions.Add(".git/");
         }
 
-        internal static PathFilterBuilder Create(string basePath, string[] expressions, bool ignoreGitPath)
+        internal static PathFilterBuilder Create(string basePath, string[] expressions, bool ignoreGitPath, bool ignoreRepositoryCommon)
         {
-            return new PathFilterBuilder(basePath, expressions, false, ignoreGitPath);
+            return new PathFilterBuilder(basePath, expressions, false, ignoreGitPath, ignoreRepositoryCommon);
         }
 
         internal void UseGitIgnore(string basePath = null)

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -805,6 +805,45 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Input.IgnoreRepositoryCommon' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Input.IgnoreRepositoryCommon | Should -Be $True;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Input.IgnoreRepositoryCommon' = $False };
+            $option.Input.IgnoreRepositoryCommon | Should -Be $False;
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Input.IgnoreRepositoryCommon | Should -Be $False;
+        }
+
+        It 'from Environment' {
+            try {
+                # With bool
+                $Env:PSRULE_INPUT_IGNOREREPOSITORYCOMMON = 'false';
+                $option = New-PSRuleOption;
+                $option.Input.IgnoreRepositoryCommon | Should -Be $False;
+
+                # With int
+                $Env:PSRULE_INPUT_IGNOREREPOSITORYCOMMON = '0';
+                $option = New-PSRuleOption;
+                $option.Input.IgnoreRepositoryCommon | Should -Be $False;
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_INPUT_IGNOREREPOSITORYCOMMON' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InputIgnoreRepositoryCommon $False -Path $emptyOptionsFilePath;
+            $option.Input.IgnoreRepositoryCommon | Should -Be $False;
+        }
+    }
+
     Context 'Read Input.ObjectPath' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -1512,6 +1551,13 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -InputIgnoreGitPath $False @optionParams;
             $option.Input.IgnoreGitPath | Should -Be $False;
+        }
+    }
+
+    Context 'Read Input.IgnoreRepositoryCommon' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -InputIgnoreRepositoryCommon $False @optionParams;
+            $option.Input.IgnoreRepositoryCommon | Should -Be $False;
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -44,6 +44,7 @@ execution:
 input:
   format: Yaml
   ignoreGitPath: false
+  ignoreRepositoryCommon: false
   objectPath: items
   pathIgnore:
   - '*.Designer.cs'

--- a/tests/PSRule.Tests/PathFilterTests.cs
+++ b/tests/PSRule.Tests/PathFilterTests.cs
@@ -59,6 +59,34 @@ namespace PSRule
             Assert.True(filter.Match("reports/bin/other.json"));
         }
 
+        [Fact]
+        public void Builder()
+        {
+            var builder = PathFilterBuilder.Create(GetWorkingPath(), new string[] { "out/" }, false, false);
+            var actual1 = builder.Build();
+            Assert.False(actual1.Match("out/not.file"));
+            Assert.True(actual1.Match(".git/HEAD"));
+            Assert.True(actual1.Match(".gitignore"));
+            Assert.True(actual1.Match(".github/CODEOWNERS"));
+            Assert.True(actual1.Match(".github/dependabot.yml"));
+
+            builder = PathFilterBuilder.Create(GetWorkingPath(), new string[] { "out/" }, true, false);
+            var actual2 = builder.Build();
+            Assert.False(actual2.Match("out/not.file"));
+            Assert.False(actual2.Match(".git/HEAD"));
+            Assert.True(actual2.Match(".gitignore"));
+            Assert.True(actual2.Match(".github/CODEOWNERS"));
+            Assert.True(actual2.Match(".github/dependabot.yml"));
+
+            builder = PathFilterBuilder.Create(GetWorkingPath(), new string[] { "out/" }, true, true);
+            var actual3 = builder.Build();
+            Assert.False(actual3.Match("out/not.file"));
+            Assert.False(actual3.Match(".git/HEAD"));
+            Assert.False(actual3.Match(".gitignore"));
+            Assert.False(actual3.Match(".github/CODEOWNERS"));
+            Assert.True(actual3.Match(".github/dependabot.yml"));
+        }
+
         private static string GetWorkingPath()
         {
             return AppDomain.CurrentDomain.BaseDirectory;

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -364,7 +364,6 @@ spec:
     field: 'Value'
     isLower: false
 
-
 ---
 # Synopsis: Test isUpper
 apiVersion: github.com/microsoft/PSRule/v1


### PR DESCRIPTION
## PR Summary

- Automatically exclude common repository files from input files. #721
  - Added `Input.IgnoreRepositoryCommon` option to change default behavior.

Fixes #721 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
