### PR TITLE
Pester v5 migration

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,6 +10,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since pre-release v1.8.0-B2110006:
+
+- Engineering:
+  - Migration of Pester v4 tests to Pester v5. [#478](https://github.com/microsoft/PSRule/issues/478)
+
 ## v1.8.0-B2110006 (pre-release)
 
 What's changed since pre-release v1.8.0-B2109022:

--- a/tests/PSRule.Tests/PSRule.AllOf.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.AllOf.Tests.ps1
@@ -10,31 +10,37 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
-}
-
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
-Describe 'PSRule -- AllOf keyword' -Tag 'AllOf' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
-    $invokeParams = @{
-        Path = $ruleFilePath
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
     }
 
-    Context 'AllOf' {
-        $testObject = @{
-            Key = 'Value'
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
+
+Describe 'PSRule -- AllOf keyword' -Tag 'AllOf' {
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+        $invokeParams = @{
+            Path = $ruleFilePath
         }
-        $result = $testObject | Invoke-PSRule @invokeParams -Name 'AllOfTest','AllOfTestNegative';
+    }
+    
+    Context 'AllOf' {
+        BeforeAll {
+            $testObject = @{
+                Key = 'Value'
+            }
+            $result = $testObject | Invoke-PSRule @invokeParams -Name 'AllOfTest','AllOfTestNegative';
+        }
 
         It 'Should succeed on all positive conditions' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'AllOfTest' };

--- a/tests/PSRule.Tests/PSRule.AnyOf.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.AnyOf.Tests.ps1
@@ -10,31 +10,37 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
-
 Describe 'PSRule -- AnyOf keyword' -Tag 'AnyOf' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
-    $invokeParams = @{
-        Path = $ruleFilePath
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+        $invokeParams = @{
+            Path = $ruleFilePath
+        }
     }
 
     Context 'AnyOf' {
-        $testObject = @{
-            Key = 'Value'
+        BeforeAll {
+            $testObject = @{
+                Key = 'Value'
+            }
+            $result = $testObject | Invoke-PSRule @invokeParams -Name 'AnyOfTest', 'AnyOfTestNegative';
         }
-        $result = $testObject | Invoke-PSRule @invokeParams -Name 'AnyOfTest', 'AnyOfTestNegative';
 
         It 'Should succeed on any positive conditions' {
             $filteredResult = $result | Where-Object { $_.RuleName -eq 'AnyOfTest' };

--- a/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Assert.Tests.ps1
@@ -8,97 +8,103 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
 
 #region PSRule variables
 
 Describe 'PSRule assertions' -Tag 'Assert' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFileAssert.Rule.ps1');
-    $invokeParams = @{
-        Path = $ruleFilePath
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFileAssert.Rule.ps1');
+        $invokeParams = @{
+            Path = $ruleFilePath
+        }
     }
 
     Context '$Assert' {
-        $testObject = @(
-            [PSCustomObject]@{
-                Name = 'TestObject1'
-                Type = 'TestType'
-                Value = 'Value1'
-                Array = 'Item1', 'Item2'
-                String = 'Value'
-                OtherField = 'Other'
-                Int = 1
-                Bool = $True
-                Version = '2.0.0'
-                CompareNumeric = 3
-                CompareArray = 1, 2, 3
-                CompareString = 'abc'
-                CompareDate = [DateTime]::Now.AddDays(3)
-                InArray = @(
-                    'Item1'
-                    'Item3'
-                    'Item4'
-                )
-                Path = $PSCommandPath
-                ParentPath = $here
-                Lower = 'test123'
-                Upper = 'TEST123'
-                LetterLower = 'test'
-                LetterUpper = 'TEST'
-                IsInteger = 1
-                IsBoolean = $True
-                IsArray = 1, 2, 3
-                IsDateTime = [DateTime]::Now.AddDays(4)
-            }
-            [PSCustomObject]@{
-                '$schema' = "http://json-schema.org/draft-07/schema`#"
-                Name = 'TestObject2'
-                NotType = 'TestType'
-                Value = $Null
-                Array = @()
-                String = ''
-                Int = 2
-                Bool = $False
-                OtherBool = $False
-                OtherInt = 2
-                Version = '1.0.0'
-                CompareNumeric = 0
-                CompareArray = @()
-                CompareString = ''
-                CompareDate = [DateTime]::Now
-                InArray = @(
-                    'item1'
-                    'item2'
-                    'item3'
-                )
-                InArrayPSObject = [PSObject[]]@(
-                    'item1'
-                    'item2'
-                    'item3'
-                )
-                ParentPath = (Join-Path -Path $here -ChildPath 'notapath/template.json')
-                Lower = 'Test123'
-                Upper = 'Test123'
-                LetterLower = 'test123'
-                LetterUpper = 'TEST123'
-                IsInteger = '1'
-                IsBoolean = 'true'
-                IsArray = '123'
-                IsDateTime = ([DateTime]::Now.AddDays(4).ToString('o'))
-            }
-        )
+        BeforeAll {
+            $testObject = @(
+                [PSCustomObject]@{
+                    Name = 'TestObject1'
+                    Type = 'TestType'
+                    Value = 'Value1'
+                    Array = 'Item1', 'Item2'
+                    String = 'Value'
+                    OtherField = 'Other'
+                    Int = 1
+                    Bool = $True
+                    Version = '2.0.0'
+                    CompareNumeric = 3
+                    CompareArray = 1, 2, 3
+                    CompareString = 'abc'
+                    CompareDate = [DateTime]::Now.AddDays(3)
+                    InArray = @(
+                        'Item1'
+                        'Item3'
+                        'Item4'
+                    )
+                    Path = $PSCommandPath
+                    ParentPath = $here
+                    Lower = 'test123'
+                    Upper = 'TEST123'
+                    LetterLower = 'test'
+                    LetterUpper = 'TEST'
+                    IsInteger = 1
+                    IsBoolean = $True
+                    IsArray = 1, 2, 3
+                    IsDateTime = [DateTime]::Now.AddDays(4)
+                }
+                [PSCustomObject]@{
+                    '$schema' = "http://json-schema.org/draft-07/schema`#"
+                    Name = 'TestObject2'
+                    NotType = 'TestType'
+                    Value = $Null
+                    Array = @()
+                    String = ''
+                    Int = 2
+                    Bool = $False
+                    OtherBool = $False
+                    OtherInt = 2
+                    Version = '1.0.0'
+                    CompareNumeric = 0
+                    CompareArray = @()
+                    CompareString = ''
+                    CompareDate = [DateTime]::Now
+                    InArray = @(
+                        'item1'
+                        'item2'
+                        'item3'
+                    )
+                    InArrayPSObject = [PSObject[]]@(
+                        'item1'
+                        'item2'
+                        'item3'
+                    )
+                    ParentPath = (Join-Path -Path $here -ChildPath 'notapath/template.json')
+                    Lower = 'Test123'
+                    Upper = 'Test123'
+                    LetterLower = 'test123'
+                    LetterUpper = 'TEST123'
+                    IsInteger = '1'
+                    IsBoolean = 'true'
+                    IsArray = '123'
+                    IsDateTime = ([DateTime]::Now.AddDays(4).ToString('o'))
+                }
+            )
+        }
 
         It 'In pre-conditions' {
             $result = @($testObject | Invoke-PSRule @invokeParams -Name 'Assert.Precondition' -Outcome All -WarningAction SilentlyContinue);
@@ -802,16 +808,18 @@ Describe 'PSRule assertions' -Tag 'Assert' {
     }
 
     Context '$Assert extension' {
-        $testObject = @(
-            [PSCustomObject]@{
-                Name = 'TestObject1'
-                Type = 'TestType'
-            }
-            [PSCustomObject]@{
-                Name = 'TestObject2'
-                NotType = 'TestType'
-            }
-        )
+        BeforeAll {
+            $testObject = @(
+                [PSCustomObject]@{
+                    Name = 'TestObject1'
+                    Type = 'TestType'
+                }
+                [PSCustomObject]@{
+                    Name = 'TestObject2'
+                    NotType = 'TestType'
+                }
+            )
+        }
 
         It 'With Add-Member' {
             $result = @($testObject | Invoke-PSRule @invokeParams -Name 'Assert.AddMember');

--- a/tests/PSRule.Tests/PSRule.Badges.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Badges.Tests.ps1
@@ -8,35 +8,41 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Badges;
+    Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+    $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-
-$here = (Resolve-Path $PSScriptRoot).Path;
-$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Badges;
-Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
-$Null = New-Item -Path $outputPath -ItemType Directory -Force;
 
 #region Baseline
 
 Describe 'Badges' -Tag 'Badges' {
-    $ruleFilePath = Join-Path -Path $here -ChildPath 'FromFileBadge.Rule.ps1';
+    BeforeAll {
+        $ruleFilePath = Join-Path -Path $here -ChildPath 'FromFileBadge.Rule.ps1';
+    }
 
     Context 'Generates badges' {
-        $testObject = @(
-            [PSCustomObject]@{
-                Name = 'TestObject1'
-            }
-        )
+        BeforeAll {
+            $testObject = @(
+                [PSCustomObject]@{
+                    Name = 'TestObject1'
+                }
+            )
+        }
 
         It 'Single' {
             $outputFile = Join-Path -Path $outputPath -ChildPath 'single.svg';

--- a/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
@@ -8,28 +8,32 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Common;
+    Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+    $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-
-$here = (Resolve-Path $PSScriptRoot).Path;
-$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Common;
-Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
-$Null = New-Item -Path $outputPath -ItemType Directory -Force;
 
 #region Get-PSRuleBaseline
 
 Describe 'Get-PSRuleBaseline' -Tag 'Baseline','Get-PSRuleBaseline' {
-    $baselineFilePath = Join-Path -Path $here -ChildPath 'Baseline.Rule.yaml';
+    BeforeAll {
+        $baselineFilePath = Join-Path -Path $here -ChildPath 'Baseline.Rule.yaml';
+    }
 
     Context 'Read baseline' {
         It 'With defaults' {
@@ -73,17 +77,21 @@ Describe 'Get-PSRuleBaseline' -Tag 'Baseline','Get-PSRuleBaseline' {
 #region Baseline
 
 Describe 'Baseline' -Tag 'Baseline' {
-    $baselineFilePath = Join-Path -Path $here -ChildPath 'Baseline.Rule.yaml';
-    $ruleFilePath = Join-Path -Path $here -ChildPath 'FromFileBaseline.Rule.ps1';
+    BeforeAll {
+        $baselineFilePath = Join-Path -Path $here -ChildPath 'Baseline.Rule.yaml';
+        $ruleFilePath = Join-Path -Path $here -ChildPath 'FromFileBaseline.Rule.ps1';
+    }
 
     Context 'Invoke-PSRule' {
-        $testObject = @(
-            [PSCustomObject]@{
-                AlternateName = 'TestObject1'
-                Kind = 'TestObjectType'
-                Id = '1'
-            }
-        )
+        BeforeAll {
+            $testObject = @(
+                [PSCustomObject]@{
+                    AlternateName = 'TestObject1'
+                    Kind = 'TestObjectType'
+                    Id = '1'
+                }
+            )
+        }
 
         It 'With -Baseline' {
             $result = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline1');

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -811,13 +811,13 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 Name = 'TestObject1'
                 Value = 1
             }
-        }
 
-        It 'Checks if DeviceGuard is enabled' {
             Mock -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Verifiable -MockWith {
                 return $True;
             }
+        }
 
+        It 'Checks if DeviceGuard is enabled' {
             $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1';
             Assert-MockCalled -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Times 1;
         }
@@ -835,7 +835,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             $option = New-PSRuleOption -Option @{ 'execution.mode' = 'ConstrainedLanguage' } -BindTargetName $bindFn;
-            { $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1' -Option $option -ErrorAction Stop } | Should -Throw 'Binding functions are not supported in this language mode.';
+            { $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1' -Option $option -ErrorAction Stop } | Should -Throw 'Exception calling "Invoke" with "4" argument(s): "Binding functions are not supported in this language mode."';
         }
     }
 
@@ -1095,13 +1095,13 @@ Describe 'Test-PSRuleTarget' -Tag 'Test-PSRuleTarget','Common' {
                 Name = 'TestObject1'
                 Value = 1
             }
-        }
 
-        It 'Checks if DeviceGuard is enabled' {
             Mock -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Verifiable -MockWith {
                 return $True;
             }
+        }
 
+        It 'Checks if DeviceGuard is enabled' {
             $Null = $testObject | Test-PSRuleTarget -Path $ruleFilePath -Name 'ConstrainedTest1';
             Assert-MockCalled -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Times 1;
         }
@@ -1119,7 +1119,7 @@ Describe 'Test-PSRuleTarget' -Tag 'Test-PSRuleTarget','Common' {
             }
 
             $option = New-PSRuleOption -Option @{ 'execution.mode' = 'ConstrainedLanguage' } -BindTargetName $bindFn;
-            { $Null = $testObject | Test-PSRuleTarget -Path $ruleFilePath -Name 'ConstrainedTest1' -Option $option -ErrorAction Stop } | Should -Throw 'Binding functions are not supported in this language mode.';
+            { $Null = $testObject | Test-PSRuleTarget -Path $ruleFilePath -Name 'ConstrainedTest1' -Option $option -ErrorAction Stop } | Should -Throw 'Exception calling "Test" with "4" argument(s): "Binding functions are not supported in this language mode."';
         }
     }
 }
@@ -1353,12 +1353,13 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
                 Name = 'TestObject1'
                 Value = 1
             }
-        }
 
-        It 'Checks if DeviceGuard is enabled' {
             Mock -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Verifiable -MockWith {
                 return $True;
             }
+        }
+
+        It 'Checks if DeviceGuard is enabled' {
             $Null = $testObject | Assert-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1' -Style Plain 6>&1;
             Assert-MockCalled -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Times 1;
         }
@@ -1376,7 +1377,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             }
 
             $option = New-PSRuleOption -Option @{ 'execution.mode' = 'ConstrainedLanguage' } -BindTargetName $bindFn;
-            { $Null = $testObject | Assert-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1' -Option $option -ErrorAction Stop 6>&1 } | Should -Throw 'Binding functions are not supported in this language mode.';
+            { $Null = $testObject | Assert-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1' -Option $option -ErrorAction Stop 6>&1 } | Should -Throw 'Exception calling "Assert" with "4" argument(s): "Binding functions are not supported in this language mode."';
         }
     }
 }
@@ -1803,11 +1804,12 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
     # }
 
     Context 'With constrained language' {
-        It 'Checks if DeviceGuard is enabled' {
+        BeforeAll {
             Mock -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Verifiable -MockWith {
                 return $True;
             }
-
+        }
+        It 'Checks if DeviceGuard is enabled' {
             $Null = Get-PSRule -Path $ruleFilePath -Name 'ConstrainedTest1';
             Assert-MockCalled -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Times 1;
         }
@@ -1945,11 +1947,13 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
     }
 
     Context 'With constrained language' {
-        It 'Checks if DeviceGuard is enabled' {
+        BeforeAll {
             Mock -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Verifiable -MockWith {
                 return $True;
             }
+        }
 
+        It 'Checks if DeviceGuard is enabled' {
             $Null = Get-PSRuleHelp -Path $ruleFilePath -Name 'ConstrainedTest1';
             Assert-MockCalled -CommandName IsDeviceGuardEnabled -ModuleName PSRule -Times 1;
         }

--- a/tests/PSRule.Tests/PSRule.Conventions.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Conventions.Tests.ps1
@@ -8,35 +8,42 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Conventions;
+    Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+    $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-
-$here = (Resolve-Path $PSScriptRoot).Path;
-$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Conventions;
-Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
-$Null = New-Item -Path $outputPath -ItemType Directory -Force;
-
 Describe 'PSRule -- Conventions' -Tag 'Convention' {
-    $rulePath = Join-Path -Path $here -ChildPath 'FromFileConventions.Rule.ps1';
+    BeforeAll {
+        $rulePath = Join-Path -Path $here -ChildPath 'FromFileConventions.Rule.ps1';
+    }
 
     Context 'With -Convention' {
-        $invokeParams = @{
-            Path = $rulePath
-            InputObject = [PSCustomObject]@{
-                Name = 'TestObject1'
-                IfTest = 0
+        BeforeAll {
+            $invokeParams = @{
+                Path = $rulePath
+                InputObject = [PSCustomObject]@{
+                    Name = 'TestObject1'
+                    IfTest = 0
+                }
             }
         }
+
         It 'Uses convention' {
             # Single convention
             $result = @(Invoke-PSRule @invokeParams -Name 'ConventionTest' -Convention 'Convention1');

--- a/tests/PSRule.Tests/PSRule.Exists.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Exists.Tests.ps1
@@ -10,20 +10,24 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
 
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
 
 Describe 'PSRule -- Exists keyword' -Tag 'Exists' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
-    $invokeParams = @{
-        Path = $ruleFilePath
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+        $invokeParams = @{
+            Path = $ruleFilePath
+        }
     }
 
     Context 'Exists' {

--- a/tests/PSRule.Tests/PSRule.Match.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Match.Tests.ps1
@@ -10,18 +10,22 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
 
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
 
 Describe 'PSRule -- Match keyword' -Tag 'Match' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    }
 
     Context 'Match' {
         It 'With defaults' {

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -10,28 +10,32 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Options;
+    Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+    $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-
-$here = (Resolve-Path $PSScriptRoot).Path;
-$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Options;
-Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
-$Null = New-Item -Path $outputPath -ItemType Directory -Force;
 
 #region New-PSRuleOption
 
 Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
-    $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
+    BeforeAll {
+        $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
+    }
 
     Context 'Use -Path' {
         It 'With file' {
@@ -1489,18 +1493,22 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
 #region Set-PSRuleOption
 
 Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
-    $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
-    $optionParams = @{
-        Path = $emptyOptionsFilePath
-        PassThru = $True
+    BeforeAll {
+        $emptyOptionsFilePath = (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml');
+        $optionParams = @{
+            Path = $emptyOptionsFilePath
+            PassThru = $True
+        }
     }
 
     Context 'Use -AllowClobber' {
-        $filePath = (Join-Path -Path $outputPath -ChildPath 'PSRule.Tests4.yml');
-        Copy-Item -Path (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml') -Destination $filePath;
+        BeforeAll {
+            $filePath = (Join-Path -Path $outputPath -ChildPath 'PSRule.Tests4.yml');
+            Copy-Item -Path (Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml') -Destination $filePath;
+        }
 
         It 'Errors with comments' {
-            { Set-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw -ErrorId 'PSRule.PSRuleOption.YamlContainsComments';
+            { Set-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw -ErrorId 'PSRule.PSRuleOption.YamlContainsComments,Set-PSRuleOption';
         }
 
         it 'Overwrites file' {
@@ -1519,7 +1527,7 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
 
         It 'With missing directory' {
             $filePath = (Join-Path -Path $outputPath -ChildPath 'set-dir/ps-rule.yaml');
-            { Set-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw -ErrorId 'PSRule.PSRuleOption.ParentPathNotFound';
+            { Set-PSRuleOption -Path $filePath -ErrorAction Stop } | Should -Throw -ErrorId 'PSRule.PSRuleOption.ParentPathNotFound,Set-PSRuleOption';
             Test-Path -Path $filePath | Should -Be $False;
         }
 

--- a/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.PSGallery.Tests.ps1
@@ -10,15 +10,19 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
+}
 
 Describe 'PSRule' -Tag 'PowerShellGallery' {
-    $modulePath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule);
+    BeforeAll {
+        $modulePath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule);
+    }
 
     Context 'Module' {
         It 'Can be imported' {
@@ -27,11 +31,13 @@ Describe 'PSRule' -Tag 'PowerShellGallery' {
     }
 
     Context 'Manifest' {
-        $manifestPath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule/PSRule.psd1);
-        $result = Test-ModuleManifest -Path $manifestPath;
-        $Global:psEditor = $True;
-        $Null = Import-Module $modulePath -Force;
-        $commands = Get-Command -Module PSRule -All;
+        BeforeAll {
+            $manifestPath = (Join-Path -Path $rootPath -ChildPath out/modules/PSRule/PSRule.psd1);
+            $result = Test-ModuleManifest -Path $manifestPath;
+            $Global:psEditor = $True;
+            $Null = Import-Module $modulePath -Force;
+            $commands = Get-Command -Module PSRule -All;
+        }
 
         It 'Has required fields' {
             $result.Name | Should -Be 'PSRule';

--- a/tests/PSRule.Tests/PSRule.Reason.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Reason.Tests.ps1
@@ -10,24 +10,30 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
 
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
 
 Describe 'PSRule -- Reason keyword' -Tag 'Reason' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    }
 
     Context 'Reason' {
-        $testObject = [PSCustomObject]@{
-            Name = 'TestObject1'
-            Value = @{
-                Value1 = 1
+        BeforeAll {
+            $testObject = [PSCustomObject]@{
+                Name = 'TestObject1'
+                Value = @{
+                    Value1 = 1
+                }
             }
         }
 

--- a/tests/PSRule.Tests/PSRule.Recommend.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Recommend.Tests.ps1
@@ -10,22 +10,26 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
 
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
 
 Describe 'PSRule -- Recommend keyword' -Tag 'Recommend' {
     Context 'Recommend' {
-        $testObject = [PSCustomObject]@{
-            Name = "TestObject1"
-            Value = @{
-                Value1 = 1
+        BeforeAll {
+            $testObject = [PSCustomObject]@{
+                Name = "TestObject1"
+                Value = @{
+                    Value1 = 1
+                }
             }
         }
 

--- a/tests/PSRule.Tests/PSRule.Selectors.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Selectors.Tests.ps1
@@ -8,31 +8,37 @@
 [CmdletBinding()]
 param ()
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+
+    $here = (Resolve-Path $PSScriptRoot).Path;
+    $outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Selectors;
+    Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
+    $Null = New-Item -Path $outputPath -ItemType Directory -Force;
 }
 
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-
-$here = (Resolve-Path $PSScriptRoot).Path;
-$outputPath = Join-Path -Path $rootPath -ChildPath out/tests/PSRule.Tests/Selectors;
-Remove-Item -Path $outputPath -Force -Recurse -Confirm:$False -ErrorAction Ignore;
-$Null = New-Item -Path $outputPath -ItemType Directory -Force;
-
 Describe 'PSRule -- Selectors' -Tag 'Selectors' {
-    $rulePath = Join-Path -Path $here -ChildPath 'FromFileWithSelectors.Rule.ps1';
-    $selectorPath = Join-Path -Path $here -ChildPath 'Selectors.Rule.yaml';
+    BeforeAll {
+        $rulePath = Join-Path -Path $here -ChildPath 'FromFileWithSelectors.Rule.ps1';
+        $selectorPath = Join-Path -Path $here -ChildPath 'Selectors.Rule.yaml';
+    }
 
     Context 'With selector' {
-        $invokeParams = @{
-            Path = $rulePath, $selectorPath
+        BeforeAll {
+            $invokeParams = @{
+                Path = $rulePath, $selectorPath
+            }
         }
         It 'From file' {
             $testObjects = @(

--- a/tests/PSRule.Tests/PSRule.TypeOf.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.TypeOf.Tests.ps1
@@ -10,18 +10,22 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
 
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
 
 Describe 'PSRule -- TypeOf keyword' -Tag 'TypeOf' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    }
 
     Context 'TypeOf' {
         It 'With defaults' {

--- a/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Variables.Tests.ps1
@@ -13,35 +13,41 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-if ($Env:SYSTEM_DEBUG -eq 'true') {
-    $VerbosePreference = 'Continue';
+    if ($Env:SYSTEM_DEBUG -eq 'true') {
+        $VerbosePreference = 'Continue';
+    }
+
+    # Setup tests paths
+    $rootPath = $PWD;
+
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
 }
-
-# Setup tests paths
-$rootPath = $PWD;
-
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
 
 #region PSRule variables
 
 Describe 'PSRule variables' -Tag 'Variables' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    }
 
     Context 'PowerShell automatic variables' {
-        $testObject = [PSCustomObject]@{
-            Name = 'VariableTest'
-            Type = 'TestType'
-            PSScriptRoot = $PSScriptRoot
-            PWD = $PWD
-            PSCommandPath = $ruleFilePath
-            RuleTest = 'WithRuleVariable'
+        BeforeAll {
+            $testObject = [PSCustomObject]@{
+                Name = 'VariableTest'
+                Type = 'TestType'
+                PSScriptRoot = $PSScriptRoot
+                PWD = $PWD
+                PSCommandPath = $ruleFilePath
+                RuleTest = 'WithRuleVariable'
+            }
+            $testObject.PSObject.TypeNames.Insert(0, $testObject.Type);
         }
-        $testObject.PSObject.TypeNames.Insert(0, $testObject.Type);
 
         It '$PSRule' {
             $option = New-PSRuleOption -BindingField @{ kind = 'Type' };

--- a/tests/PSRule.Tests/PSRule.Within.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Within.Tests.ps1
@@ -10,18 +10,22 @@ param (
 
 )
 
-# Setup error handling
-$ErrorActionPreference = 'Stop';
-Set-StrictMode -Version latest;
+BeforeAll {
+    # Setup error handling
+    $ErrorActionPreference = 'Stop';
+    Set-StrictMode -Version latest;
 
-# Setup tests paths
-$rootPath = $PWD;
+    # Setup tests paths
+    $rootPath = $PWD;
 
-Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
-$here = (Resolve-Path $PSScriptRoot).Path;
+    Import-Module (Join-Path -Path $rootPath -ChildPath out/modules/PSRule) -Force;
+    $here = (Resolve-Path $PSScriptRoot).Path;
+}
 
 Describe 'PSRule -- Within keyword' -Tag 'Within' {
-    $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    BeforeAll {
+        $ruleFilePath = (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1');
+    }
 
     Context 'Within' {
         It 'With defaults' {


### PR DESCRIPTION
## PR Summary

Fix #478

Converted to pester v5 tests syntax and v5.3.0 module version. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
