### PR TITLE
Added JSON support for reading rules and selectors from pipeline

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+Whats's changed since v1.9.0:
+
+- General improvements:
+  - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)
+
 ## v1.9.0
 
 What's changed since v1.8.0:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
@@ -188,7 +188,8 @@ One or more rules can be defined in a single JSON array separating each rule in 
 
 Within the `Rule` resource, the `condition` property specifies conditions to pass or fail the rule.
 
-Use the `.jsonc` extension to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
+Rules can also be defined within `.json` files.
+We recommend using `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
 
 Syntax:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
@@ -83,7 +83,7 @@ spec:
   condition: { }
 ```
 
-```json
+```jsonc
 [
   {
     // Synopsis: An example YAML rule with pre-conditions.
@@ -192,7 +192,7 @@ Use the `.jsonc` extension to view [JSON with Comments](https://code.visualstudi
 
 Syntax:
 
-```json
+```jsonc
 [
   {
     // Synopsis: {{ Synopsis }}
@@ -213,7 +213,7 @@ Syntax:
 
 Example:
 
-```json
+```jsonc
 [
   {
     // Synopsis: Use a Standard load-balancer with AKS clusters.

--- a/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
@@ -45,10 +45,10 @@ Pre-conditions come in three forms:
   To use a script block pre-condition, specify the `-If` script parameter on the `Rule` block.
 - Type - A type string that is compared against the bound object type.
   When the type matches the rule will be executed.
-  To use a type pre-conditions, specify the `-Type` script parameter or `type` YAML property.
-- Selector - A YAML-based expression that is evaluated against the object.
+  To use a type pre-conditions, specify the `-Type` script parameter or `type` YAML/JSON property.
+- Selector - A YAML/JSON based expression that is evaluated against the object.
   When the expression matches the rule will be executed.
-  To use a selector pre-conditions, specify the `-With` script parameter or `with` YAML property.
+  To use a selector pre-conditions, specify the `-With` script parameter or `with` YAML/JSON property.
 
 Different forms of pre-conditions can be combined.
 When combining pre-conditions, different forms must be all true (logical AND).
@@ -81,6 +81,30 @@ spec:
   - 'Selector.1'
   - 'Selector.2'
   condition: { }
+```
+
+```json
+[
+  {
+    // Synopsis: An example YAML rule with pre-conditions.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "YamlRule"
+    },
+    "spec": {
+      "type": [
+        "CustomType1",
+        "CustomType2"
+      ],
+      "with": [
+        "Selector.1",
+        "Selector.2"
+      ],
+      "condition": {}
+    }
+  }
+]
 ```
 
 Pre-conditions are evaluated in the following order: Selector, Type, then Script.
@@ -154,6 +178,66 @@ spec:
   condition:
     field: 'Properties.networkProfile.loadBalancerSku'
     equals: 'standard'
+```
+
+### Defining JSON rules
+
+To define a JSON rule use the `Rule` resource in a JSON file.
+Each rule must be defined within a `.Rule.json` file following a standard schema.
+One or more rules can be defined in a single JSON array separating each rule in a JSON object.
+
+Within the `Rule` resource, the `condition` property specifies conditions to pass or fail the rule.
+
+JSON rules can also be saved with the `.Rule.jsonc` extension, for example `CustomRules.Rule.jsonc`.
+Use `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
+
+Syntax:
+
+```json
+[
+  {
+    // Synopsis: {{ Synopsis }}
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "{{ Name }}",
+      "tags": {}
+    },
+    "spec": {
+      "type": [],
+      "with": [],
+      "condition": {}
+    }
+  }
+]
+```
+
+Example:
+
+```json
+[
+  {
+    // Synopsis: Use a Standard load-balancer with AKS clusters.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "Azure.AKS.StandardLB",
+      "tags": {
+        "release": "GA",
+        "ruleSet": "2020_06"
+      }
+    },
+    "spec": {
+      "type": [
+        "Microsoft.ContainerService/managedClusters"
+      ],
+      "condition": {
+        "field": "Properties.networkProfile.loadBalancerSku",
+        "equals": "standard"
+      }
+    }
+  }
+]
 ```
 
 ## NOTE

--- a/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Rules.md
@@ -183,13 +183,12 @@ spec:
 ### Defining JSON rules
 
 To define a JSON rule use the `Rule` resource in a JSON file.
-Each rule must be defined within a `.Rule.json` file following a standard schema.
+Each rule must be defined within a `.Rule.jsonc` file following a standard schema.
 One or more rules can be defined in a single JSON array separating each rule in a JSON object.
 
 Within the `Rule` resource, the `condition` property specifies conditions to pass or fail the rule.
 
-JSON rules can also be saved with the `.Rule.jsonc` extension, for example `CustomRules.Rule.jsonc`.
-Use `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
+Use the `.jsonc` extension to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
 
 Syntax:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -92,7 +92,7 @@ spec:
   if: { }
 ```
 
-```json
+```jsonc
 [
   {
     // Synopsis: {{ Synopsis }}
@@ -157,8 +157,8 @@ spec:
 
 ### Example Selectors.Rule.json
 
-```json
-// Example Selectors.Rule.json
+```jsonc
+// Example Selectors.Rule.jsonc
 [
   {
     // Synopsis: Require the CustomValue field.

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -77,7 +77,8 @@ Selectors can be defined with either YAML or JSON format, and can be included wi
 In either case, define a selector within a file ending with the `.Rule.yaml` or `.Rule.jsonc` extension.
 A selector can be defined side-by-side with other resources such as baselines or module configurations.
 
-Use `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
+Selectors can also be defined within `.json` files.
+We recommend using `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
 
 Use the following template to define a selector:
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -155,7 +155,7 @@ spec:
     - 'Value2'
 ```
 
-### Example Selectors.Rule.json
+### Example Selectors.Rule.jsonc
 
 ```jsonc
 // Example Selectors.Rule.jsonc

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -11,7 +11,7 @@ Describes PSRule Selectors including how to use and author them.
 PSRule executes rules to validate an object from input.
 When evaluating an object from input, PSRule can use selectors to perform complex matches of an object.
 
-- A selector is a YAML-based expression that evaluates an object.
+- A selector is a YAML/JSON based expression that evaluates an object.
 - Each selector is comprised of nested conditions, operators, and comparison properties.
 - Selectors must use one or more available conditions with a comparison property to evaluate the object.
 - Optionally a condition can be nested in an operator.
@@ -73,9 +73,12 @@ If one or more selector pre-conditions are used, they are evaluated before type 
 
 ### Defining selectors
 
-Selectors are defined in YAML and can be included within a module or standalone `.Rule.yaml` file.
-In either case, define a selector within a file ending with the `.Rule.yaml` extension.
+Selectors can be defined with either YAML or JSON format, and can be included with a module or standalone `.Rule.yaml` or `.Rule.json` file.
+In either case, define a selector within a file ending with the `.Rule.yaml` or `.Rule.json` extension.
 A selector can be defined side-by-side with other resources such as baselines or module configurations.
+
+JSON selectors can also be saved with the `.Rule.jsonc` extension, for example `Selectors.Rule.jsonc`.
+Use `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
 
 Use the following template to define a selector:
 
@@ -88,6 +91,22 @@ metadata:
   name: '{{ Name }}'
 spec:
   if: { }
+```
+
+```json
+[
+  {
+    // Synopsis: {{ Synopsis }}
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "{{ Name }}"
+    },
+    "spec": {
+      "if": {}
+    }
+  }
+]
 ```
 
 Within the `if` object, one or more conditions or logical operators can be used.
@@ -135,6 +154,67 @@ spec:
     in:
     - 'Value1'
     - 'Value2'
+```
+
+### Example Selectors.Rule.json
+
+```json
+// Example Selectors.Rule.json
+[
+  {
+    // Synopsis: Require the CustomValue field.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "RequireCustomValue"
+    },
+    "spec": {
+      "if": {
+        "field": "CustomValue",
+        "exists": true
+      }
+    }
+  },
+  {
+    // Synopsis: Require a Name or AlternativeName.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "RequireName"
+    },
+    "spec": {
+      "if": {
+        "anyOf": [
+          {
+            "field": "AlternateName",
+            "exists": true
+          },
+          {
+            "field": "Name",
+            "exists": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    // Synopsis: Require a specific CustomValue
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "RequireSpecificCustomValue"
+    },
+    "spec": {
+      "if": {
+        "field": "CustomValue",
+        "in": [
+          "Value1",
+          "Value2"
+        ]
+      }
+    }
+  }
+]
 ```
 
 ## NOTE

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -73,11 +73,10 @@ If one or more selector pre-conditions are used, they are evaluated before type 
 
 ### Defining selectors
 
-Selectors can be defined with either YAML or JSON format, and can be included with a module or standalone `.Rule.yaml` or `.Rule.json` file.
-In either case, define a selector within a file ending with the `.Rule.yaml` or `.Rule.json` extension.
+Selectors can be defined with either YAML or JSON format, and can be included with a module or standalone `.Rule.yaml` or `.Rule.jsonc` file.
+In either case, define a selector within a file ending with the `.Rule.yaml` or `.Rule.jsonc` extension.
 A selector can be defined side-by-side with other resources such as baselines or module configurations.
 
-JSON selectors can also be saved with the `.Rule.jsonc` extension, for example `Selectors.Rule.jsonc`.
 Use `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
 
 Use the following template to define a selector:

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -94,14 +94,11 @@ namespace PSRule.Commands
 
             CheckDependsOn();
             var ps = GetCondition(context, errorPreference);
-            var helpInfo = PSRule.Host.HostHelper.GetHelpInfo(context, Name) ?? new RuleHelpInfo(
+            var helpInfo = PSRule.Host.HostHelper.GetHelpInfo(context, Name, metadata.Synopsis) ?? new RuleHelpInfo(
                 name: Name,
                 displayName: Name,
                 moduleName: source.ModuleName
             );
-
-            if (helpInfo.Synopsis == null)
-                helpInfo.Synopsis = metadata.Synopsis;
 
 #pragma warning disable CA2000 // Dispose objects before losing scope, needs to be passed to pipeline
             var block = new RuleBlock(

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -360,8 +360,7 @@ namespace PSRule
         private const string FIELD_KIND = "kind";
         private const string FIELD_METADATA = "metadata";
         private const string FIELD_SPEC = "spec";
-
-        private const string SYNOPSIS = "Synopsis: ";
+        private const string FIELD_SYNOPSIS = "Synopsis: ";
 
         public override bool CanRead => true;
 
@@ -462,11 +461,11 @@ namespace PSRule
                 {
                     var commentLine = reader.Value.ToString().TrimStart();
 
-                    if (commentLine.Length > SYNOPSIS.Length && commentLine.StartsWith(SYNOPSIS))
+                    if (commentLine.Length > FIELD_SYNOPSIS.Length && commentLine.StartsWith(FIELD_SYNOPSIS))
                     {
                         comment = new CommentMetadata
                         {
-                            Synopsis = commentLine.Substring(SYNOPSIS.Length)
+                            Synopsis = commentLine.Substring(FIELD_SYNOPSIS.Length)
                         };
                     }
                 }

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -460,7 +460,7 @@ namespace PSRule
                 {
                     var commentLine = reader.Value.ToString().TrimStart();
 
-                    if (commentLine.StartsWith("Synopsis: "))
+                    if (commentLine.Length > 10 && commentLine.StartsWith("Synopsis: "))
                     {
                         comment = new CommentMetadata
                         {

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -13,6 +13,7 @@ using PSRule.Configuration;
 using PSRule.Data;
 using PSRule.Definitions;
 using PSRule.Definitions.Baselines;
+using PSRule.Definitions.Expressions;
 using PSRule.Pipeline;
 using PSRule.Resources;
 using PSRule.Runtime;
@@ -389,7 +390,7 @@ namespace PSRule
 
         private IResource MapResource(JsonReader reader, JsonSerializer serializer)
         {
-            if (reader.TokenType != JsonToken.StartObject)
+            if (reader.TokenType != JsonToken.StartObject || !reader.Read())
             {
                 throw new PipelineSerializationException(PSRuleResources.ReadJsonFailed);
             }
@@ -400,70 +401,75 @@ namespace PSRule
             ResourceMetadata metadata = null;
             CommentMetadata comment = null;
 
-            if (reader.Read())
+            while (reader.TokenType != JsonToken.EndObject)
             {
-                while (reader.TokenType != JsonToken.EndObject)
+                if (reader.TokenType == JsonToken.PropertyName)
                 {
-                    if (reader.TokenType == JsonToken.PropertyName)
+                    var propertyName = reader.Value.ToString();
+
+                    // Read apiVersion
+                    if (TryApiVersion(reader: reader, propertyName: propertyName, apiVersion: out string apiVersionValue))
                     {
-                        var propertyName = reader.Value.ToString();
-
-                        // Read apiVersion
-                        if (TryApiVersion(reader: reader, propertyName: propertyName, apiVersion: out string apiVersionValue))
-                        {
-                            apiVersion = apiVersionValue;
-                        }
-
-                        // Read kind
-                        else if (TryKind(reader: reader, propertyName: propertyName, kind: out string kindValue))
-                        {
-                            kind = kindValue;
-                        }
-
-                        // Read metadata
-                        else if (TryMetadata(
-                            reader: reader,
-                            serializer: serializer,
-                            propertyName: propertyName,
-                            metadata: out ResourceMetadata metadataValue))
-                        {
-                            metadata = metadataValue;
-                        }
-
-                        // Try Spec
-                        else if (kind != null && TrySpec(
-                            reader: reader,
-                            serializer: serializer,
-                            propertyName: propertyName,
-                            apiVersion: apiVersion,
-                            kind: kind,
-                            metadata: metadata,
-                            comment: comment,
-                            spec: out IResource specValue))
-                        {
-                            result = specValue;
-                        }
-
-                        else
-                        {
-                            reader.Skip();
-                        }
-
+                        apiVersion = apiVersionValue;
                     }
-                    else if (reader.TokenType == JsonToken.Comment)
-                    {
-                        var commentLine = reader.Value.ToString().TrimStart();
 
-                        if (commentLine.StartsWith("Synopsis: "))
+                    // Read kind
+                    else if (TryKind(reader: reader, propertyName: propertyName, kind: out string kindValue))
+                    {
+                        kind = kindValue;
+                    }
+
+                    // Read metadata
+                    else if (TryMetadata(
+                        reader: reader,
+                        serializer: serializer,
+                        propertyName: propertyName,
+                        metadata: out ResourceMetadata metadataValue))
+                    {
+                        metadata = metadataValue;
+                    }
+
+                    // Try Spec
+                    else if (kind != null && TrySpec(
+                        reader: reader,
+                        serializer: serializer,
+                        propertyName: propertyName,
+                        apiVersion: apiVersion,
+                        kind: kind,
+                        metadata: metadata,
+                        comment: comment,
+                        spec: out IResource specValue))
+                    {
+                        result = specValue;
+
+                        // Break out of loop if result is populated
+                        // Needed so we don't read more than we have to
+                        if (result != null && reader.TokenType == JsonToken.EndObject)
                         {
-                            comment = new CommentMetadata
-                            {
-                                Synopsis = commentLine.Substring(10)
-                            };
+                            break;
                         }
                     }
-                    reader.Read();
+
+                    else
+                    {
+                        reader.Skip();
+                    }
                 }
+
+                else if (reader.TokenType == JsonToken.Comment)
+                {
+                    var commentLine = reader.Value.ToString().TrimStart();
+
+                    if (commentLine.StartsWith("Synopsis: "))
+                    {
+                        comment = new CommentMetadata
+                        {
+                            Synopsis = commentLine.Substring(10)
+                        };
+                    }
+                }
+
+                reader.Read();
             }
 
             return result;
@@ -501,9 +507,11 @@ namespace PSRule
 
             if (propertyName == FIELD_METADATA)
             {
-                reader.Read();
-                metadata = serializer.Deserialize<ResourceMetadata>(reader);
-                return true;
+                if (reader.Read() && reader.TokenType == JsonToken.StartObject)
+                {
+                    metadata = serializer.Deserialize<ResourceMetadata>(reader);
+                    return true;
+                }
             }
 
             return false;
@@ -526,23 +534,24 @@ namespace PSRule
                 name: kind,
                 descriptor: out ISpecDescriptor descriptor))
             {
-                reader.Read();
-
-                var deserializedSpec = serializer.Deserialize(reader, objectType: descriptor.SpecType);
-
-                spec = descriptor.CreateInstance(
-                    source: RunspaceContext.CurrentThread.Source.File,
-                    metadata: metadata,
-                    comment: comment,
-                    spec: deserializedSpec
-                );
-
-                if (string.IsNullOrEmpty(apiVersion))
+                if (reader.Read() && reader.TokenType == JsonToken.StartObject)
                 {
-                    spec.SetApiVersionIssue();
-                }
+                    var deserializedSpec = serializer.Deserialize(reader, objectType: descriptor.SpecType);
 
-                return true;
+                    spec = descriptor.CreateInstance(
+                        source: RunspaceContext.CurrentThread.Source.File,
+                        metadata: metadata,
+                        comment: comment,
+                        spec: deserializedSpec
+                    );
+
+                    if (string.IsNullOrEmpty(apiVersion))
+                    {
+                        spec.SetApiVersionIssue();
+                    }
+
+                    return true;
+                }
             }
 
             return false;
@@ -579,42 +588,218 @@ namespace PSRule
 
         private static void ReadFieldMap(FieldMap map, JsonReader reader)
         {
-            if (reader.TokenType != JsonToken.StartObject)
+            if (reader.TokenType != JsonToken.StartObject || !reader.Read())
             {
                 throw new PipelineSerializationException(PSRuleResources.ReadJsonFailed);
             }
 
-            if (reader.Read())
-            {
-                string propertyName = null;
+            string propertyName = null;
 
+            while (reader.TokenType != JsonToken.EndObject)
+            {
+                if (reader.TokenType == JsonToken.PropertyName)
+                {
+                    propertyName = reader.Value.ToString();
+                }
+
+                else if (reader.TokenType == JsonToken.StartArray)
+                {
+                    var items = new List<string>();
+
+                    while (reader.TokenType != JsonToken.EndArray)
+                    {
+                        var item = reader.ReadAsString();
+
+                        if (!string.IsNullOrEmpty(item))
+                        {
+                            items.Add(item);
+                        }
+                    }
+
+                    map.Set(propertyName, items.ToArray());
+                }
+
+                reader.Read();
+            }
+        }
+    }
+
+    /// <summary>
+    /// A JSON converter for deserializing Language Expressions
+    /// </summary>
+    internal sealed class LanguageExpressionJsonConverter : JsonConverter
+    {
+        private const string OPERATOR_IF = "if";
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => false;
+
+        private readonly LanguageExpressionFactory _Factory;
+
+        public LanguageExpressionJsonConverter()
+        {
+            _Factory = new LanguageExpressionFactory();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(LanguageExpression).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var expression = MapOperator(OPERATOR_IF, reader);
+            return new LanguageIf(expression);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        private LanguageExpression MapOperator(string type, JsonReader reader)
+        {
+            if (TryExpression(type, out LanguageOperator result))
+            {
+                if (reader.TokenType == JsonToken.StartObject)
+                {
+                    result.Add(MapExpression(reader));
+                    reader.Read();
+                }
+
+                else if (reader.TokenType == JsonToken.StartArray && reader.Read())
+                {
+                    while (reader.TokenType != JsonToken.EndArray)
+                    {
+                        result.Add(MapExpression(reader));
+                        reader.Read();
+                    }
+                    reader.Read();
+                }
+            }
+
+            return result;
+        }
+
+        private LanguageExpression MapCondition(string type, LanguageExpression.PropertyBag properties, JsonReader reader)
+        {
+            if (TryExpression(type, out LanguageCondition result))
+            {
                 while (reader.TokenType != JsonToken.EndObject)
                 {
-                    if (reader.TokenType == JsonToken.PropertyName)
+                    MapProperty(properties, reader, out _);
+                }
+                result.Add(properties);
+            }
+            return result;
+        }
+
+        private LanguageExpression MapExpression(JsonReader reader)
+        {
+            LanguageExpression result = null;
+
+            var properties = new LanguageExpression.PropertyBag();
+
+            MapProperty(properties, reader, out string key);
+
+            if (key != null && TryCondition(key))
+            {
+                result = MapCondition(key, properties, reader);
+            }
+
+            else if (TryOperator(key) &&
+                (reader.TokenType == JsonToken.StartObject ||
+                 reader.TokenType == JsonToken.StartArray))
+            {
+                result = MapOperator(key, reader);
+            }
+
+            return result;
+        }
+
+        private void MapProperty(LanguageExpression.PropertyBag properties, JsonReader reader, out string name)
+        {
+            if (reader.TokenType != JsonToken.StartObject || !reader.Read())
+            {
+                throw new PipelineSerializationException(PSRuleResources.ReadJsonFailed);
+            }
+
+            name = null;
+
+            while (reader.TokenType != JsonToken.EndObject)
+            {
+                var key = reader.Value.ToString();
+
+                if (TryCondition(key) || TryOperator(key))
+                {
+                    name = key;
+                }
+
+                if (reader.Read())
+                {
+                    if (reader.TokenType == JsonToken.StartObject)
                     {
-                        propertyName = reader.Value.ToString();
+                        break;
                     }
 
                     else if (reader.TokenType == JsonToken.StartArray)
                     {
-                        var items = new List<string>();
+                        if (!TryCondition(key))
+                        {
+                            break;
+                        }
+
+                        var objects = new List<string>();
 
                         while (reader.TokenType != JsonToken.EndArray)
                         {
-                            var item = reader.ReadAsString();
+                            var value = reader.ReadAsString();
 
-                            if (!string.IsNullOrEmpty(item))
+                            if (!string.IsNullOrEmpty(value))
                             {
-                                items.Add(item);
+                                objects.Add(value);
                             }
                         }
 
-                        map.Set(propertyName, items.ToArray());
+                        properties.Add(key, objects.ToArray());
                     }
 
-                    reader.Read();
+                    else
+                    {
+                        properties.Add(key, reader.Value);
+                    }
                 }
+
+                reader.Read();
             }
+        }
+
+        private bool TryOperator(string key)
+        {
+            return _Factory.IsOperator(key);
+        }
+
+        private bool TryCondition(string key)
+        {
+            return _Factory.IsCondition(key);
+        }
+
+        private bool TryExpression<T>(string type, out T expression) where T : LanguageExpression
+        {
+            expression = null;
+
+            if (_Factory.TryDescriptor(type, out ILanguageExpresssionDescriptor descriptor))
+            {
+                expression = (T)descriptor.CreateInstance(
+                    source: RunspaceContext.CurrentThread.Source.File,
+                    properties: null
+                );
+
+                return expression != null;
+            }
+
+            return false;
         }
     }
 }

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -361,6 +361,8 @@ namespace PSRule
         private const string FIELD_METADATA = "metadata";
         private const string FIELD_SPEC = "spec";
 
+        private const string SYNOPSIS = "Synopsis: ";
+
         public override bool CanRead => true;
 
         public override bool CanWrite => false;
@@ -460,11 +462,11 @@ namespace PSRule
                 {
                     var commentLine = reader.Value.ToString().TrimStart();
 
-                    if (commentLine.Length > 10 && commentLine.StartsWith("Synopsis: "))
+                    if (commentLine.Length > SYNOPSIS.Length && commentLine.StartsWith(SYNOPSIS))
                     {
                         comment = new CommentMetadata
                         {
-                            Synopsis = commentLine.Substring(10)
+                            Synopsis = commentLine.Substring(SYNOPSIS.Length)
                         };
                     }
                 }

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -70,9 +70,9 @@ namespace PSRule.Host
         }
 
         /// <summary>
-        /// Read YAML objects and return baselines.
+        /// Read YAML/JSON objects and return baselines.
         /// </summary>
-        internal static IEnumerable<Baseline> GetBaselineYaml(Source[] source, RunspaceContext context)
+        internal static IEnumerable<Baseline> GetBaseline(Source[] source, RunspaceContext context)
         {
             var results = new List<ILanguageBlock>();
 
@@ -287,6 +287,7 @@ namespace PSRule.Host
 
             deserializer.Converters.Add(new ResourceObjectJsonConverter());
             deserializer.Converters.Add(new FieldMapJsonConverter());
+            deserializer.Converters.Add(new LanguageExpressionJsonConverter());
 
             try
             {
@@ -321,7 +322,11 @@ namespace PSRule.Host
                                         result.Add(value.Block);
                                     }
 
-                                    reader.Read();
+                                    // Consume all end objects at the end of each resource
+                                    while (reader.TokenType == JsonToken.EndObject)
+                                    {
+                                        reader.Read();
+                                    }
                                 }
                             }
                         }

--- a/src/PSRule/Pipeline/ExportBaselinePipelineBuilder.cs
+++ b/src/PSRule/Pipeline/ExportBaselinePipelineBuilder.cs
@@ -42,8 +42,13 @@ namespace PSRule.Pipeline
         public override IPipeline Build(IPipelineWriter writer = null)
         {
             var filter = new BaselineFilter(_Name);
+
             return new GetBaselinePipeline(
-                pipeline: PrepareContext(null, null, null),
+                pipeline: PrepareContext(
+                    bindTargetName: null,
+                    bindTargetType: null,
+                    bindField: null
+                ),
                 source: Source,
                 reader: PrepareReader(),
                 writer: writer ?? PrepareWriter(),

--- a/src/PSRule/Pipeline/GetBaselinePipeline.cs
+++ b/src/PSRule/Pipeline/GetBaselinePipeline.cs
@@ -26,7 +26,7 @@ namespace PSRule.Pipeline
 
         public override void End()
         {
-            Writer.WriteObject(HostHelper.GetBaselineYaml(Source, Context).Where(Match), true);
+            Writer.WriteObject(HostHelper.GetBaseline(Source, Context).Where(Match), true);
             Writer.End();
         }
 

--- a/src/PSRule/Pipeline/GetRulePipeline.cs
+++ b/src/PSRule/Pipeline/GetRulePipeline.cs
@@ -1,69 +1,21 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using PSRule.Configuration;
 using PSRule.Host;
 
 namespace PSRule.Pipeline
 {
-    public interface IGetPipelineBuilder : IPipelineBuilder
-    {
-        void IncludeDependencies();
-    }
-
-    /// <summary>
-    /// A helper to construct a get pipeline.
-    /// </summary>
-    internal sealed class GetRulePipelineBuilder : PipelineBuilderBase, IGetPipelineBuilder
-    {
-        private bool _IncludeDependencies;
-
-        internal GetRulePipelineBuilder(Source[] source, HostContext hostContext)
-            : base(source, hostContext) { }
-
-        public override IPipelineBuilder Configure(PSRuleOption option)
-        {
-            if (option == null)
-                return this;
-
-            Option.Execution.LanguageMode = option.Execution.LanguageMode ?? ExecutionOption.Default.LanguageMode;
-            Option.Output.Culture = GetCulture(option.Output.Culture);
-            Option.Output.Format = SuppressFormat(option.Output.Format);
-            Option.Requires = new RequiresOption(option.Requires);
-            Option.Output.JsonIndent = NormalizeJsonIndentRange(option.Output.JsonIndent);
-
-            if (option.Rule != null)
-                Option.Rule = new RuleOption(option.Rule);
-
-            return this;
-        }
-        public void IncludeDependencies()
-        {
-            _IncludeDependencies = true;
-        }
-
-        public override IPipeline Build(IPipelineWriter writer = null)
-        {
-            if (!RequireModules() || !RequireSources())
-                return null;
-
-            return new GetRulePipeline(PrepareContext(null, null, null), Source, PrepareReader(), writer ?? PrepareWriter(), _IncludeDependencies);
-        }
-
-        private static OutputFormat SuppressFormat(OutputFormat? format)
-        {
-            return !format.HasValue ||
-                !(format == OutputFormat.Wide ||
-                format == OutputFormat.Json ||
-                format == OutputFormat.Yaml) ? OutputFormat.None : format.Value;
-        }
-    }
-
     internal sealed class GetRulePipeline : RulePipeline, IPipeline
     {
         private readonly bool _IncludeDependencies;
 
-        internal GetRulePipeline(PipelineContext pipeline, Source[] source, PipelineReader reader, IPipelineWriter writer, bool includeDependencies)
+        internal GetRulePipeline(
+            PipelineContext pipeline,
+            Source[] source,
+            PipelineReader reader,
+            IPipelineWriter writer,
+            bool includeDependencies
+        )
             : base(pipeline, source, reader, writer)
         {
             _IncludeDependencies = includeDependencies;

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -107,7 +107,7 @@ namespace PSRule
             var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, new OptionContext(), null), null);
             context.Init(GetSource());
             context.Begin();
-            var baseline = HostHelper.GetBaselineYaml(source, context).ToArray();
+            var baseline = HostHelper.GetBaseline(source, context).ToArray();
             return baseline;
         }
 

--- a/tests/PSRule.Tests/FromFile.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFile.Rule.jsonc
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+// YAML-based rules for unit testing
+//
+
+[
+    {
+        // Synopsis: A YAML rule for testing.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "BasicRule",
+            "tags": {
+                "feature": "tag"
+            }
+        },
+        "spec": {
+            "condition": {
+                "allOf": [
+                    {
+                        "field": "Name",
+                        "equals": "TargetObject1"
+                    },
+                    {
+                        "field": "Value",
+                        "in": [
+                            "Value1",
+                            "Value2"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: A YAML rule for testing.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "RuleJsonTrue",
+            "tags": {
+                "release": "GA"
+            }
+        },
+        "spec": {
+            "condition": {
+                "field": "Value",
+                "equals": 3
+            }
+        }
+    },
+    {
+        // Synopsis: A YAML rule for testing.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "RuleJsonFalse",
+            "tags": {
+                "release": "GA"
+            }
+        },
+        "spec": {
+            "condition": {
+                "field": "Value",
+                "greater": 3
+            }
+        }
+    },
+    {
+        // Synopsis: A YAML rule for testing.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "RuleWithCustomType",
+            "tags": {
+                "release": "GA"
+            }
+        },
+        "spec": {
+            "type": [
+                "CustomType"
+            ],
+            "condition": {
+                "field": "Value",
+                "greater": 3
+            }
+        }
+    },
+    {
+        // Synopsis: A YAML rule for testing.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "RuleWithSelector",
+            "tags": {
+                "release": "GA"
+            }
+        },
+        "spec": {
+            "with": [
+                "Test.Rule.Selector.1"
+            ],
+            "condition": {
+                "field": "notValue",
+                "greaterOrEquals": 3
+            }
+        }
+    },
+    {
+        // Synopsis: A selector for YAML rule tests
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Test.Rule.Selector.1"
+        },
+        "spec": {
+            "if": {
+                "field": "notValue",
+                "exists": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test reason from rule.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonReasonTest",
+            "tags": {
+                "test": "Reason"
+            }
+        },
+        "spec": {
+            "condition": {
+                "field": "Name",
+                "equals": "TestValue"
+            }
+        }
+    }
+]

--- a/tests/PSRule.Tests/FromFile.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFile.Rule.jsonc
@@ -14,9 +14,6 @@
             "name": "BasicRule",
             "tags": {
                 "feature": "tag"
-            },
-            "annotations": {
-                "obsolete": true
             }
         },
         "spec": {

--- a/tests/PSRule.Tests/FromFile.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFile.Rule.jsonc
@@ -14,6 +14,9 @@
             "name": "BasicRule",
             "tags": {
                 "feature": "tag"
+            },
+            "annotations": {
+                "obsolete": true
             }
         },
         "spec": {

--- a/tests/PSRule.Tests/FromFileWithSelectors.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileWithSelectors.Rule.ps1
@@ -5,7 +5,10 @@ Rule 'WithSelectorTrue' -With 'BasicSelector' {
     $True
 }
 
-Rule 'WithSelectorFalse' -With 'YamlCustomValueIn' {
+Rule 'WithSelectorFalse1' -With 'YamlCustomValueIn' {
     $False
 }
 
+Rule 'WithSelectorFalse2' -With 'JsonCustomValueIn' {
+    $False
+}

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -34,6 +34,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
     BeforeAll {
         $ruleFilePath = Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1';
         $yamlFilePath = Join-Path -Path $here -ChildPath 'FromFile.Rule.yaml';
+        $jsonFilePath = Join-Path -Path $here -ChildPath 'FromFile.Rule.jsonc';
         $emptyOptionsFilePath = Join-Path -Path $here -ChildPath 'PSRule.Tests4.yml';
     }
 
@@ -158,8 +159,14 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
         }
 
         It 'Processes rule tags' {
-            # Ensure that rules can be selected by tag and that tags are mapped back to the rule results
+            # Ensure that rules can be selected by tag and that tags are mapped back to the rule results using Yaml file path
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath, $yamlFilePath -Tag @{ feature = 'tag' };
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 6;
+            $result.Tag.feature | Should -BeIn 'tag';
+
+            # Ensure that rules can be selected by tag and that tags are mapped back to the rule results using Json file path
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath, $jsonFilePath -Tag @{ feature = 'tag' };
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 6;
             $result.Tag.feature | Should -BeIn 'tag';
@@ -293,6 +300,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 }
             )
 
+            # With Yaml path
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath, $yamlFilePath -Tag @{ test = 'Reason' };
             $result | Should -Not -BeNullOrEmpty;
             $result.Count | Should -Be 4;
@@ -300,6 +308,16 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result[1].Reason | Should -BeExactly 'Field Name: Is set to ''TestObject1''.';
             $result[2].Reason | Should -BeExactly 'The field ''Name'' is set to ''TestObject2''.';
             $result[3].Reason | Should -BeExactly 'Field Name: Is set to ''TestObject2''.';
+
+            # With Json path
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath, $jsonFilePath -Tag @{ test = 'Reason' };
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 4;
+            $result[0].Reason | Should -BeExactly 'The field ''Name'' is set to ''TestObject1''.';
+            $result[1].Reason | Should -BeExactly 'Field Name: Is set to ''TestObject1''.';
+            $result[2].Reason | Should -BeExactly 'The field ''Name'' is set to ''TestObject2''.';
+            $result[3].Reason | Should -BeExactly 'Field Name: Is set to ''TestObject2''.';
+
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Selectors.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Selectors.Tests.ps1
@@ -31,16 +31,12 @@ BeforeAll {
 Describe 'PSRule -- Selectors' -Tag 'Selectors' {
     BeforeAll {
         $rulePath = Join-Path -Path $here -ChildPath 'FromFileWithSelectors.Rule.ps1';
-        $selectorPath = Join-Path -Path $here -ChildPath 'Selectors.Rule.yaml';
+        $yamlSelectorPath = Join-Path -Path $here -ChildPath 'Selectors.Rule.yaml';
+        $jsonSelectorPath = Join-Path -Path $here -ChildPath 'Selectors.Rule.jsonc';
     }
 
     Context 'With selector' {
         BeforeAll {
-            $invokeParams = @{
-                Path = $rulePath, $selectorPath
-            }
-        }
-        It 'From file' {
             $testObjects = @(
                 [PSCustomObject]@{
                     Name = 'TargetObject1'
@@ -52,29 +48,37 @@ Describe 'PSRule -- Selectors' -Tag 'Selectors' {
                     CustomValue = 'Value2'
                 }
             )
+        }
 
-            $result = @($testObjects | Invoke-PSRule @invokeParams -Name 'WithSelectorTrue', 'WithSelectorFalse');
+        It 'From Yaml file' {
+            $invokeParams = @{
+                Path = $rulePath, $yamlSelectorPath
+            }
+
+            $result = @($testObjects | Invoke-PSRule @invokeParams -Name 'WithSelectorTrue', 'WithSelectorFalse1');
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
             $result[0].Outcome | Should -Be 'Pass';
             $result[0].RuleName | Should -Be 'WithSelectorTrue';
             $result[1].Outcome | Should -Be 'Fail';
-            $result[1].RuleName | Should -Be 'WithSelectorFalse';
+            $result[1].RuleName | Should -Be 'WithSelectorFalse1';
+        }
+
+        It 'From Json file' {
+            $invokeParams = @{
+                Path = $rulePath, $jsonSelectorPath
+            }
+
+            $result = @($testObjects | Invoke-PSRule @invokeParams -Name 'WithSelectorTrue', 'WithSelectorFalse2');
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Length | Should -Be 2;
+            $result[0].Outcome | Should -Be 'Pass';
+            $result[0].RuleName | Should -Be 'WithSelectorTrue';
+            $result[1].Outcome | Should -Be 'Fail';
+            $result[1].RuleName | Should -Be 'WithSelectorFalse2';
         }
 
         It 'From module' {
-            $testObjects = @(
-                [PSCustomObject]@{
-                    Name = 'TargetObject1'
-                    Value = 'value1'
-                }
-                [PSCustomObject]@{
-                    Name = 'TargetObject2'
-                    Value = 'value1'
-                    CustomValue = 'Value2'
-                }
-            )
-
             $testModuleSourcePath = Join-Path $here -ChildPath 'TestModule2';
             $Null = Import-Module $testModuleSourcePath;
             $testModuleSourcePath = Join-Path $here -ChildPath 'TestModule3';

--- a/tests/PSRule.Tests/Selectors.Rule.jsonc
+++ b/tests/PSRule.Tests/Selectors.Rule.jsonc
@@ -1,0 +1,870 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+// Selectors for unit testing
+[
+    {
+        // Synopsis: A selector to match basic objects
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "BasicSelector"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "Name",
+                        "equals": "TargetObject1"
+                    },
+                    {
+                        "field": "Value",
+                        "equals": "value1"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: A selector to match objects using a specific JSON schema
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "BasicSelector"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "Name",
+                        "equals": "TargetObject1"
+                    },
+                    {
+                        "field": "Value",
+                        "equals": "value1"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: A selector to match object with a field
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "HasCustomValueField"
+        },
+        "spec": {
+            "if": {
+                "field": "CustomValue",
+                "exists": "true'"
+            }
+        }
+    },
+    {
+        // Synopsis: Test AnyOf
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonAnyOf"
+        },
+        "spec": {
+            "if": {
+                "anyOf": [
+                    {
+                        "field": "AlternateName",
+                        "exists": true
+                    },
+                    {
+                        "field": "Name",
+                        "exists": true
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test AllOf
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonAllOf"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "AlternateName",
+                        "exists": true
+                    },
+                    {
+                        "field": "Name",
+                        "exists": true
+                    }
+                ]
+            }
+        }
+    },
+    {
+        //Synopsis: Test Not
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNot"
+        },
+        "spec": {
+            "if": {
+                "not": {
+                    "anyOf": [
+                        {
+                            "field": "AlternateName",
+                            "exists": true
+                        },
+                        {
+                            "field": "Name",
+                            "exists": true
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    {
+        // Synopsis: Test custom value is in
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonCustomValueIn"
+        },
+        "spec": {
+            "if": {
+                "field": "CustomValue",
+                "in": [
+                    "Value1",
+                    "Value2"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test exists true
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonExistsTrue"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "exists": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test exists false
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonExistsFalse"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "exists": false
+            }
+        }
+    },
+    {
+        // Synopsis: Test equals
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonEquals"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "ValueString",
+                        "equals": "abc"
+                    },
+                    {
+                        "field": "ValueInt",
+                        "equals": 123
+                    },
+                    {
+                        "field": "ValueBool",
+                        "equals": true
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test notEquals
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNotEquals"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "field": "ValueString",
+                        "notEquals": "abc"
+                    },
+                    {
+                        "field": "ValueInt",
+                        "notEquals": 123
+                    },
+                    {
+                        "field": "ValueBool",
+                        "notEquals": true
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test hasValue true
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonHasValueTrue"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "hasValue": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test hasValue false
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonHasValueFalse"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "hasValue": false
+            }
+        }
+    },
+    {
+        // Synopsis: Test match
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonMatch"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "match": "^(abc|efg)$"
+            }
+        }
+    },
+    {
+        // Synopsis: Test notMatch
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNotMatch"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "notMatch": "^(abc|efg)$"
+            }
+        }
+    },
+    {
+        // Synopsis: Test in
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIn"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "in": [
+                    "Value1",
+                    "Value2"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test notIn
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNotIn"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "notIn": [
+                    "Value1",
+                    "Value2"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test less
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonLess"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "less": 3
+            }
+        }
+    },
+    {
+        //Synopsis: Test lessOrEquals
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonLessOrEquals"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "lessOrEquals": 3
+            }
+        }
+    },
+    {
+        // Synopsis: Test greater
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonGreater"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "greater": 3
+            }
+        }
+    },
+    {
+        // Synopsis: Test greaterOrEquals
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonGreaterOrEquals"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "greaterOrEquals": 3
+            }
+        }
+    },
+    {
+        // Synopsis: Test startsWith
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonStartsWith"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "field": "Value",
+                                "startsWith": "a"
+                            },
+                            {
+                                "field": "Value",
+                                "startsWith": "e"
+                            }
+                        ]
+                    },
+                    {
+                        "field": "Value",
+                        "startsWith": [
+                            "a",
+                            "e"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test endsWith
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonEndsWith"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "field": "Value",
+                                "endsWith": "c"
+                            },
+                            {
+                                "field": "Value",
+                                "endsWith": "g"
+                            }
+                        ]
+                    },
+                    {
+                        "field": "Value",
+                        "endsWith": [
+                            "c",
+                            "g"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test contains
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonContains"
+        },
+        "spec": {
+            "if": {
+                "allOf": [
+                    {
+                        "anyOf": [
+                            {
+                                "field": "Value",
+                                "contains": "ab"
+                            },
+                            {
+                                "field": "Value",
+                                "contains": "bc"
+                            }
+                        ]
+                    },
+                    {
+                        "field": "Value",
+                        "contains": [
+                            "ab",
+                            "bc"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test isString
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIsStringTrue"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "isString": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test isString
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIsStringFalse"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "isString": false
+            }
+        }
+    },
+    {
+        // Synopsis: Test isLower
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIsLowerTrue"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "isLower": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test isLower
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIsLowerFalse"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "isLower": false
+            }
+        }
+    },
+    {
+        // Synopsis: Test isUpper
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIsUpperTrue"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "isUpper": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test isUpper
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonIsUpperFalse"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "isUpper": false
+            }
+        }
+    },
+    {
+        // Synopsis: Test setOf
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonSetOf"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "setOf": [
+                    "cluster-autoscaler",
+                    "kube-apiserver"
+                ],
+                "caseSensitive": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test subset
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonSubset"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "subset": [
+                    "cluster-autoscaler",
+                    "kube-apiserver"
+                ],
+                "caseSensitive": true,
+                "unique": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test count
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonCount"
+        },
+        "spec": {
+            "if": {
+                "field": "Value",
+                "count": 2
+            }
+        }
+    },
+    {
+        // Synopsis: Test with type
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonTypeEquals"
+        },
+        "spec": {
+            "if": {
+                "type": ".",
+                "equals": "CustomType1"
+            }
+        }
+    },
+    {
+        // Synopsis: Test equals with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameEquals"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "equals": "TargetObject1"
+            }
+        }
+    },
+    {
+        // Synopsis: Test notEquals with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameNotEquals"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "notEquals": "TargetObject1"
+            }
+        }
+    },
+    {
+        // Synopsis: Test hasValue with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameHasValue"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "hasValue": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test match with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameMatch"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "match": ".*1$"
+            }
+        }
+    },
+    {
+        // Synopsis: Test notMatch with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameNotMatch"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "notMatch": ".*1$"
+            }
+        }
+    },
+    {
+        // Synopsis: Test in with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameIn"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "in": [
+                    "TargetObject1"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test notIn with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameNotIn"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "notIn": [
+                    "TargetObject1"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test startsWith with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameStartsWith"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "startsWith": [
+                    "1"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test endsWith with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameEndsWith"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "endsWith": [
+                    "1"
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test contains with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameContains"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "contains": [
+                    ".1."
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: Test isString with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameIsString"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "isString": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test less with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameLess"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "less": 8
+            }
+        }
+    },
+    {
+        // Synopsis: Test lessOrEquals with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameLessOrEquals"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "lessOrEquals": 7
+            }
+        }
+    },
+    {
+        // Synopsis: Test greater with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameGreater"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "greater": 8
+            }
+        }
+    },
+    {
+        // Synopsis: Test greaterOrEquals with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameGreaterOrEquals"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "greaterOrEquals": 9
+            }
+        }
+    },
+    {
+        // Synopsis: Test isLower with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameIsLower"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "isLower": true
+            }
+        }
+    },
+    {
+        // Synopsis: Test isUpper with name
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "JsonNameIsUpper"
+        },
+        "spec": {
+            "if": {
+                "name": ".",
+                "isUpper": true
+            }
+        }
+    }
+]


### PR DESCRIPTION
## PR Summary

Fix #857

Added JSON support for reading rules and selectors. 

Also did some refactoring and cleanup with some previous baseline code. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
