### PR TITLE
Added Yaml OutputFormat option for Get-PSRuleBaseline cmdlet

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,22 @@
             "request": "launch",
             "name": "PowerShell Interactive Session",
             "cwd": "${workspaceRoot}"
+        },
+        {
+            "name": "Debug C# Code",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "Build",
+            "program": "pwsh",
+            "args": [
+                "-NoExit",
+                "-NoProfile",
+                "-Command",
+                "Import-Module ${workspaceFolder}/out/modules/PSRule/PSRule.dll, ${workspaceFolder}/out/modules/PSRule/PSRule.psd1",
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,7 @@
             "cwd": "${workspaceRoot}"
         },
         {
-            "name": "Debug C# Code",
+            "name": "Debug PSRule Cmdlets",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "Build",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,7 @@
                 "-NoExit",
                 "-NoProfile",
                 "-Command",
-                "Import-Module ${workspaceFolder}/out/modules/PSRule/PSRule.dll, ${workspaceFolder}/out/modules/PSRule/PSRule.psd1",
+                "Import-Module ${workspaceFolder}/out/modules/PSRule/PSRule.psd1",
             ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,5 +60,8 @@
         "runspace",
         "runspaces",
         "unencrypted"
-    ]
+    ],
+    "[csharp]": {
+        "editor.formatOnSave": true
+    }
 }

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.8.0-B2109022:
+
+- Engine features:
+  - Added YAML output format support for `Get-PSRuleBaseline`. [#326](https://github.com/microsoft/PSRule/issues/326)
+
 ## v1.8.0-B2109022 (pre-release)
 
 What's changed since pre-release v1.8.0-B2109015:

--- a/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
@@ -15,7 +15,7 @@ Get a list of baselines.
 
 ```text
 Get-PSRuleBaseline [-Module <String[]>] [-ListAvailable] [[-Path] <String[]>] [-Name <String[]>]
- [-Option <PSRuleOption>] [-Culture <String>] [<CommonParameters>]
+ [-Option <PSRuleOption>] [-Culture <String>] [-OutputFormat <OutputFormat>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -135,6 +135,28 @@ The PowerShell cmdlet `Get-Culture` shows the current culture of PowerShell.
 Type: String
 Parameter Sets: (All)
 Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFormat
+
+Configures the format that output is presented in.
+
+The following format options are available:
+
+- None - Output is presented as an object using PowerShell defaults. This is the default.
+- Yaml - Output is serialized as YAML.
+
+```yaml
+Type: OutputFormat
+Parameter Sets: (All)
+Aliases: o
+Accepted values: None, Yaml
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1716,7 +1716,7 @@ variables:
 ### Output.Format
 
 Configures the format that results will be presented in.
-This option applies to `Invoke-PSRule`, `Assert-PSRule`, and `Get-PSRule`.
+This option applies to `Invoke-PSRule`, `Assert-PSRule`, `Get-PSRule` and `Get-PSRuleBaseline`.
 This options is ignored by other cmdlets.
 
 The following format options are available:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1736,6 +1736,8 @@ RuleName, Pass, Fail, Outcome, Synopsis, Recommendation
 The Wide format is ignored by `Assert-PSRule`. `Get-PSRule` only accepts `Wide` or `None`.
 Usage of other formats are treated as `None`.
 
+The `Get-PSRuleBaseline` cmdlet only accepts `None` or `Yaml`.
+
 This option can be specified using:
 
 ```powershell

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -357,7 +357,7 @@ namespace PSRule
         {
             return type
                 .GetRuntimeFields()
-                .Where(f => !f.IsStatic && f.IsPublic)
+                .Where(f => !f.IsStatic && f.IsPublic && !f.IsDefined(typeof(YamlIgnoreAttribute), true))
                 .Select(p => new Field(p, _TypeResolver, _NamingConvention));
         }
 
@@ -365,7 +365,7 @@ namespace PSRule
         {
             return type
                 .GetProperties(bindingAttr: BindingFlags.Public | BindingFlags.GetProperty | BindingFlags.Instance)
-                .Where(p => p.CanRead && IsAllowedProperty(p.Name))
+                .Where(p => p.CanRead && IsAllowedProperty(p.Name) && !p.IsDefined(typeof(YamlIgnoreAttribute), true))
                 .Select(p => new Property(p, _TypeResolver, _NamingConvention));
         }
 

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -322,6 +322,26 @@ namespace PSRule
     }
 
     /// <summary>
+    /// A YAML type inspector to sort properties by name
+    /// </summary>
+    internal sealed class SortedPropertyYamlTypeInspector : TypeInspectorSkeleton
+    {
+        private readonly ITypeInspector _innerTypeDescriptor;
+
+        public SortedPropertyYamlTypeInspector(ITypeInspector innerTypeDescriptor)
+        {
+            this._innerTypeDescriptor = innerTypeDescriptor;
+        }
+
+        public override IEnumerable<IPropertyDescriptor> GetProperties(Type type, object container)
+        {
+            return _innerTypeDescriptor
+                .GetProperties(type, container)
+                .OrderBy(p => p.Name);
+        }
+    }
+
+    /// <summary>
     /// A YAML type inspector to read fields and properties from a type for serialization.
     /// </summary>
     internal sealed class FieldYamlTypeInspector : TypeInspectorSkeleton

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -9,6 +9,7 @@ using PSRule.Definitions.Expressions;
 using PSRule.Host;
 using PSRule.Runtime;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
@@ -128,6 +129,87 @@ namespace PSRule
                 }
                 emitter.Emit(new SequenceEnd());
             }
+            emitter.Emit(new MappingEnd());
+        }
+    }
+
+    /// <summary>
+    /// A YAML converter for serializing Hashtable
+    /// </summary>
+    internal sealed class HashtableYamlTypeConverter : IYamlTypeConverter
+    {
+        public bool Accepts(Type type)
+        {
+            return type == typeof(Hashtable);
+        }
+        public object ReadYaml(IParser parser, Type type)
+        {
+            throw new NotImplementedException();
+        }
+        public void WriteYaml(IEmitter emitter, object value, Type type)
+        {
+            if (type == typeof(Hashtable) && value == null)
+            {
+                emitter.Emit(new MappingStart());
+                emitter.Emit(new MappingEnd());
+            }
+
+            if (!(value is Hashtable hashtable))
+                return;
+
+            emitter.Emit(new MappingStart());
+
+            if (hashtable != null && hashtable.Count > 0)
+            {
+                foreach (DictionaryEntry entry in hashtable)
+                {
+                    emitter.Emit(new Scalar(entry.Key.ToString()));
+
+                    if (entry.Value == null)
+                    {
+                        emitter.Emit(new Scalar(string.Empty));
+                    }
+
+                    else if (entry.Value is string stringEntryValue)
+                    {
+                        emitter.Emit(new Scalar(stringEntryValue));
+                    }
+
+                    else if (entry.Value is string[] stringEntryValueArray)
+                    {
+                        emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+
+                        foreach (string strVal in stringEntryValueArray)
+                        {
+                            emitter.Emit(new Scalar(strVal));
+                        }
+
+                        emitter.Emit(new SequenceEnd());
+                    }
+
+                    else if (entry.Value is PSObject psObjectEntryValue)
+                    {
+                        emitter.Emit(new Scalar(psObjectEntryValue.BaseObject.ToString()));
+                    }
+
+                    else if (entry.Value is PSObject[] psObjectEntryValueArray)
+                    {
+                        emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+
+                        foreach (PSObject obj in psObjectEntryValueArray)
+                        {
+                            emitter.Emit(new Scalar(obj.BaseObject.ToString()));
+                        }
+
+                        emitter.Emit(new SequenceEnd());
+                    }
+                    else
+                    {
+                        emitter.Emit(new Scalar(entry.Value.ToString()));
+                    }
+                }
+            }
+
             emitter.Emit(new MappingEnd());
         }
     }

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -249,8 +249,10 @@ namespace PSRule.Definitions
 
         public string Name { get; set; }
 
+        [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
         public ResourceAnnotations Annotations { get; set; }
 
+        [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections)]
         public ResourceTags Tags { get; set; }
     }
 

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -297,6 +297,7 @@ namespace PSRule.Definitions
         [YamlIgnore()]
         public readonly SourceFile Source;
 
+        [YamlIgnore()]
         public readonly ResourceHelpInfo Info;
 
         public ResourceMetadata Metadata { get; }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -791,7 +791,12 @@ function Get-PSRuleBaseline {
         [PSRule.Configuration.PSRuleOption]$Option,
 
         [Parameter(Mandatory = $False)]
-        [String]$Culture
+        [String]$Culture,
+
+        [Parameter(Mandatory = $False)]
+        [ValidateSet('None', 'Yaml')]
+        [Alias('o')]
+        [PSRule.Configuration.OutputFormat]$OutputFormat
     )
     begin {
         Write-Verbose -Message "[Get-PSRuleBaseline] BEGIN::";
@@ -833,6 +838,10 @@ function Get-PSRuleBaseline {
 
         if ($PSBoundParameters.ContainsKey('Culture')) {
             $Option.Output.Culture = $Culture;
+        }
+        
+        if ($PSBoundParameters.ContainsKey('OutputFormat')) {
+            $Option.Output.Format = $OutputFormat;
         }
 
         $builder = [PSRule.Pipeline.PipelineBuilder]::GetBaseline($sourceFiles, $Option, $PSCmdlet, $ExecutionContext);;

--- a/src/PSRule/Pipeline/GetBaselinePipeline.cs
+++ b/src/PSRule/Pipeline/GetBaselinePipeline.cs
@@ -34,7 +34,7 @@ namespace PSRule.Pipeline
 
             Option.Output.As = ResultFormat.Detail;
             Option.Output.Culture = GetCulture(option.Output.Culture);
-            Option.Output.Format = OutputFormat.None;
+            Option.Output.Format = SuppressFormat(option.Output.Format);
             return this;
         }
 
@@ -48,6 +48,11 @@ namespace PSRule.Pipeline
                 writer: PrepareWriter(),
                 filter: filter
             );
+        }
+
+        private static OutputFormat SuppressFormat(OutputFormat? format)
+        {
+            return !format.HasValue || format != OutputFormat.Yaml ? OutputFormat.None : format.Value;
         }
     }
 
@@ -64,6 +69,7 @@ namespace PSRule.Pipeline
         public override void End()
         {
             Writer.WriteObject(HostHelper.GetBaselineYaml(Source, Context).Where(Match), true);
+            Writer.End();
         }
 
         private bool Match(Baseline baseline)

--- a/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
@@ -14,12 +14,20 @@ namespace PSRule.Pipeline.Output
 
         protected override string Serialize(object[] o)
         {
+            return ToYaml(o);
+        }
+
+        internal static string ToYaml(object[] o)
+        {
             var s = new SerializerBuilder()
                 .DisableAliases()
                 .WithTypeInspector(f => new FieldYamlTypeInspector())
                 .WithTypeInspector(inspector => new SortedPropertyYamlTypeInspector(inspector))
                 .WithTypeConverter(new HashtableYamlTypeConverter())
+                .WithTypeConverter(new PSObjectYamlTypeConverter())
+                .WithTypeConverter(new FieldMapYamlTypeConverter())
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
                 .Build();
 
             return s.Serialize(o);

--- a/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
@@ -15,7 +15,9 @@ namespace PSRule.Pipeline.Output
         protected override string Serialize(object[] o)
         {
             var s = new SerializerBuilder()
+                .DisableAliases()
                 .WithTypeInspector(f => new FieldYamlTypeInspector())
+                .WithTypeConverter(new HashtableYamlTypeConverter())
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();
 

--- a/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
@@ -17,6 +17,7 @@ namespace PSRule.Pipeline.Output
             var s = new SerializerBuilder()
                 .DisableAliases()
                 .WithTypeInspector(f => new FieldYamlTypeInspector())
+                .WithTypeInspector(inspector => new SortedPropertyYamlTypeInspector(inspector))
                 .WithTypeConverter(new HashtableYamlTypeConverter())
                 .WithNamingConvention(CamelCaseNamingConvention.Instance)
                 .Build();

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -5,12 +5,14 @@ using PSRule.Configuration;
 using PSRule.Definitions.Baselines;
 using PSRule.Host;
 using PSRule.Pipeline;
+using PSRule.Pipeline.Output;
 using PSRule.Runtime;
 using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using Xunit;
+using YamlDotNet.Serialization;
 using Assert = Xunit.Assert;
 
 namespace PSRule
@@ -72,6 +74,30 @@ namespace PSRule
             var actual = baseline.FirstOrDefault(b => filter.Match(b));
 
             Assert.Equal("TestBaseline5", actual.Name);
+        }
+
+        [Fact]
+        public void BaselineAsYaml()
+        {
+            var expected = GetBaselines(GetSource());
+            var s = YamlOutputWriter.ToYaml(expected);
+            var d = new DeserializerBuilder().Build();
+            var actual = d.Deserialize<dynamic>(s);
+
+            // TestBaseline1
+            Assert.Equal("github.com/microsoft/PSRule/v1", actual[0]["apiVersion"]);
+            Assert.Equal("Baseline", actual[0]["kind"]);
+            Assert.Equal("TestBaseline1", actual[0]["metadata"]["name"]);
+            Assert.NotNull(actual[0]["spec"]);
+            Assert.Equal("kind", actual[0]["spec"]["binding"]["field"]["kind"][0]);
+            Assert.Equal("Id", actual[0]["spec"]["binding"]["field"]["uniqueIdentifer"][0]);
+            Assert.Equal("AlternateName", actual[0]["spec"]["binding"]["field"]["uniqueIdentifer"][1]);
+            Assert.Equal("AlternateName", actual[0]["spec"]["binding"]["targetName"][0]);
+            Assert.Equal("kind", actual[0]["spec"]["binding"]["targetType"][0]);
+            Assert.Equal("WithBaseline", actual[0]["spec"]["rule"]["include"][0]);
+            Assert.Equal("value1", actual[0]["spec"]["configuration"]["key1"]);
+            Assert.Equal("abc", actual[0]["spec"]["configuration"]["key2"][0]["value1"]);
+            Assert.Equal("def", actual[0]["spec"]["configuration"]["key2"][1]["value2"]);
         }
 
         #region Helper methods


### PR DESCRIPTION
## PR Summary

Fix #326 

Added `OutputFormat` option for `Get-PSRuleBaseline` cmdlet.

Serializes as shown below:

```powershell
> Get-PSRuleBaseline -Module PSRule.Rules.Azure -Path ..\PSRule.Rules.Azure\ -Name Azure.GA_2021_09  -OutputFormat Yaml

- - apiVersion: github.com/microsoft/PSRule/v1
    kind: Baseline
    metadata:
      annotations: {}
      name: Azure.GA_2021_09
      tags: {}
    spec:
      binding:
      configuration:
      convention:
      rule:
        exclude:
        include: 
        includeLocal:
        tag:
          ruleSet:
          - 2020_06
          - 2020_09
          - 2020_12
          - 2021_03
          - 2021_06
          - 2021_09
          release: GA
```

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
