### PR TITLE
Added aggregation assertions AnyOf and AllOf #776

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -16,6 +16,8 @@ What's changed since v1.6.0:
   - Automatically exclude common repository files from input files. [#721](https://github.com/microsoft/PSRule/issues/721)
     - Added `Input.IgnoreRepositoryCommon` option to change default behavior.
     - See [about_PSRule_Options] for details.
+  - Added aggregation assertion methods for `AnyOf` and `AllOf`. [#776](https://github.com/microsoft/PSRule/issues/776)
+    - See [about_PSRule_Assert] for details.
 
 ## v1.6.0
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -1372,11 +1372,36 @@ Rule 'Assert.HasCustomValue' {
 The following built-in helper methods are provided for working with `$Assert` when authoring new assertion methods:
 
 - `Create(<bool> condition, <string> reason, params <object[]> args)` - Returns a result either pass or fail assertion result.
-Additional arguments can be provided to format the custom reason string.
+  Additional arguments can be provided to format the custom reason string.
 - `Pass()` - Returns a pass assertion result.
 - `Fail()` - Results a fail assertion result.
 - `Fail(<string> reason, params <object[]> args)` - Results a fail assertion result with a custom reason.
-Additional arguments can be provided to format the custom reason string.
+  Additional arguments can be provided to format the custom reason string.
+
+### Aggregating assertion methods
+
+The following built-in helper methods are provided for aggregating assertion results:
+
+- `AnyOf(<AssertResult[]> results)` - Results from assertion methods are aggregated into a single result.
+  If any result is a pass, the result is a pass.
+  If all results are fails, the result is a fail and any reasons are added to the result.
+  If no results are provided, the result is a fail.
+- `AllOf(<AssertResult[]> results)` - Results from assertion methods are aggregated into a single result.
+  If all results are passes, the result is a pass.
+  If any result is a fail, the result is a fail and any reasons are added to the result.
+  If no results are provided, the result is a fail.
+
+For example:
+
+```powershell
+Rule 'Assert.HasFieldValue' {
+    $Assert.AllOf(
+        $Assert.HasFieldValue($TargetObject, 'Name'),
+        $Assert.HasFieldValue($TargetObject, 'Type'),
+        $Assert.HasFieldValue($TargetObject, 'Value')
+    )
+}
+```
 
 ## NOTE
 

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -358,6 +358,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No results were provided..
+        /// </summary>
+        internal static string ResultsNotProvided {
+            get {
+                return ResourceManager.GetString("ResultsNotProvided", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not start with &apos;{1}&apos;..
         /// </summary>
         internal static string StartsWith {

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -222,6 +222,9 @@
   <data name="NullParameter" xml:space="preserve">
     <value>The parameter '{0}' is null.</value>
   </data>
+  <data name="ResultsNotProvided" xml:space="preserve">
+    <value>No results were provided.</value>
+  </data>
   <data name="StartsWith" xml:space="preserve">
     <value>The field '{0}' does not start with '{1}'.</value>
   </data>

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -69,6 +69,46 @@ namespace PSRule.Runtime
         }
 
         /// <summary>
+        /// Aggregates one or more results. If any one results is a pass, then pass is returned.
+        /// </summary>
+        public AssertResult AnyOf(params AssertResult[] results)
+        {
+            if (results == null || results.Length == 0)
+                return Fail(ReasonStrings.ResultsNotProvided);
+
+            var result = Fail();
+            for (var i = 0; i < results.Length; i++)
+            {
+                if (results[i].Result)
+                    return Pass();
+                else
+                    result.AddReason(result);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Aggregates one or more results. If all results are a pass, then pass is returned.
+        /// </summary>
+        public AssertResult AllOf(params AssertResult[] results)
+        {
+            if (results == null || results.Length == 0)
+                return Fail(ReasonStrings.ResultsNotProvided);
+
+            var result = Fail();
+            var shouldPass = true;
+            for (var i = 0; i < results.Length; i++)
+            {
+                if (!results[i].Result)
+                {
+                    result.AddReason(results[i]);
+                    shouldPass = false;
+                }
+            }
+            return shouldPass ? Pass() : result;
+        }
+
+        /// <summary>
         /// The object should match the defined schema.
         /// </summary>
         public AssertResult JsonSchema(PSObject inputObject, string uri)

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -49,6 +49,17 @@ namespace PSRule.Runtime
         }
 
         /// <summary>
+        /// Add a reasons from an existing result.
+        /// </summary>
+        internal void AddReason(AssertResult result)
+        {
+            if (result == null || Result || result.Result || result._Reason == null || result._Reason.Count == 0)
+                return;
+
+            _Reason.AddRange(result._Reason);
+        }
+
+        /// <summary>
         /// Add a reason.
         /// </summary>
         /// <param name="text">The text of a reason to add. This text should already be localized for the currently culture.</param>

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -54,6 +54,20 @@ namespace PSRule
             Assert.Equal("Fail reason", actual3.ToString());
             actual3 = assert.Fail("Fail {0}", "reason");
             Assert.Equal("Fail reason", actual3.ToString());
+
+            // Aggregate results
+            Assert.True(assert.AnyOf(actual2, actual3).Result);
+            Assert.True(assert.AnyOf(actual2).Result);
+            Assert.True(assert.AnyOf(actual3, actual2, actual1).Result);
+            Assert.False(assert.AnyOf().Result);
+
+            Assert.False(assert.AllOf(actual2, actual3).Result);
+            Assert.Equal("Fail reason", assert.AllOf(actual2, actual3).ToString());
+            Assert.Equal("New New Reason Fail reason", assert.AllOf(actual1, actual2, actual3).ToString());
+            Assert.True(assert.AllOf(actual2, actual2).Result);
+            Assert.True(assert.AllOf(actual2).Result);
+            Assert.False(assert.AllOf().Result);
+
         }
 
         [Fact]

--- a/tests/PSRule.Tests/FromFileAssert.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileAssert.Rule.ps1
@@ -48,6 +48,24 @@ Rule 'Assert.Fail' {
     $Assert.Fail('Reason {0}', 3).Reason('Reason 4').Reason('Reason {0}', '5')
 }
 
+# Synopsis: Test for $Assert.AnyOf
+Rule 'Assert.AnyOf' {
+    $Assert.AnyOf(
+        $Assert.HasField($TargetObject, 'Name'),
+        $Assert.HasField($TargetObject, 'Type'),
+        $Assert.HasField($TargetObject, 'OtherField')
+    )
+}
+
+# Synopsis: Test for $Assert.AllOf
+Rule 'Assert.AllOf' {
+    $Assert.AllOf(@(
+        $Assert.HasField($TargetObject, 'Name'),
+        $Assert.HasField($TargetObject, 'Type'),
+        $Assert.HasField($TargetObject, 'OtherField')
+    ))
+}
+
 # Synopsis: Test for $Assert.Contains
 Rule 'Assert.Contains' {
     $Assert.Contains($TargetObject, 'OtherField', @('abc', 'th'))

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -169,6 +169,21 @@ Describe 'PSRule assertions' -Tag 'Assert' {
             $result[0].Reason[2] | Should -Be 'Reason 5';
         }
 
+        It 'AnyOf' {
+            $result = @($testObject | Invoke-PSRule @invokeParams -Name 'Assert.AnyOf');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+            $result.Outcome | Should -BeIn 'Pass';
+        }
+
+        It 'AllOf' {
+            $result = @($testObject | Invoke-PSRule @invokeParams -Name 'Assert.AllOf');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+            $result[0].IsSuccess() | Should -Be $True;
+            $result[1].IsSuccess() | Should -Be $False;
+        }
+
         It 'Contains' {
             $result = @($testObject | Invoke-PSRule @invokeParams -Name 'Assert.Contains');
             $result | Should -Not -BeNullOrEmpty;


### PR DESCRIPTION
## PR Summary

- Added aggregation assertion methods for `AnyOf` and `AllOf`. #776

Fixes #776 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
