### PR TITLE
Added unique run id with rule results #774

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,9 @@
                 "kind": "test",
                 "isDefault": true
             },
-            "problemMatcher": [ "$pester" ],
+            "problemMatcher": [
+                "$pester"
+            ],
             "presentation": {
                 "clear": true,
                 "panel": "dedicated"
@@ -37,7 +39,7 @@
             "detail": "Run repository analysis.",
             "type": "shell",
             "command": "Invoke-Build AnalyzeRepository -AssertStyle Client",
-            "problemMatcher": [ ],
+            "problemMatcher": [],
             "presentation": {
                 "clear": true,
                 "panel": "dedicated"
@@ -58,7 +60,9 @@
             "label": "coverage",
             "type": "shell",
             "command": "Invoke-Build Test -CodeCoverage",
-            "problemMatcher": [ "$pester" ],
+            "problemMatcher": [
+                "$pester"
+            ],
             "presentation": {
                 "clear": true,
                 "panel": "dedicated"

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Output.Banner](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputbanner)
   - [Output.Culture](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputculture)
   - [Output.Encoding](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputencoding)
+  - [Output.Footer](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputfooter)
   - [Output.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputformat)
   - [Output.Outcome](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputoutcome)
   - [Output.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#outputpath)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -16,6 +16,12 @@ What's changed since pre-release v1.7.0-B2108021:
   - Added support for generating badges from rule results. [#623](https://github.com/microsoft/PSRule/issues/623)
     - Standard or custom badges can be generated using a convention and the badge API.
     - See [about_PSRule_Badges] for details.
+- General improvements:
+  - Rule results now include a run ID or each run. [#774](https://github.com/microsoft/PSRule/issues/774)
+    - Run ID is returned in `Assert-PSRule` output at the end of each run by default.
+    - By default a unique `runId` is generated when the rule is run.
+    - The `Output.Footer`option was added to configure the output footer.
+    - See [about_PSRule_Options] for details.
 
 ## v1.7.0-B2108021 (pre-release)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -33,6 +33,7 @@ The following workspace options are available for use:
 - [Output.Banner](#outputbanner)
 - [Output.Culture](#outputculture)
 - [Output.Encoding](#outputencoding)
+- [Output.Footer](#outputfooter)
 - [Output.Format](#outputformat)
 - [Output.Outcome](#outputoutcome)
 - [Output.Path](#outputpath)
@@ -1523,7 +1524,7 @@ Set-PSRuleOption -OutputBanner Minimal;
 ```yaml
 # YAML: Using the output/banner property
 output:
-  banner: OutputBanner
+  banner: Minimal
 ```
 
 ```bash
@@ -1649,6 +1650,66 @@ env:
 variables:
 - name: PSRULE_OUTPUT_ENCODING
   value: UTF8
+```
+
+### Output.Footer
+
+The information displayed for PSRule footer.
+This option is only applicable when using `Assert-PSRule` cmdlet.
+
+The following information can be shown or hidden by configuring this option.
+
+- `RuleCount` (1) - Shows a summary of rules processed.
+- `RunInfo` (2) - Shows information about the run.
+
+Additionally the following rollup options exist:
+
+- `Default` - Shows `RuleCount`, and `RunInfo`.
+This is the default option.
+
+This option can be configured using one of the named values described above.
+Alternatively, this value can be configured by specifying a bit mask as an integer.
+For example `3` would show `RunInfo`, and `RuleCount`.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the OutputFooter parameter
+$option = New-PSRuleOption -OutputFooter RuleCount;
+```
+
+```powershell
+# PowerShell: Using the Output.Footer hashtable key
+$option = New-PSRuleOption -Option @{ 'Output.Footer' = 'RuleCount' };
+```
+
+```powershell
+# PowerShell: Using the OutputFooter parameter to set YAML
+Set-PSRuleOption -OutputFooter RuleCount;
+```
+
+```yaml
+# YAML: Using the output/footer property
+output:
+  footer: RuleCount
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_OUTPUT_FOOTER=RuleCount
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_OUTPUT_FOOTER: RuleCount
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_OUTPUT_FOOTER
+  value: RuleCount
 ```
 
 ### Output.Format
@@ -2173,6 +2234,7 @@ output:
   culture:
   - en-US
   encoding: UTF8
+  footer: RuleCount
   format: Json
   outcome: Fail
   style: GitHubActions
@@ -2265,6 +2327,7 @@ output:
   banner: Default
   culture: [ ]
   encoding: Default
+  footer: Default
   format: None
   outcome: Processed
   style: Detect

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -13,6 +13,8 @@ input:
   pathIgnore:
   - '*.Designer.cs'
   - '*.md'
+  - '*.sln'
+  - 'docs/**/toc.yml'
 
 include:
   path: []

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -422,6 +422,26 @@
                     ],
                     "default": "Default"
                 },
+                "footer": {
+                    "title": "Footer format",
+                    "description": "The information displayed for Assert-PSRule footer. The default is Default which includes RuleCount, and RunInfo.",
+                    "markdownDescription": "The information displayed for Assert-PSRule footer. The default is `Default` which includes `RuleCount`, and `RunInfo`. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Options.html#outputfooter)",
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": [
+                                "None",
+                                "RuleCount",
+                                "RunInfo",
+                                "Default"
+                            ]
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "default": "Default"
+                },
                 "format": {
                     "type": "string",
                     "title": "Output format",

--- a/src/PSRule/Common/EnvironmentHelper.cs
+++ b/src/PSRule/Common/EnvironmentHelper.cs
@@ -8,6 +8,38 @@ using System.Security;
 
 namespace PSRule
 {
+    internal static class EnvironmentHelperExtensions
+    {
+        public static bool IsAzurePipelines(this EnvironmentHelper helper)
+        {
+            return helper.TryBool("TF_BUILD", out bool azp) && azp;
+        }
+
+        public static bool IsGitHubActions(this EnvironmentHelper helper)
+        {
+            return helper.TryBool("GITHUB_ACTIONS", out bool gh) && gh;
+        }
+
+        public static bool IsVisualStudioCode(this EnvironmentHelper helper)
+        {
+            return helper.TryString("TERM_PROGRAM", out string term) && term == "vscode";
+        }
+
+        public static string GetRunId(this EnvironmentHelper helper)
+        {
+            if (helper.TryString("PSRULE_RUN_ID", out string runId))
+                return runId;
+
+            if (helper.TryString("BUILD_REPOSITORY_NAME", out string prefix) && helper.TryString("BUILD_BUILDID", out string suffix))
+                return string.Concat(prefix, "/", suffix);
+
+            if (helper.TryString("GITHUB_REPOSITORY", out prefix) && helper.TryString("GITHUB_RUN_ID", out suffix))
+                return string.Concat(prefix, "/", suffix);
+
+            return null;
+        }
+    }
+
     internal sealed class EnvironmentHelper
     {
         private readonly static char[] STRINGARRAY_SEPARATOR = new char[] { ';' };

--- a/src/PSRule/Common/HashAlgorithmExtensions.cs
+++ b/src/PSRule/Common/HashAlgorithmExtensions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace PSRule
+{
+    internal static class HashAlgorithmExtensions
+    {
+        public static string GetDigest(this HashAlgorithm algorithm, byte[] buffer)
+        {
+            var hash = algorithm.ComputeHash(buffer);
+            return string.Join("", hash.Select(b => b.ToString("x2")).ToArray());
+        }
+    }
+}

--- a/src/PSRule/Configuration/FooterFormat.cs
+++ b/src/PSRule/Configuration/FooterFormat.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// The information displayed for Assert-PSRule footer.
+    /// </summary>
+    [Flags]
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum FooterFormat
+    {
+        /// <summary>
+        /// No footer is shown.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// A summary of rules processed.
+        /// </summary>
+        RuleCount = 1,
+
+        /// <summary>
+        /// Information about the run.
+        /// </summary>
+        RunInfo = 2,
+
+        Default = RuleCount | RunInfo
+    }
+}

--- a/src/PSRule/Configuration/OutputOption.cs
+++ b/src/PSRule/Configuration/OutputOption.cs
@@ -16,6 +16,7 @@ namespace PSRule.Configuration
         private const ResultFormat DEFAULT_AS = ResultFormat.Detail;
         private const BannerFormat DEFAULT_BANNER = BannerFormat.Default;
         private const OutputEncoding DEFAULT_ENCODING = OutputEncoding.Default;
+        private const FooterFormat DEFAULT_FOOTER = FooterFormat.Default;
         private const OutputFormat DEFAULT_FORMAT = OutputFormat.None;
         private const RuleOutcome DEFAULT_OUTCOME = RuleOutcome.Processed;
         private const OutputStyle DEFAULT_STYLE = OutputStyle.Detect;
@@ -25,6 +26,7 @@ namespace PSRule.Configuration
             As = DEFAULT_AS,
             Banner = DEFAULT_BANNER,
             Encoding = DEFAULT_ENCODING,
+            Footer = DEFAULT_FOOTER,
             Format = DEFAULT_FORMAT,
             Outcome = DEFAULT_OUTCOME,
             Style = DEFAULT_STYLE,
@@ -36,6 +38,7 @@ namespace PSRule.Configuration
             Banner = null;
             Culture = null;
             Encoding = null;
+            Footer = null;
             Format = null;
             Path = null;
             Style = null;
@@ -50,6 +53,7 @@ namespace PSRule.Configuration
             Banner = option.Banner;
             Culture = option.Culture;
             Encoding = option.Encoding;
+            Footer = option.Footer;
             Format = option.Format;
             Outcome = option.Outcome;
             Path = option.Path;
@@ -68,6 +72,7 @@ namespace PSRule.Configuration
                 Banner == other.Banner &&
                 Culture == other.Culture &&
                 Encoding == other.Encoding &&
+                Footer == other.Footer &&
                 Format == other.Format &&
                 Outcome == other.Outcome &&
                 Path == other.Path &&
@@ -83,6 +88,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (Banner.HasValue ? Banner.Value.GetHashCode() : 0);
                 hash = hash * 23 + (Culture != null ? Culture.GetHashCode() : 0);
                 hash = hash * 23 + (Encoding.HasValue ? Encoding.Value.GetHashCode() : 0);
+                hash = hash * 23 + (Footer.HasValue ? Footer.Value.GetHashCode() : 0);
                 hash = hash * 23 + (Format.HasValue ? Format.Value.GetHashCode() : 0);
                 hash = hash * 23 + (Outcome.HasValue ? Outcome.Value.GetHashCode() : 0);
                 hash = hash * 23 + (Path != null ? Path.GetHashCode() : 0);
@@ -99,6 +105,7 @@ namespace PSRule.Configuration
                 Banner = o1.Banner ?? o2.Banner,
                 Culture = o1.Culture ?? o2.Culture,
                 Encoding = o1.Encoding ?? o2.Encoding,
+                Footer = o1.Footer ?? o2.Footer,
                 Format = o1.Format ?? o2.Format,
                 Outcome = o1.Outcome ?? o2.Outcome,
                 Path = o1.Path ?? o2.Path,
@@ -130,6 +137,12 @@ namespace PSRule.Configuration
         /// </summary>
         [DefaultValue(null)]
         public OutputEncoding? Encoding { get; set; }
+
+        /// <summary>
+        /// The information displayed for Assert-PSRule footer.
+        /// </summary>
+        [DefaultValue(null)]
+        public FooterFormat? Footer { get; set; }
 
         /// <summary>
         /// The output format.
@@ -169,6 +182,9 @@ namespace PSRule.Configuration
             if (env.TryEnum("PSRULE_OUTPUT_ENCODING", out OutputEncoding encoding))
                 Encoding = encoding;
 
+            if (env.TryEnum("PSRULE_OUTPUT_FOOTER", out FooterFormat footer))
+                Footer = footer;
+
             if (env.TryEnum("PSRULE_OUTPUT_FORMAT", out OutputFormat format))
                 Format = format;
 
@@ -195,6 +211,9 @@ namespace PSRule.Configuration
 
             if (index.TryPopEnum("Output.Encoding", out OutputEncoding encoding))
                 Encoding = encoding;
+
+            if (index.TryPopEnum("Output.Footer", out FooterFormat footer))
+                Footer = footer;
 
             if (index.TryPopEnum("Output.Format", out OutputFormat format))
                 Format = format;

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1134,6 +1134,11 @@ function New-PSRuleOption {
         [ValidateSet('Default', 'UTF8', 'UTF7', 'Unicode', 'UTF32', 'ASCII')]
         [PSRule.Configuration.OutputEncoding]$OutputEncoding = 'Default',
 
+        # Sets the Output.Footer option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Default', 'None', 'RuleCount', 'RunInfo')]
+        [PSRule.Configuration.FooterFormat]$OutputFooter = 'Default',
+
         # Sets the Output.Format option
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'NUnit3', 'Csv', 'Wide')]
@@ -1365,6 +1370,11 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [ValidateSet('Default', 'UTF8', 'UTF7', 'Unicode', 'UTF32', 'ASCII')]
         [PSRule.Configuration.OutputEncoding]$OutputEncoding = 'Default',
+
+        # Sets the Output.Footer option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Default', 'None', 'RuleCount', 'RunInfo')]
+        [PSRule.Configuration.FooterFormat]$OutputFooter = 'Default',
 
         # Sets the Output.Format option
         [Parameter(Mandatory = $False)]
@@ -2027,6 +2037,11 @@ function SetOptions {
         [ValidateSet('Default', 'UTF8', 'UTF7', 'Unicode', 'UTF32', 'ASCII')]
         [PSRule.Configuration.OutputEncoding]$OutputEncoding = 'Default',
 
+        # Sets the Output.Footer option
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('Default', 'None', 'RuleCount', 'RunInfo')]
+        [PSRule.Configuration.FooterFormat]$OutputFooter = 'Default',
+
         # Sets the Output.Format option
         [Parameter(Mandatory = $False)]
         [ValidateSet('None', 'Yaml', 'Json', 'Markdown', 'NUnit3', 'Csv', 'Wide')]
@@ -2165,7 +2180,7 @@ function SetOptions {
             $Option.Output.As = $OutputAs;
         }
 
-        # Sets option Output.As
+        # Sets option Output.Banner
         if ($PSBoundParameters.ContainsKey('OutputBanner')) {
             $Option.Output.Banner = $OutputBanner;
         }
@@ -2178,6 +2193,11 @@ function SetOptions {
         # Sets option Output.Encoding
         if ($PSBoundParameters.ContainsKey('OutputEncoding')) {
             $Option.Output.Encoding = $OutputEncoding;
+        }
+
+        # Sets option Output.Footer
+        if ($PSBoundParameters.ContainsKey('OutputFooter')) {
+            $Option.Output.Footer = $OutputFooter;
         }
 
         # Sets option Output.Format

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -11,6 +11,7 @@ using PSRule.Runtime;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 using System.Security.Cryptography;
@@ -52,6 +53,9 @@ namespace PSRule.Pipeline
         internal readonly BindTargetMethod BindTargetName;
         internal readonly BindTargetMethod BindTargetType;
         internal readonly BindTargetMethod BindField;
+        internal readonly string RunId;
+
+        internal readonly Stopwatch RunTime;
 
         public HashAlgorithm ObjectHashAlgorithm
         {
@@ -81,6 +85,8 @@ namespace PSRule.Pipeline
             Baseline = baseline;
             _Unresolved = unresolved;
             _TrackedIssues = new List<ResourceIssue>();
+            RunId = EnvironmentHelper.Default.GetRunId() ?? ObjectHashAlgorithm.GetDigest(Guid.NewGuid().ToByteArray());
+            RunTime = Stopwatch.StartNew();
         }
 
         public static PipelineContext New(PSRuleOption option, HostContext hostContext, PipelineReader reader, BindTargetMethod bindTargetName, BindTargetMethod bindTargetType, BindTargetMethod bindField, OptionContext baseline, IDictionary<string, ResourceRef> unresolved)
@@ -237,6 +243,7 @@ namespace PSRule.Pipeline
                     LocalizedDataCache.Clear();
                     ExpressionCache.Clear();
                     ContentCache.Clear();
+                    RunTime.Stop();
                 }
                 _Disposed = true;
             }

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -124,8 +124,7 @@ namespace PSRule.Pipeline
             var settings = new JsonSerializerSettings { Formatting = Formatting.None, TypeNameHandling = TypeNameHandling.None, MaxDepth = 1024, Culture = CultureInfo.InvariantCulture };
             settings.Converters.Insert(0, new PSObjectJsonConverter());
             var json = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(targetObject, settings));
-            var hash = PipelineContext.CurrentThread.ObjectHashAlgorithm.ComputeHash(json);
-            return string.Join("", hash.Select(b => b.ToString("x2")).ToArray());
+            return PipelineContext.CurrentThread.ObjectHashAlgorithm.GetDigest(json);
         }
 
         /// <summary>

--- a/src/PSRule/Resources/FormatterStrings.Designer.cs
+++ b/src/PSRule/Resources/FormatterStrings.Designer.cs
@@ -70,6 +70,24 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rules processed: {0}, failed: {1}, errored: {2}.
+        /// </summary>
+        internal static string FooterRuleCount {
+            get {
+                return ResourceManager.GetString("FooterRuleCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Run {0} completed in {1}.
+        /// </summary>
+        internal static string FooterRunInfo {
+            get {
+                return ResourceManager.GetString("FooterRunInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to     | HELP:.
         /// </summary>
         internal static string Help {
@@ -246,15 +264,6 @@ namespace PSRule.Resources {
         internal static string StartObjectPrefix {
             get {
                 return ResourceManager.GetString("StartObjectPrefix", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Rules processed: {0}, failed: {1}, errored: {2}.
-        /// </summary>
-        internal static string Summary {
-            get {
-                return ResourceManager.GetString("Summary", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/FormatterStrings.resx
+++ b/src/PSRule/Resources/FormatterStrings.resx
@@ -120,6 +120,12 @@
   <data name="Banner" xml:space="preserve">
     <value>    ____  _____ ____        __\n   / __ \/ ___// __ \__  __/ /__\n  / /_/ /\__ \/ /_/ / / / / / _ \\n / ____/___/ / _, _/ /_/ / /  __/\n/_/    /____/_/ |_|\__,_/_/\___/</value>
   </data>
+  <data name="FooterRuleCount" xml:space="preserve">
+    <value>Rules processed: {0}, failed: {1}, errored: {2}</value>
+  </data>
+  <data name="FooterRunInfo" xml:space="preserve">
+    <value>Run {0} completed in {1}</value>
+  </data>
   <data name="Help" xml:space="preserve">
     <value>    | HELP:</value>
   </data>
@@ -181,9 +187,6 @@
   </data>
   <data name="StartObjectPrefix" xml:space="preserve">
     <value> -&gt; </value>
-  </data>
-  <data name="Summary" xml:space="preserve">
-    <value>Rules processed: {0}, failed: {1}, errored: {2}</value>
   </data>
   <data name="SynopsisPrefix" xml:space="preserve">
     <value>    | SYNOPSIS: </value>

--- a/src/PSRule/Rules/RuleRecord.cs
+++ b/src/PSRule/Rules/RuleRecord.cs
@@ -20,8 +20,9 @@ namespace PSRule.Rules
     [JsonObject]
     public sealed class RuleRecord
     {
-        internal RuleRecord(string ruleId, string ruleName, PSObject targetObject, string targetName, string targetType, TagSet tag, RuleHelpInfo info, Hashtable field, Hashtable data, TargetSourceInfo[] source, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
+        internal RuleRecord(string runId, string ruleId, string ruleName, PSObject targetObject, string targetName, string targetType, TagSet tag, RuleHelpInfo info, Hashtable field, Hashtable data, TargetSourceInfo[] source, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
         {
+            RunId = runId;
             RuleId = ruleId;
             RuleName = ruleName;
             TargetObject = targetObject;
@@ -40,6 +41,12 @@ namespace PSRule.Rules
             // Limit allocations for most scenarios. Runtime calls GetData().
             Data = data;
         }
+
+        /// <summary>
+        /// A unique identifier for the run.
+        /// </summary>
+        [JsonProperty(PropertyName = "runId")]
+        public string RunId { get;  }
 
         /// <summary>
         /// A unique identifier for the rule.

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -595,6 +595,7 @@ namespace PSRule.Runtime
             _RuleErrors = 0;
             RuleBlock = ruleBlock;
             RuleRecord = new RuleRecord(
+                runId: Pipeline.RunId,
                 ruleId: ruleBlock.RuleId,
                 ruleName: ruleBlock.RuleName,
                 targetObject: TargetObject.Value,

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -1227,6 +1227,42 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Output.Footer' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Output.Footer | Should -Be 'Default';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Output.Footer' = 'RuleCount' };
+            $option.Output.Footer | Should -Be 'RuleCount';
+
+            $option = New-PSRuleOption -Option @{ 'Output.Footer' = 1 };
+            $option.Output.Footer | Should -Be 'RuleCount';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Output.Footer | Should -Be 'RuleCount';
+        }
+
+        It 'from Environment' {
+            try {
+                $Env:PSRULE_OUTPUT_FOOTER = 'RuleCount';
+                $option = New-PSRuleOption;
+                $option.Output.Footer | Should -Be 'RuleCount';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_OUTPUT_FOOTER' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -OutputFooter 'RuleCount' -Path $emptyOptionsFilePath;
+            $option.Output.Footer | Should -Be 'RuleCount';
+        }
+    }
+
     Context 'Read Output.Format' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -1639,6 +1675,13 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -OutputEncoding 'UTF7' @optionParams;
             $option.Output.Encoding | Should -Be 'UTF7';
+        }
+    }
+
+    Context 'Read Output.Footer' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -OutputFooter 'RuleCount' @optionParams;
+            $option.Output.Footer | Should -Be 'RuleCount';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -74,6 +74,7 @@ output:
   banner: Minimal
   culture: [ 'en-CC' ]
   encoding: UTF7
+  footer: RuleCount
   format: Json
   outcome: Pass
   path: 'out/OutputPath.txt'


### PR DESCRIPTION
## PR Summary

  - Rule results now include a run ID or each run. #774
    - Run ID is returned in `Assert-PSRule` output at the end of each run by default.
    - By default a unique `runId` is generated when the rule is run.
    - The `Output.Footer`option was added to configure the output footer.

Fixes #774 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
