### PR TITLE
Add HasSchema expression #860 #859

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Field](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#field)
   - [Greater](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#greater)
   - [GreaterOrEquals](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#greaterorequals)
+  - [HasSchema](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#hasschema)
   - [HasValue](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#hasvalue)
   - [In](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#in)
   - [IsLower](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#islower)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -15,6 +15,10 @@ Whats's changed since v1.9.0:
 
 - General improvements:
   - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)
+  - Added `HasSchema` expression to check the schema of an object. [#860](https://github.com/microsoft/PSRule/issues/860)
+    - See [about_PSRule_Expressions] for details.
+- Bug fixes:
+  - Fixed `$Assert.HasJsonSchema` accepts empty value. [#859](https://github.com/microsoft/PSRule/issues/859)
 
 ## v1.9.0
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -484,7 +484,7 @@ Rule 'HasFieldValue' {
 ### HasJsonSchema
 
 The `HasJsonSchema` assertion method determines if the input object has a `$schema` property defined.
-If the `$schema` property is defined, it must match one of the supplied schemas.
+If the `$schema` property is defined, it must not be empty and match one of the supplied schemas.
 If a trailing `#` is specified it is ignored from the `$schema` property and `uri` parameter below.
 
 The following parameters are accepted:
@@ -501,6 +501,7 @@ Reasons include:
 - _The parameter 'inputObject' is null._
 - _The field '$schema' does not exist._
 - _The field value '$schema' is not a string._
+- _The value of '$schema' is null or empty._
 - _None of the specified schemas match '{0}'._
 
 Examples:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -20,6 +20,7 @@ The following conditions are available:
 - [Exists](#exists)
 - [Greater](#greater)
 - [GreaterOrEquals](#greaterorequals)
+- [HasSchema](#hasschema)
 - [HasValue](#hasvalue)
 - [In](#in)
 - [IsLower](#islower)
@@ -89,7 +90,6 @@ spec:
       exists: true
     - field: 'Description'
       exists: true
-
 ```
 
 ### AnyOf
@@ -455,6 +455,68 @@ spec:
   if:
     field: 'Name'
     greaterOrEquals: 3
+```
+
+### HasSchema
+
+The `hasSchema` condition determines if the operand has a `$schema` property defined.
+If the `$schema` property is defined, it must match one of the specified schemas.
+If a trailing `#` is specified it is ignored.
+
+The following properties are accepted:
+
+- `caseSensitive` - Optionally, a case-sensitive comparison can be performed.
+  By default, case-insensitive comparison is performed.
+- `ignoreScheme` - Optionally, the URI scheme is ignored in the comparison.
+  By default, the scheme is compared.
+  When `true`, the schema will match if either `http://` or `https://` is specified.
+
+Syntax:
+
+```yaml
+hasSchema: <array>
+caseSensitive: <bool>
+ignoreScheme: <bool>
+```
+
+- When `hasSchema: []`, hasSchema will return `true` if any non-empty `$schema` property is defined.
+
+For example:
+
+```yaml
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: 'ExampleHasSchema'
+spec:
+  condition:
+    field: '.'
+    hasSchema:
+    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleHasSchema'
+spec:
+  if:
+    field: '.'
+    hasSchema:
+    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+    ignoreScheme: true
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleHasAnySchema'
+spec:
+  if:
+    field: '.'
+    hasSchema: []
 ```
 
 ### HasValue
@@ -1045,7 +1107,7 @@ spec:
 ### Subset
 
 The `subset` condition can be used to determine if the operand is a set of specified values.
-Additionally the following properties are accepted:
+The following properties are accepted:
 
 - `caseSensitive` - Optionally, a case-sensitive comparison can be performed.
   By default, case-insensitive comparison is performed.

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -580,6 +580,9 @@
                 },
                 {
                     "$ref": "#/definitions/selectorConditionIsUpper"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionHasSchema"
                 }
             ]
         },
@@ -609,7 +612,8 @@
                     "type": "string",
                     "title": "Field",
                     "description": "The path of the field.",
-                    "markdownDescription": "The path of the field. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#field)"
+                    "markdownDescription": "The path of the field. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#field)",
+                    "default": "."
                 }
             },
             "required": [
@@ -1147,6 +1151,48 @@
             "oneOf": [
                 {
                     "$ref": "#/definitions/selectorPropertiesString"
+                }
+            ]
+        },
+        "selectorConditionHasSchema": {
+            "type": "object",
+            "properties": {
+                "hasSchema": {
+                    "type": "array",
+                    "title": "Has schema",
+                    "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
+                    "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
+                    "default": [],
+                    "items": {
+                        "type": "string",
+                        "title": "Has schema",
+                        "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
+                    "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
+                        "minLength": 1
+                    },
+                    "uniqueItems": true
+                },
+                "ignoreScheme": {
+                    "type": "boolean",
+                    "title": "Ignore scheme",
+                    "description": "Determines comparing values is case-sensitive.",
+                    "markdownDescription": "Determines comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
+                    "default": false
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines comparing schemas is case-sensitive.",
+                    "markdownDescription": "Determines comparing schemas is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
+                    "default": false
+                }
+            },
+            "required": [
+                "hasSchema"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
                 }
             ]
         },

--- a/src/PSRule/Definitions/Expressions/ExpressionContext.cs
+++ b/src/PSRule/Definitions/Expressions/ExpressionContext.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using PSRule.Runtime;
 
@@ -33,11 +34,13 @@ namespace PSRule.Definitions.Expressions
 
         public string LanguageScope { get; }
 
+        [DebuggerStepThrough]
         void IBindingContext.CacheNameToken(string expression, NameToken nameToken)
         {
             _NameTokenCache[expression] = nameToken;
         }
 
+        [DebuggerStepThrough]
         bool IBindingContext.GetNameToken(string expression, out NameToken nameToken)
         {
             return _NameTokenCache.TryGetValue(expression, out nameToken);

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources
-{
+namespace PSRule.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,697 +22,580 @@ namespace PSRule.Resources
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class ReasonStrings
-    {
-
+    internal class ReasonStrings {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal ReasonStrings()
-        {
+        internal ReasonStrings() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.ReasonStrings", typeof(ReasonStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not match the expression &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_DoesNotMatch
-        {
-            get
-            {
+        internal static string Assert_DoesNotMatch {
+            get {
                 return ResourceManager.GetString("Assert_DoesNotMatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only lowercase characters..
         /// </summary>
-        internal static string Assert_IsLower
-        {
-            get
-            {
+        internal static string Assert_IsLower {
+            get {
                 return ResourceManager.GetString("Assert_IsLower", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Is null or empty..
         /// </summary>
-        internal static string Assert_IsNullOrEmpty
-        {
-            get
-            {
+        internal static string Assert_IsNullOrEmpty {
+            get {
                 return ResourceManager.GetString("Assert_IsNullOrEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Is set to &apos;{0}&apos;..
         /// </summary>
-        internal static string Assert_IsSetTo
-        {
-            get
-            {
+        internal static string Assert_IsSetTo {
+            get {
                 return ResourceManager.GetString("Assert_IsSetTo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only uppercase characters..
         /// </summary>
-        internal static string Assert_IsUpper
-        {
-            get
-            {
+        internal static string Assert_IsUpper {
+            get {
                 return ResourceManager.GetString("Assert_IsUpper", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; matches the expression &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_Matches
-        {
-            get
-            {
+        internal static string Assert_Matches {
+            get {
                 return ResourceManager.GetString("Assert_Matches", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not {1} {2}..
         /// </summary>
-        internal static string Assert_NotComparedTo
-        {
-            get
-            {
+        internal static string Assert_NotComparedTo {
+            get {
                 return ResourceManager.GetString("Assert_NotComparedTo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain any of {1}..
         /// </summary>
-        internal static string Assert_NotContains
-        {
-            get
-            {
+        internal static string Assert_NotContains {
+            get {
                 return ResourceManager.GetString("Assert_NotContains", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not end with any of {1}..
         /// </summary>
-        internal static string Assert_NotEndsWith
-        {
-            get
-            {
+        internal static string Assert_NotEndsWith {
+            get {
                 return ResourceManager.GetString("Assert_NotEndsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not in {1}..
         /// </summary>
-        internal static string Assert_NotInSet
-        {
-            get
-            {
+        internal static string Assert_NotInSet {
+            get {
                 return ResourceManager.GetString("Assert_NotInSet", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The value &apos;{0}&apos; does not start with any of {1}..
-        /// </summary>
-        internal static string Assert_NotStartsWith
-        {
-            get
-            {
-                return ResourceManager.GetString("Assert_NotStartsWith", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The value &apos;{0}&apos; is not a string..
-        /// </summary>
-        internal static string Assert_NotString
-        {
-            get
-            {
-                return ResourceManager.GetString("Assert_NotString", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field value &apos;{0}&apos; can not be compared with &apos;{1}&apos;..
-        /// </summary>
-        internal static string Compare
-        {
-            get
-            {
-                return ResourceManager.GetString("Compare", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not contain &apos;{1}&apos;..
-        /// </summary>
-        internal static string Contains
-        {
-            get
-            {
-                return ResourceManager.GetString("Contains", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field &apos;{0}&apos; has &apos;{1}&apos; items instead of &apos;{2}&apos;..
-        /// </summary>
-        internal static string Count
-        {
-            get
-            {
-                return ResourceManager.GetString("Count", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not end with &apos;{1}&apos;..
-        /// </summary>
-        internal static string EndsWith
-        {
-            get
-            {
-                return ResourceManager.GetString("EndsWith", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to None of the field(s) existed: {0}.
-        /// </summary>
-        internal static string Exists
-        {
-            get
-            {
-                return ResourceManager.GetString("Exists", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field(s) existed: {0}.
-        /// </summary>
-        internal static string ExistsNot
-        {
-            get
-            {
-                return ResourceManager.GetString("ExistsNot", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The header was not set..
-        /// </summary>
-        internal static string FileHeader
-        {
-            get
-            {
-                return ResourceManager.GetString("FileHeader", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The file &apos;{0}&apos; does not exist..
-        /// </summary>
-        internal static string FilePath
-        {
-            get
-            {
-                return ResourceManager.GetString("FilePath", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &gt; &apos;{1}&apos;..
-        /// </summary>
-        internal static string Greater
-        {
-            get
-            {
-                return ResourceManager.GetString("Greater", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &gt;= &apos;{1}&apos;..
-        /// </summary>
-        internal static string GreaterOrEqual
-        {
-            get
-            {
-                return ResourceManager.GetString("GreaterOrEqual", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field &apos;{0}&apos; is set to &apos;{1}&apos;..
-        /// </summary>
-        internal static string HasExpectedFieldValue
-        {
-            get
-            {
-                return ResourceManager.GetString("HasExpectedFieldValue", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The field &apos;{0}&apos; exists..
-        /// </summary>
-        internal static string HasField
-        {
-            get
-            {
-                return ResourceManager.GetString("HasField", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the specified schemas match &apos;{0}&apos;..
         /// </summary>
-        internal static string HasJsonSchema
-        {
-            get
-            {
+        internal static string Assert_NotSpecifiedSchema {
+            get {
+                return ResourceManager.GetString("Assert_NotSpecifiedSchema", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; does not start with any of {1}..
+        /// </summary>
+        internal static string Assert_NotStartsWith {
+            get {
+                return ResourceManager.GetString("Assert_NotStartsWith", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; is not a string..
+        /// </summary>
+        internal static string Assert_NotString {
+            get {
+                return ResourceManager.GetString("Assert_NotString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field value &apos;{0}&apos; can not be compared with &apos;{1}&apos;..
+        /// </summary>
+        internal static string Compare {
+            get {
+                return ResourceManager.GetString("Compare", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not contain &apos;{1}&apos;..
+        /// </summary>
+        internal static string Contains {
+            get {
+                return ResourceManager.GetString("Contains", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; has &apos;{1}&apos; items instead of &apos;{2}&apos;..
+        /// </summary>
+        internal static string Count {
+            get {
+                return ResourceManager.GetString("Count", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; does not end with &apos;{1}&apos;..
+        /// </summary>
+        internal static string EndsWith {
+            get {
+                return ResourceManager.GetString("EndsWith", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None of the field(s) existed: {0}.
+        /// </summary>
+        internal static string Exists {
+            get {
+                return ResourceManager.GetString("Exists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field(s) existed: {0}.
+        /// </summary>
+        internal static string ExistsNot {
+            get {
+                return ResourceManager.GetString("ExistsNot", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The header was not set..
+        /// </summary>
+        internal static string FileHeader {
+            get {
+                return ResourceManager.GetString("FileHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The file &apos;{0}&apos; does not exist..
+        /// </summary>
+        internal static string FilePath {
+            get {
+                return ResourceManager.GetString("FilePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &gt; &apos;{1}&apos;..
+        /// </summary>
+        internal static string Greater {
+            get {
+                return ResourceManager.GetString("Greater", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &gt;= &apos;{1}&apos;..
+        /// </summary>
+        internal static string GreaterOrEqual {
+            get {
+                return ResourceManager.GetString("GreaterOrEqual", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; is set to &apos;{1}&apos;..
+        /// </summary>
+        internal static string HasExpectedFieldValue {
+            get {
+                return ResourceManager.GetString("HasExpectedFieldValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The field &apos;{0}&apos; exists..
+        /// </summary>
+        internal static string HasField {
+            get {
+                return ResourceManager.GetString("HasField", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to None of the specified schemas match &apos;{0}&apos;..
+        /// </summary>
+        internal static string HasJsonSchema {
+            get {
                 return ResourceManager.GetString("HasJsonSchema", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; was not included in the set..
         /// </summary>
-        internal static string In
-        {
-            get
-            {
+        internal static string In {
+            get {
                 return ResourceManager.GetString("In", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only letters..
         /// </summary>
-        internal static string IsLetter
-        {
-            get
-            {
+        internal static string IsLetter {
+            get {
                 return ResourceManager.GetString("IsLetter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed schema validation on {0}. {1}.
         /// </summary>
-        internal static string JsonSchemaInvalid
-        {
-            get
-            {
+        internal static string JsonSchemaInvalid {
+            get {
                 return ResourceManager.GetString("JsonSchemaInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The JSON schema &apos;{0}&apos; could not be found..
         /// </summary>
-        internal static string JsonSchemaNotFound
-        {
-            get
-            {
+        internal static string JsonSchemaNotFound {
+            get {
                 return ResourceManager.GetString("JsonSchemaNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &lt; &apos;{1}&apos;..
         /// </summary>
-        internal static string Less
-        {
-            get
-            {
+        internal static string Less {
+            get {
                 return ResourceManager.GetString("Less", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &lt;= &apos;{1}&apos;..
         /// </summary>
-        internal static string LessOrEqual
-        {
-            get
-            {
+        internal static string LessOrEqual {
+            get {
                 return ResourceManager.GetString("LessOrEqual", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the regex(s) matched: {0}.
         /// </summary>
-        internal static string Match
-        {
-            get
-            {
+        internal static string Match {
+            get {
                 return ResourceManager.GetString("Match", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The regex &apos;{0}&apos; matched..
         /// </summary>
-        internal static string MatchNot
-        {
-            get
-            {
+        internal static string MatchNot {
+            get {
                 return ResourceManager.GetString("MatchNot", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; does not match the pattern &apos;{1}&apos;..
         /// </summary>
-        internal static string MatchPattern
-        {
-            get
-            {
+        internal static string MatchPattern {
+            get {
                 return ResourceManager.GetString("MatchPattern", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; is not enumerable..
         /// </summary>
-        internal static string NotEnumerable
-        {
-            get
-            {
+        internal static string NotEnumerable {
+            get {
                 return ResourceManager.GetString("NotEnumerable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not exist..
         /// </summary>
-        internal static string NotHasField
-        {
-            get
-            {
+        internal static string NotHasField {
+            get {
                 return ResourceManager.GetString("NotHasField", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value of &apos;{0}&apos; is null or empty..
         /// </summary>
-        internal static string NotHasFieldValue
-        {
-            get
-            {
+        internal static string NotHasFieldValue {
+            get {
                 return ResourceManager.GetString("NotHasFieldValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; was in the set..
         /// </summary>
-        internal static string NotIn
-        {
-            get
-            {
+        internal static string NotIn {
+            get {
                 return ResourceManager.GetString("NotIn", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; matches the pattern &apos;{1}&apos;..
         /// </summary>
-        internal static string NotMatchPattern
-        {
-            get
-            {
+        internal static string NotMatchPattern {
+            get {
                 return ResourceManager.GetString("NotMatchPattern", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not null..
         /// </summary>
-        internal static string NotNull
-        {
-            get
-            {
+        internal static string NotNull {
+            get {
                 return ResourceManager.GetString("NotNull", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The file &apos;{0}&apos; is within the path &apos;{1}&apos;..
         /// </summary>
-        internal static string NotWithinPath
-        {
-            get
-            {
+        internal static string NotWithinPath {
+            get {
                 return ResourceManager.GetString("NotWithinPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is null..
         /// </summary>
-        internal static string Null
-        {
-            get
-            {
+        internal static string Null {
+            get {
                 return ResourceManager.GetString("Null", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; is not empty..
         /// </summary>
-        internal static string NullOrEmpty
-        {
-            get
-            {
+        internal static string NullOrEmpty {
+            get {
                 return ResourceManager.GetString("NullOrEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is null or empty..
         /// </summary>
-        internal static string NullOrEmptyParameter
-        {
-            get
-            {
+        internal static string NullOrEmptyParameter {
+            get {
                 return ResourceManager.GetString("NullOrEmptyParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is null..
         /// </summary>
-        internal static string NullParameter
-        {
-            get
-            {
+        internal static string NullParameter {
+            get {
                 return ResourceManager.GetString("NullParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No results were provided..
         /// </summary>
-        internal static string ResultsNotProvided
-        {
-            get
-            {
+        internal static string ResultsNotProvided {
+            get {
                 return ResourceManager.GetString("ResultsNotProvided", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not start with &apos;{1}&apos;..
         /// </summary>
-        internal static string StartsWith
-        {
-            get
-            {
+        internal static string StartsWith {
+            get {
                 return ResourceManager.GetString("StartsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not a string..
         /// </summary>
-        internal static string String
-        {
-            get
-            {
+        internal static string String {
+            get {
                 return ResourceManager.GetString("String", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; did not contain &apos;{1}&apos;..
         /// </summary>
-        internal static string Subset
-        {
-            get
-            {
+        internal static string Subset {
+            get {
                 return ResourceManager.GetString("Subset", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; included multiple instances of &apos;{1}&apos;..
         /// </summary>
-        internal static string SubsetDuplicate
-        {
-            get
-            {
+        internal static string SubsetDuplicate {
+            get {
                 return ResourceManager.GetString("SubsetDuplicate", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{2}&apos; of type {1} is not {0}..
         /// </summary>
-        internal static string Type
-        {
-            get
-            {
+        internal static string Type {
+            get {
                 return ResourceManager.GetString("Type", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{1}&apos; of type {0} is not an integer..
         /// </summary>
-        internal static string TypeInteger
-        {
-            get
-            {
+        internal static string TypeInteger {
+            get {
                 return ResourceManager.GetString("TypeInteger", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{1}&apos; of type {0} is not numeric..
         /// </summary>
-        internal static string TypeNumeric
-        {
-            get
-            {
+        internal static string TypeNumeric {
+            get {
                 return ResourceManager.GetString("TypeNumeric", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the type name(s) match: {0}.
         /// </summary>
-        internal static string TypeOf
-        {
-            get
-            {
+        internal static string TypeOf {
+            get {
                 return ResourceManager.GetString("TypeOf", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not a version string..
         /// </summary>
-        internal static string Version
-        {
-            get
-            {
+        internal static string Version {
+            get {
                 return ResourceManager.GetString("Version", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The version &apos;{0}&apos; does not match the constraint &apos;{1}&apos;..
         /// </summary>
-        internal static string VersionContraint
-        {
-            get
-            {
+        internal static string VersionContraint {
+            get {
                 return ResourceManager.GetString("VersionContraint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value didn&apos;t match the set..
         /// </summary>
-        internal static string Within
-        {
-            get
-            {
+        internal static string Within {
+            get {
                 return ResourceManager.GetString("Within", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was within the set..
         /// </summary>
-        internal static string WithinNot
-        {
-            get
-            {
+        internal static string WithinNot {
+            get {
                 return ResourceManager.GetString("WithinNot", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The file &apos;{0}&apos; is not within the path &apos;{1}&apos;..
         /// </summary>
-        internal static string WithinPath
-        {
-            get
-            {
+        internal static string WithinPath {
+            get {
                 return ResourceManager.GetString("WithinPath", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -147,6 +147,9 @@
   <data name="Assert_NotInSet" xml:space="preserve">
     <value>The value '{0}' was not in {1}.</value>
   </data>
+  <data name="Assert_NotSpecifiedSchema" xml:space="preserve">
+    <value>None of the specified schemas match '{0}'.</value>
+  </data>
   <data name="Assert_NotStartsWith" xml:space="preserve">
     <value>The value '{0}' does not start with any of {1}.</value>
   </data>

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -150,6 +150,7 @@ namespace PSRule
             var actual2 = GetObject((name: "schema", value: "abc"));
             var actual3 = GetObject((name: "$schema", value: "http://json-schema.org/draft-07/schema#"));
             var actual4 = GetObject((name: "$schema", value: "http://json-schema.org/draft-07/schema#definition"));
+            var actual5 = GetObject((name: "$schema", value: ""));
 
             Assert.True(assert.HasJsonSchema(actual1, null).Result);
             Assert.True(assert.HasJsonSchema(actual1, new string[] { "abc" }).Result);
@@ -159,6 +160,7 @@ namespace PSRule
             Assert.True(assert.HasJsonSchema(actual3, new string[] { "https://json-schema.org/draft-07/schema#" }, true).Result);
             Assert.True(assert.HasJsonSchema(actual3, new string[] { "https://json-schema.org/draft-07/schema#", "http://json-schema.org/draft-07/schema#" }).Result);
             Assert.False(assert.HasJsonSchema(actual4, new string[] { "https://json-schema.org/draft-07/schema#" }, true).Result);
+            Assert.False(assert.HasJsonSchema(actual5, null).Result);
         }
 
         [Fact]

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -25,7 +25,7 @@ namespace PSRule
             context.Begin();
             var selector = HostHelper.GetSelectorYaml(GetSource(), context).ToArray();
             Assert.NotNull(selector);
-            Assert.Equal(51, selector.Length);
+            Assert.Equal(55, selector.Length);
 
             Assert.Equal("BasicSelector", selector[0].Name);
             Assert.Equal("YamlAllOf", selector[4].Name);
@@ -759,6 +759,50 @@ namespace PSRule
 
             context.EnterTargetObject(new TargetObject(actual8));
             Assert.False(withName.Match(actual8));
+        }
+
+
+        [Fact]
+        public void HasSchemaExpression()
+        {
+            var hasSchema = GetSelectorVisitor("YamlHasSchema", out _);
+            var actual1 = GetObject((name: "key", value: "value"), (name: "$schema", value: "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#"));
+            var actual2 = GetObject((name: "key", value: "value"), (name: "$schema", value: "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json"));
+            var actual3 = GetObject((name: "key", value: "value"), (name: "$schema", value: "http://schema.management.azure.com/schemas/2019-04-01/DeploymentParameters.json#"));
+            var actual4 = GetObject((name: "key", value: "value"), (name: "$schema", value: null));
+            var actual5 = GetObject((name: "key", value: "value"), (name: "$schema", value: ""));
+            var actual6 = GetObject();
+
+            Assert.True(hasSchema.Match(actual1));
+            Assert.True(hasSchema.Match(actual2));
+            Assert.False(hasSchema.Match(actual3));
+            Assert.False(hasSchema.Match(actual4));
+            Assert.False(hasSchema.Match(actual5));
+            Assert.False(hasSchema.Match(actual6));
+
+            hasSchema = GetSelectorVisitor("YamlHasSchemaIgnoreScheme", out _);
+            Assert.True(hasSchema.Match(actual1));
+            Assert.True(hasSchema.Match(actual2));
+            Assert.True(hasSchema.Match(actual3));
+            Assert.False(hasSchema.Match(actual4));
+            Assert.False(hasSchema.Match(actual5));
+            Assert.False(hasSchema.Match(actual6));
+
+            hasSchema = GetSelectorVisitor("YamlHasSchemaCaseSensitive", out _);
+            Assert.True(hasSchema.Match(actual1));
+            Assert.True(hasSchema.Match(actual2));
+            Assert.False(hasSchema.Match(actual3));
+            Assert.False(hasSchema.Match(actual4));
+            Assert.False(hasSchema.Match(actual5));
+            Assert.False(hasSchema.Match(actual6));
+
+            hasSchema = GetSelectorVisitor("YamlHasAnySchema", out _);
+            Assert.True(hasSchema.Match(actual1));
+            Assert.True(hasSchema.Match(actual2));
+            Assert.True(hasSchema.Match(actual3));
+            Assert.False(hasSchema.Match(actual4));
+            Assert.False(hasSchema.Match(actual5));
+            Assert.False(hasSchema.Match(actual6));
         }
 
         #endregion Conditions

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -427,6 +427,60 @@ spec:
     count: 2
 
 ---
+# Synopsis: Test hasSchema
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlHasSchema
+spec:
+  if:
+    field: '.'
+    hasSchema:
+    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+
+---
+# Synopsis: Test hasSchema ignoring scheme
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlHasSchemaIgnoreScheme
+spec:
+  if:
+    field: '.'
+    hasSchema:
+    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+    ignoreScheme: true
+
+---
+# Synopsis: Test hasSchema with case sensitivity
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlHasSchemaCaseSensitive
+spec:
+  if:
+    field: '.'
+    hasSchema:
+    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+    caseSensitive: true
+
+---
+# Synopsis: Test hasSchema matching any schema
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlHasAnySchema
+spec:
+  if:
+    field: '.'
+    hasSchema: []
+
+#region With type tests
+
+---
 # Synopsis: Test with type
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Selector
@@ -436,6 +490,10 @@ spec:
   if:
     type: '.'
     equals: 'CustomType1'
+
+#endregion With type tests
+
+#region With name tests
 
 ---
 # Synopsis: Test equals with name
@@ -631,3 +689,5 @@ spec:
   if:
     name: '.'
     isUpper: true
+
+#endregion With name tests


### PR DESCRIPTION
## PR Summary

- Added `HasSchema` expression to check the schema of an object. #860
- Fixed `$Assert.HasJsonSchema` accepts empty value. #859

Fixes #860 
Fixes #859 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
