### PR TITLE
Fix link to building from source in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,4 +67,4 @@ When you are ready to contribute a fix or feature:
 [github-fork]: https://help.github.com/en/github/getting-started-with-github/fork-a-repo
 [github-pr]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests
 [github-pr-create]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request-from-a-fork
-[build]: docs/scenarios/install-instructions.md#building-from-source
+[build]: https://github.com/microsoft/PSRule/blob/main/docs/install-instructions.md#building-from-source


### PR DESCRIPTION
## PR Summary

Fixed the link inside `CONTRIBUTING.md` for building from source.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
