### PR TITLE
Pre-release v1.8.0-B2110020

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -10,12 +10,14 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.8.0-B2110020 (pre-release)
+
 What's changed since pre-release v1.8.0-B2110006:
 
-- Engineering:
-  - Migration of Pester v4 tests to Pester v5. [#478](https://github.com/microsoft/PSRule/issues/478)
 - Engine features
   - Added YAML/JSON output format support for `Get-PSRule`. [#128](https://github.com/microsoft/PSRule/issues/128)
+- Engineering:
+  - Migration of Pester v4 tests to Pester v5. [#478](https://github.com/microsoft/PSRule/issues/478)
 
 ## v1.8.0-B2110006 (pre-release)
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v1.8.0-B2110006:

- Engine features
  - Added YAML/JSON output format support for `Get-PSRule`. #128
- Engineering:
  - Migration of Pester v4 tests to Pester v5. #478

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
