### PR TITLE
Fixed resource tags ToHashtable method #798

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.7.0:
+
+- Bug fixes:
+  - Fixed ResourceTags does not contain a method named ToHashtable. [#798](https://github.com/microsoft/PSRule/issues/798)
+
 ## v1.7.0
 
 What's changed since v1.6.0:

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -139,6 +139,9 @@ namespace PSRule.Definitions
     {
         public ResourceTags() : base(StringComparer.OrdinalIgnoreCase) { }
 
+        /// <summary>
+        /// Convert from a hashtable to resource tags.
+        /// </summary>
         internal static ResourceTags FromHashtable(Hashtable hashtable)
         {
             if (hashtable == null || hashtable.Count == 0)
@@ -151,6 +154,9 @@ namespace PSRule.Definitions
             return tags;
         }
 
+        /// <summary>
+        /// Convert from a dictionary of string pairs to resource tags.
+        /// </summary>
         internal static ResourceTags FromDictionary(Dictionary<string, string> dictionary)
         {
             if (dictionary == null)
@@ -163,11 +169,17 @@ namespace PSRule.Definitions
             return tags;
         }
 
-        internal Hashtable ToHashtable()
+        /// <summary>
+        /// Convert resource tags to a hashtable.
+        /// </summary>
+        public Hashtable ToHashtable()
         {
             return new Hashtable(this, StringComparer.OrdinalIgnoreCase);
         }
 
+        /// <summary>
+        /// Check if a specific resource tag exists.
+        /// </summary>
         internal bool Contains(object key, object value)
         {
             if (key == null || value == null || !(key is string k) || !ContainsKey(k))

--- a/src/PSRule/Definitions/Rules/Rule.cs
+++ b/src/PSRule/Definitions/Rules/Rule.cs
@@ -38,7 +38,6 @@ namespace PSRule.Definitions.Rules
         string ILanguageBlock.Id => Name;
     }
 
-
     internal sealed class RuleV1Spec : Spec, IRuleSpec
     {
         public LanguageIf Condition { get; set; }

--- a/tests/PSRule.Tests/RulesTests.cs
+++ b/tests/PSRule.Tests/RulesTests.cs
@@ -26,6 +26,9 @@ namespace PSRule
             var rule = HostHelper.GetRuleYaml(GetSource(), context).ToArray();
             Assert.NotNull(rule);
             Assert.Equal("BasicRule", rule[0].RuleName);
+
+            var hashtable = rule[0].Tag.ToHashtable();
+            Assert.Equal("tag", hashtable["feature"]);
         }
 
         [Fact]


### PR DESCRIPTION
## PR Summary

- Fixed ResourceTags does not contain a method named ToHashtable.
 
Fixes #798

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
