### PR TITLE
Added support for ReasonIf #804

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.8.0-B2109015:
+
+- General improvements:
+  - Added support for conditional reason messages with `ReasonIf`. [#804](https://github.com/microsoft/PSRule/issues/804)
+    - See [about_PSRule_Assert] for details.
+
 ## v1.8.0-B2109015 (pre-release)
 
 What's changed since v1.7.2:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -1423,20 +1423,22 @@ The following properties are available:
 The following methods are available:
 
 - `AddReason(<string> text)` - Can be used to append additional reasons to the result.
-A reason can only be set if the assertion failed.
-Reason text should be localized before calling this method.
-Localization can be done using the `$LocalizedData` automatic variable.
+  A reason can only be set if the assertion failed.
+  Reason text should be localized before calling this method.
+  Localization can be done using the `$LocalizedData` automatic variable.
 - `WithReason(<string> text, <bool> replace)` - Can be used to append or replace reasons on the result.
-In addition, `WithReason` can be chained.
+  In addition, `WithReason` can be chained.
 - `Reason(<string> text, params <object[]> args)` - Replaces the reason on the results with a formatted string.
-This method can be chained.
-For usage see examples below.
+  This method can be chained.
+  For usage see examples below.
+- `ReasonIf(<bool> condition, <string> text, params <object[]> args)` - Replaces the reason if the condition is true.
+  This method can be chained, similar to `Reason`.
 - `GetReason()` - Gets any reasons currently associated with the failed result.
 - `Complete()` - Returns `$True` (Pass) or `$False` (Fail) to the rule record.
-If the assertion failed, any reasons are automatically added to the rule record.
-To read the result without adding reason to the rule record use the `Result` property.
+  If the assertion failed, any reasons are automatically added to the rule record.
+  To read the result without adding reason to the rule record use the `Result` property.
 - `Ignore()` - Ignores the result. Nothing future is returned and any reasons are cleared.
-Use this method when implementing custom handling.
+  Use this method when implementing custom handling.
 
 Use of `Complete` is optional, uncompleted results are automatically completed after the rule has executed.
 Uncompleted results may return reasons out of sequence.

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -92,7 +92,7 @@ namespace PSRule.Runtime
         /// <summary>
         /// Replace the existing reason with the supplied format string.
         /// </summary>
-        /// <param name="text">The text of a reason to add. This text should already be localized for the currently culture.</param>
+        /// <param name="text">The text of a reason to use. This text should already be localized for the currently culture.</param>
         /// <param name="args">Replacement arguments for the format string.</param>
         public AssertResult Reason(string text, params object[] args)
         {
@@ -101,6 +101,21 @@ namespace PSRule.Runtime
 
             AddReason(text, args);
             return this;
+        }
+
+        /// <summary>
+        /// Replace the existing reason with the supplied format string if the condition is true.
+        /// </summary>
+        /// <param name="condition">When true the reason will be used. When false the existing reason will be used.</param>
+        /// <param name="text">The text of a reason to use. This text should already be localized for the currently culture.</param>
+        /// <param name="args">Replacement arguments for the format string.</param>
+        /// <returns></returns>
+        public AssertResult ReasonIf(bool condition, string text, params object[] args)
+        {
+            if (!condition)
+                return this;
+
+            return Reason(text, args);
         }
 
         /// <summary>

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -49,6 +49,10 @@ namespace PSRule
             actual1.Reason("New {0}", "Reason");
             actual1.Reason("New New Reason");
             Assert.Equal("New New Reason", actual1.ToString());
+            actual1.ReasonIf(false, "Not a reason");
+            Assert.Equal("New New Reason", actual1.ToString());
+            actual1.ReasonIf(true, "New New New Reason");
+            Assert.Equal("New New New Reason", actual1.ToString());
 
             var actual3 = assert.Fail("Fail reason");
             Assert.Equal("Fail reason", actual3.ToString());
@@ -63,7 +67,7 @@ namespace PSRule
 
             Assert.False(assert.AllOf(actual2, actual3).Result);
             Assert.Equal("Fail reason", assert.AllOf(actual2, actual3).ToString());
-            Assert.Equal("New New Reason Fail reason", assert.AllOf(actual1, actual2, actual3).ToString());
+            Assert.Equal("New New New Reason Fail reason", assert.AllOf(actual1, actual2, actual3).ToString());
             Assert.True(assert.AllOf(actual2, actual2).Result);
             Assert.True(assert.AllOf(actual2).Result);
             Assert.False(assert.AllOf().Result);


### PR DESCRIPTION
## PR Summary

- Added support for conditional reason messages with `ReasonIf`. #804

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
