### PR TITLE
Fixes configuration array as dictionary #779

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.7.0-B2108016:
+
+- Bug fixes:
+  - Fixed configuration array deserializes as dictionary from YAML options. [#779](https://github.com/microsoft/PSRule/issues/779)
+
 ## v1.7.0-B2108016 (pre-release)
 
 What's changed since v1.6.0:

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -261,6 +261,8 @@ namespace PSRule.Configuration
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithTypeConverter(new FieldMapYamlTypeConverter())
                 .WithTypeConverter(new SuppressionRuleYamlTypeConverter())
+                .WithTypeConverter(new PSObjectYamlTypeConverter())
+                .WithNodeTypeResolver(new PSOptionYamlTypeResolver())
                 .Build();
 
             var option = d.Deserialize<PSRuleOption>(yaml) ?? new PSRuleOption();

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -222,6 +222,8 @@ namespace PSRule.Host
                 .IgnoreUnmatchedProperties()
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .WithTypeConverter(new FieldMapYamlTypeConverter())
+                .WithTypeConverter(new PSObjectYamlTypeConverter())
+                .WithNodeTypeResolver(new PSOptionYamlTypeResolver())
                 .WithNodeDeserializer(
                     inner => new LanguageBlockDeserializer(new LanguageExpressionDeserializer(inner)),
                     s => s.InsteadOf<ObjectNodeDeserializer>())

--- a/tests/PSRule.Tests/Baseline.Rule.yaml
+++ b/tests/PSRule.Tests/Baseline.Rule.yaml
@@ -29,6 +29,9 @@ spec:
     - 'WithBaseline'
   configuration:
     key1: value1
+    key2:
+    - value1: abc
+    - value2: def
 
 ---
 # Synopsis: This is an example baseline

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -8,6 +8,7 @@ using PSRule.Runtime;
 using System;
 using System.IO;
 using System.Linq;
+using System.Management.Automation;
 using Xunit;
 using Assert = Xunit.Assert;
 
@@ -29,6 +30,15 @@ namespace PSRule
             Assert.Equal("value", baseline[0].Metadata.Annotations["key"]);
             Assert.False(baseline[0].Obsolete);
             Assert.False(baseline[0].GetApiVersionIssue());
+            
+            var config = baseline[0].Spec.Configuration["key2"] as Array;
+            Assert.NotNull(config);
+            Assert.Equal(2, config.Length);
+            Assert.IsType<PSObject>(config.GetValue(0));
+            var pso = config.GetValue(0) as PSObject;
+            Assert.Equal("abc", pso.PropertyValue<string>("value1"));
+            pso = config.GetValue(1) as PSObject;
+            Assert.Equal("def", pso.PropertyValue<string>("value2"));
 
             // TestBaseline5
             Assert.Equal("TestBaseline5", baseline[4].Name);

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -193,6 +193,10 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
             $option.Configuration.option1 | Should -Be 'option';
             $option.Configuration.option2 | Should -Be 2;
             $option.Configuration.option3 | Should -BeIn 'option3a', 'option3b';
+            $option.Configuration.option4.Length | Should -Be 2;
+            $option.Configuration.option4[0].location | Should -Be 'East US';
+            $option.Configuration.option4[0].zones | Should -BeIn '1', '2', '3';
+            $option.Configuration.option5 | Should -BeIn 'option5a', 'option5b';
         }
 
         It 'from Environment' {

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -14,6 +14,14 @@ configuration:
   option1: option
   option2: 2
   option3: [ 'option3a', 'option3b' ]
+  option4:
+  - location: 'East US'
+    zones: [ "1", "2", "3" ]
+  - location: 'Australia South East'
+    zones: [ ]
+  option5:
+  - option5a
+  - option5b
 
 # Configure conventions
 convention:


### PR DESCRIPTION
## PR Summary

- Fixed configuration array deserializes as dictionary from YAML options.

Fixes #779

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
