### PR TITLE
Fix typo in rule-docs.md

### DIFF
--- a/docs/scenarios/rule-docs/rule-docs.md
+++ b/docs/scenarios/rule-docs/rule-docs.md
@@ -277,7 +277,7 @@ Consider setting the recommended label `app.kubernetes.io/name` on deployment an
 
 The notes section is indicated by the heading `## NOTES`.
 Any text following the heading is interpreted by PSRule and included in pipeline output.
-Notes are excluded when formating output as YAML and JSON.
+Notes are excluded when formatting output as YAML and JSON.
 
 To view any included notes use the `Get-PSRuleHelp` cmdlet with the `-Full` switch.
 
@@ -305,7 +305,7 @@ The Kubernetes recommended labels include:
 
 The links section is indicated by the heading `## LINKS`.
 Any markdown links following the heading are interpreted by PSRule and included in pipeline output.
-Links are excluded when formating output as YAML and JSON.
+Links are excluded when formatting output as YAML and JSON.
 
 To view any included links use the `Get-PSRuleHelp` cmdlet with the `-Full` switch.
 


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->
`formating` to `formatting` at lines 280 and 308.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [ ] Link to a filed issue
  - [ ] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
