### PR TITLE
Added Yaml/Json output format options for Get-PSRule

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -14,6 +14,8 @@ What's changed since pre-release v1.8.0-B2110006:
 
 - Engineering:
   - Migration of Pester v4 tests to Pester v5. [#478](https://github.com/microsoft/PSRule/issues/478)
+- Engine features
+  - Added YAML/JSON output format support for `Get-PSRule`. [#128](https://github.com/microsoft/PSRule/issues/128)
 
 ## v1.8.0-B2110006 (pre-release)
 

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -226,12 +226,14 @@ The following format options are available:
 
 - None - Output is presented as an object using PowerShell defaults. This is the default.
 - Wide - Output is presented using the wide table format, which includes tags and wraps columns.
+- Yaml - Output is serialized as YAML.
+- Json - Output is serialized as JSON.
 
 ```yaml
 Type: OutputFormat
 Parameter Sets: (All)
 Aliases: o
-Accepted values: None, Wide
+Accepted values: None, Wide, Yaml, Json
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1733,7 +1733,7 @@ RuleName, TargetName, TargetType, Outcome, OutcomeReason, Synopsis, Recommendati
 RuleName, Pass, Fail, Outcome, Synopsis, Recommendation
 - Wide -  Output is presented using the wide table format, which includes reason and wraps columns.
 
-The Wide format is ignored by `Assert-PSRule`. `Get-PSRule` only accepts `Wide` or `None`.
+The Wide format is ignored by `Assert-PSRule`. `Get-PSRule` only accepts `None`, `Wide`, `Yaml` and `Json`.
 Usage of other formats are treated as `None`.
 
 The `Get-PSRuleBaseline` cmdlet only accepts `None` or `Yaml`.

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using PSRule.Data;
 using PSRule.Pipeline;
 using PSRule.Resources;
@@ -9,6 +10,7 @@ using PSRule.Runtime;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
 
 namespace PSRule
@@ -302,6 +304,20 @@ namespace PSRule
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    /// A contract resolver to sort properties alphabetically
+    /// </summary>
+    internal sealed class SortedPropertyContractResolver : DefaultContractResolver
+    {
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            return base
+                .CreateProperties(type, memberSerialization)
+                .OrderBy(prop => prop.PropertyName)
+                .ToList();
         }
     }
 }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -649,7 +649,7 @@ function Get-PSRule {
         [Switch]$ListAvailable,
 
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Wide')]
+        [ValidateSet('None', 'Wide', 'Yaml', 'Json')]
         [Alias('o')]
         [PSRule.Configuration.OutputFormat]$OutputFormat,
 

--- a/src/PSRule/Pipeline/Output/JsonOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/JsonOutputWriter.cs
@@ -16,6 +16,7 @@ namespace PSRule.Pipeline.Output
             var settings = new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore,
+                Formatting = Formatting.Indented
             };
             settings.Converters.Add(new ErrorCategoryJsonConverter());
             return JsonConvert.SerializeObject(o, settings: settings);

--- a/src/PSRule/Pipeline/Output/JsonOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/JsonOutputWriter.cs
@@ -19,6 +19,7 @@ namespace PSRule.Pipeline.Output
                 Formatting = Formatting.Indented
             };
             settings.Converters.Add(new ErrorCategoryJsonConverter());
+            settings.ContractResolver = new SortedPropertyContractResolver();
             return JsonConvert.SerializeObject(o, settings: settings);
         }
     }

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -37,6 +37,7 @@ namespace PSRule.Pipeline
         [JsonProperty(PropertyName = "path")]
         public string Path { get; }
 
+        [JsonProperty(PropertyName = "moduleName")]
         public string ModuleName { get; }
 
         [YamlIgnore]

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -12,6 +12,8 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Threading;
+using YamlDotNet.Serialization;
+using Newtonsoft.Json;
 
 namespace PSRule.Pipeline
 {
@@ -32,12 +34,17 @@ namespace PSRule.Pipeline
 
         internal Source Source;
 
+        [JsonProperty(PropertyName = "path")]
         public string Path { get; }
 
         public string ModuleName { get; }
 
+        [YamlIgnore]
+        [JsonIgnore]
         public SourceType Type { get; }
 
+        [YamlIgnore]
+        [JsonIgnore]
         public string HelpPath { get; }
 
         public SourceFile(string path, string moduleName, SourceType type, string helpPath)

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1764,19 +1764,19 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
             ($result | Get-Member).TypeName | Should -BeIn 'PSRule.Rules.Rule+Wide';
         }
 
-        # It 'Yaml' {
-        #     $result = Get-PSRule -Path $ruleFilePath -Name 'FromFile1' -OutputFormat Yaml;
-        #     $result | Should -Not -BeNullOrEmpty;
-        #     $result | Should -BeOfType System.String;
-        #     $result -cmatch 'ruleName: FromFile1' | Should -Be $True;
-        # }
+        It 'Yaml' {
+            $result = Get-PSRule -Path $ruleFilePath -Name 'FromFile1' -OutputFormat Yaml;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeOfType System.String;
+            $result -cmatch 'ruleName: FromFile1' | Should -Be $True;
+        }
 
-        # It 'Json' {
-        #     $result = Get-PSRule -Path $ruleFilePath -Name 'FromFile1' -OutputFormat Json;
-        #     $result | Should -Not -BeNullOrEmpty;
-        #     $result | Should -BeOfType System.String;
-        #     $result -cmatch '"ruleName":"FromFile1"' | Should -Be $True;
-        # }
+        It 'Json' {
+            $result = Get-PSRule -Path $ruleFilePath -Name 'FromFile1' -OutputFormat Json;
+            $result | Should -Not -BeNullOrEmpty;
+            $result | Should -BeOfType System.String;
+            $result -cmatch '"ruleName": "FromFile1"' | Should -Be $True;
+        }
     }
 
     Context 'With -Culture' {

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -489,10 +489,10 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile1' -OutputFormat Json);
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.String;
-            $result -cmatch '"ruleName":"FromFile1"' | Should -Be $True;
-            $result -cmatch '"outcome":"Pass"' | Should -Be $True;
-            $result -cmatch '"targetName":"TestObject1"' | Should -Be $True;
-            $result -cmatch '"targetType":"TestType"' | Should -Be $True;
+            $result -cmatch '"ruleName": "FromFile1"' | Should -Be $True;
+            $result -cmatch '"outcome": "Pass"' | Should -Be $True;
+            $result -cmatch '"targetName": "TestObject1"' | Should -Be $True;
+            $result -cmatch '"targetType": "TestType"' | Should -Be $True;
             $result | Should -Not -Match '"targetObject":';
         }
 


### PR DESCRIPTION
## PR Summary

Fix #128



### Yaml

```pwsh
Get-PSRule -Module PSRule.Rules.Azure -Path ..\PSRule.Rules.Azure\ -OutputFormat Yaml -Name Azure.AKS.AutoScaling
```

```yaml
- info:
    annotations:
      pillar: Performance Efficiency
      severity: Important
      category: Performance
      resource: Azure Kubernetes Service
      online version: https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AutoScaling/
    description: In addition to perform manual scaling, AKS clusters support autoscaling. Autoscaling reduces manual intervention required to scale a cluster to keep up with application demands.
    displayName: Enable AKS cluster autoscaler
    moduleName: PSRule.Rules.Azure
    name: Azure.AKS.AutoScaling
    recommendation: Consider enabling autoscaling for AKS clusters deployed with virtual machine scale sets.
    synopsis: Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present.
  ruleId: PSRule.Rules.Azure\Azure.AKS.AutoScaling
  ruleName: Azure.AKS.AutoScaling
  source:
    moduleName: PSRule.Rules.Azure
    path: C:\Users\armcleod\Documents\github-repos\PSRule.Rules.Azure\out\modules\PSRule.Rules.Azure\rules\Azure.AKS.Rule.ps1
  tag:
    release: GA
    ruleSet: 2021_09
```

### Json

```pwsh
Get-PSRule -Module PSRule.Rules.Azure -Path ..\PSRule.Rules.Azure\ -OutputFormat Json -Name Azure.AKS.AutoScaling
```

```json
[
  {
    "info": {
      "annotations": {
        "pillar": "Performance Efficiency",
        "severity": "Important",
        "category": "Performance",
        "resource": "Azure Kubernetes Service",
        "online version": "https://azure.github.io/PSRule.Rules.Azure/en/rules/Azure.AKS.AutoScaling/"
      },
      "description": "In addition to perform manual scaling, AKS clusters support autoscaling. Autoscaling reduces manual intervention required to scale a cluster to keep up with application demands.",
      "displayName": "Enable AKS cluster autoscaler",
      "moduleName": "PSRule.Rules.Azure",
      "name": "Azure.AKS.AutoScaling",
      "recommendation": "Consider enabling autoscaling for AKS clusters deployed with virtual machine scale sets.",
      "synopsis": "Use Autoscaling to ensure AKS clusters deployed with virtual machine scale sets are running efficiently with the right number of nodes for the workloads present."
    },
    "ruleId": "PSRule.Rules.Azure\\Azure.AKS.AutoScaling",
    "ruleName": "Azure.AKS.AutoScaling",
    "source": {
      "moduleName": "PSRule.Rules.Azure",
      "path": "C:\\Users\\armcleod\\Documents\\github-repos\\PSRule.Rules.Azure\\out\\modules\\PSRule.Rules.Azure\\rules\\Azure.AKS.Rule.ps1"
    },
    "tag": {
      "release": "GA",
      "ruleSet": "2021_09"
    }
  }
]
```

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
