### PR TITLE
Fixed get baseline from module #801

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.7.1:
+
+- Bug fixes:
+  - Fixed `Get-PSRuleBaseline` does not return any results from module. [#801](https://github.com/microsoft/PSRule/issues/801)
+
 ## v1.7.1
 
 What's changed since v1.7.0:

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -541,37 +541,37 @@ namespace PSRule.Host
         private static bool Match(RunspaceContext context, RuleBlock resource)
         {
             context.EnterSourceScope(resource.Source);
-            var filter = context.LanguageScope.GetFilter();
-            return filter.Match(resource);
+            var filter = context.LanguageScope.GetFilter(ResourceKind.Rule);
+            return filter == null || filter.Match(resource);
         }
 
         private static bool Match(RunspaceContext context, Rule resource)
         {
             context.EnterSourceScope(resource.Source);
-            var filter = context.LanguageScope.GetFilter();
-            return filter.Match(resource);
+            var filter = context.LanguageScope.GetFilter(ResourceKind.Rule);
+            return filter == null || filter.Match(resource);
         }
 
         private static bool Match(RunspaceContext context, Baseline resource)
         {
             context.EnterSourceScope(resource.Source);
-            var filter = context.LanguageScope.GetFilter();
-            return filter.Match(resource);
+            var filter = context.LanguageScope.GetFilter(ResourceKind.Baseline);
+            return filter == null || filter.Match(resource);
         }
 
         private static bool Match(RunspaceContext context, ScriptBlockConvention block, out int order)
         {
             context.EnterSourceScope(block.Source);
             order = int.MaxValue;
-            var filter = context.Pipeline.Baseline.GetConventionFilter();
-            return filter.Match(block);
+            var filter = context.LanguageScope.GetFilter(ResourceKind.Convention);
+            return filter == null || filter.Match(block);
         }
 
         private static bool Match(RunspaceContext context, SelectorV1 resource)
         {
-            var scope = context.EnterSourceScope(source: resource.Source);
-            var filter = context.LanguageScope.GetFilter();
-            return filter.Match(resource);
+            context.EnterSourceScope(source: resource.Source);
+            var filter = context.LanguageScope.GetFilter(ResourceKind.Selector);
+            return filter == null || filter.Match(resource);
         }
 
         internal static RuleHelpInfo GetHelpInfo(RunspaceContext context, string name)

--- a/src/PSRule/PSRule.Format.ps1xml
+++ b/src/PSRule/PSRule.Format.ps1xml
@@ -564,7 +564,7 @@
             <Width>35</Width>
           </TableColumnHeader>
           <TableColumnHeader>
-            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="ModuleName"/>
+            <Label AssemblyName="PSRule" BaseName="PSRule.Resources.ViewStrings" ResourceId="Module"/>
             <Width>26</Width>
           </TableColumnHeader>
           <TableColumnHeader>
@@ -578,7 +578,7 @@
               <PropertyName>Name</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
-                <PropertyName>ModuleName</PropertyName>
+                <PropertyName>Module</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
                 <PropertyName>Synopsis</PropertyName>

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -837,8 +837,6 @@ function Get-PSRuleBaseline {
 
         $builder = [PSRule.Pipeline.PipelineBuilder]::GetBaseline($sourceFiles, $Option, $PSCmdlet, $ExecutionContext);;
         $builder.Name($Name);
-        # $builder.UseCommandRuntime($PSCmdlet);
-        # $builder.UseExecutionContext($ExecutionContext);
         try {
             $pipeline = $builder.Build();
             if ($Null -ne $pipeline) {

--- a/src/PSRule/Pipeline/OptionContext.cs
+++ b/src/PSRule/Pipeline/OptionContext.cs
@@ -262,7 +262,7 @@ namespace PSRule.Pipeline
             _ConventionFilter = null;
         }
 
-        public IResourceFilter RuleFilter()
+        private IResourceFilter GetRuleFilter()
         {
             if (_Filter != null)
                 return _Filter;
@@ -274,7 +274,7 @@ namespace PSRule.Pipeline
             return _Filter = new RuleFilter(include, tag, exclude, includeLocal);
         }
 
-        public IResourceFilter GetConventionFilter()
+        private IResourceFilter GetConventionFilter()
         {
             if (_ConventionFilter != null)
                 return _ConventionFilter;
@@ -359,7 +359,8 @@ namespace PSRule.Pipeline
             UseScope(languageScope.Name);
             var configuration = GetConfiguration();
             languageScope.Configure(configuration);
-            languageScope.WithFilter(RuleFilter());
+            languageScope.WithFilter(GetRuleFilter());
+            languageScope.WithFilter(GetConventionFilter());
         }
 
         private Dictionary<string, object> AddConfiguration()

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -33,8 +33,11 @@ namespace PSRule.Pipeline
         internal Source Source;
 
         public string Path { get; }
+
         public string ModuleName { get; }
+
         public SourceType Type { get; }
+
         public string HelpPath { get; }
 
         public SourceFile(string path, string moduleName, SourceType type, string helpPath)

--- a/src/PSRule/Resources/ViewStrings.Designer.cs
+++ b/src/PSRule/Resources/ViewStrings.Designer.cs
@@ -88,6 +88,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Module.
+        /// </summary>
+        internal static string Module {
+            get {
+                return ResourceManager.GetString("Module", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to ModuleName.
         /// </summary>
         internal static string ModuleName {

--- a/src/PSRule/Resources/ViewStrings.resx
+++ b/src/PSRule/Resources/ViewStrings.resx
@@ -126,6 +126,9 @@
   <data name="Message" xml:space="preserve">
     <value>Message</value>
   </data>
+  <data name="Module" xml:space="preserve">
+    <value>Module</value>
+  </data>
   <data name="ModuleName" xml:space="preserve">
     <value>ModuleName</value>
   </data>

--- a/src/PSRule/Runtime/LanguageScope.cs
+++ b/src/PSRule/Runtime/LanguageScope.cs
@@ -26,7 +26,7 @@ namespace PSRule.Runtime
 
         void WithFilter(IResourceFilter resourceFilter);
 
-        IResourceFilter GetFilter();
+        IResourceFilter GetFilter(ResourceKind kind);
     }
 
     internal sealed class LanguageScope : ILanguageScope
@@ -35,12 +35,13 @@ namespace PSRule.Runtime
 
         private readonly Dictionary<string, object> _Configuration;
 
-        private IResourceFilter _Filter;
+        private Dictionary<ResourceKind, IResourceFilter> _Filter;
 
         public LanguageScope(string name)
         {
             Name = name ?? STANDALONE_SCOPENAME;
             _Configuration = new Dictionary<string, object>();
+            _Filter = new Dictionary<ResourceKind, IResourceFilter>();
         }
 
         public string Name { get; }
@@ -61,12 +62,12 @@ namespace PSRule.Runtime
 
         public void WithFilter(IResourceFilter resourceFilter)
         {
-            _Filter = resourceFilter;
+            _Filter[resourceFilter.Kind] = resourceFilter;
         }
 
-        public IResourceFilter GetFilter()
+        public IResourceFilter GetFilter(ResourceKind kind)
         {
-            return _Filter;
+            return _Filter.TryGetValue(kind, out IResourceFilter filter) ? filter : null;
         }
     }
 

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
+using PSRule.Definitions.Baselines;
 using PSRule.Host;
 using PSRule.Pipeline;
 using PSRule.Runtime;
@@ -19,10 +20,7 @@ namespace PSRule
         [Fact]
         public void ReadBaseline()
         {
-            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, new OptionContext(), null), null);
-            context.Init(GetSource());
-            context.Begin();
-            var baseline = HostHelper.GetBaselineYaml(GetSource(), context).ToArray();
+            var baseline = GetBaselines(GetSource());
             Assert.NotNull(baseline);
             Assert.Equal(5, baseline.Length);
 
@@ -49,6 +47,44 @@ namespace PSRule
             Assert.True(baseline[4].GetApiVersionIssue());
         }
 
+        [Fact]
+        public void ReadBaselineInModule()
+        {
+            var baseline = GetBaselines(GetSourceInModule());
+            Assert.NotNull(baseline);
+            Assert.Equal(5, baseline.Length);
+
+            // TestBaseline1
+            Assert.Equal("TestBaseline1", baseline[0].Name);
+            Assert.Equal("github.com/microsoft/PSRule/v1", baseline[0].ApiVersion);
+            Assert.Equal("value", baseline[0].Metadata.Annotations["key"]);
+            Assert.False(baseline[0].Obsolete);
+            Assert.False(baseline[0].GetApiVersionIssue());
+        }
+
+        [Fact]
+        public void FilterBaseline()
+        {
+            var baseline = GetBaselines(GetSource());
+            Assert.NotNull(baseline);
+
+            var filter = new BaselineFilter(new string[] { "TestBaseline5" });
+            var actual = baseline.FirstOrDefault(b => filter.Match(b));
+
+            Assert.Equal("TestBaseline5", actual.Name);
+        }
+
+        #region Helper methods
+
+        private Baseline[] GetBaselines(Source[] source)
+        {
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, new OptionContext(), null), null);
+            context.Init(GetSource());
+            context.Begin();
+            var baseline = HostHelper.GetBaselineYaml(source, context).ToArray();
+            return baseline;
+        }
+
         private PSRuleOption GetOption()
         {
             return new PSRuleOption();
@@ -61,9 +97,18 @@ namespace PSRule
             return builder.Build();
         }
 
+        private Source[] GetSourceInModule()
+        {
+            var file = new SourceFile(GetSourcePath("Baseline.Rule.yaml"), "TestModule", SourceType.Yaml, null);
+            var source = new Source(AppDomain.CurrentDomain.BaseDirectory, new SourceFile[] { file });
+            return new Source[] { source };
+        }
+
         private string GetSourcePath(string fileName)
         {
             return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
         }
+
+        #endregion Helper methods
     }
 }

--- a/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
@@ -6,9 +6,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 # Setup error handling
 $ErrorActionPreference = 'Stop';
@@ -39,7 +37,8 @@ Describe 'Get-PSRuleBaseline' -Tag 'Baseline','Get-PSRuleBaseline' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 5;
             $result[0].Name | Should -Be 'TestBaseline1';
-            $result[3].Name | Should -Be 'TestBaseline4';;
+            $result[0].Module | Should -BeNullOrEmpty;
+            $result[3].Name | Should -Be 'TestBaseline4';
         }
 
         It 'With -Name' {
@@ -47,6 +46,24 @@ Describe 'Get-PSRuleBaseline' -Tag 'Baseline','Get-PSRuleBaseline' {
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 1;
             $result[0].Name | Should -Be 'TestBaseline1';
+        }
+
+        It 'With -Module' {
+            $testModuleSourcePath = Join-Path $here -ChildPath 'TestModule4';
+            $Null = Import-Module $testModuleSourcePath;
+
+            $result = @(Get-PSRuleBaseline -Module 'TestModule4');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 3;
+            $result.Name | Should -BeIn 'Module4', 'Baseline2', 'Baseline3';
+            $result.Module | Should -BeIn 'TestModule4';
+
+            # Filter by name
+            $result = @(Get-PSRuleBaseline -Module 'TestModule4' -Name 'Baseline2');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 1;
+            $result.Name | Should -BeIn 'Baseline2';
+            $result.Module | Should -BeIn 'TestModule4';
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed `Get-PSRuleBaseline` does not return any results from module.

Fixes #801

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
