### PR TITLE
Release v1.10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 **Module in use and version:**
 
 - Module: PSRule
-- Version: **[e.g. 1.8.0]**
+- Version: **[e.g. 1.10.0]**
 
 Captured output from `$PSVersionTable`:
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -13,7 +13,7 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## v1.10.0
 
-Whats's changed since v1.9.0:
+What's changed since v1.9.0:
 
 - General improvements:
   - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)
@@ -36,7 +36,7 @@ What's changed since pre-release v1.10.0-B2111024:
 
 ## v1.10.0-B2111024 (pre-release)
 
-Whats's changed since v1.9.0:
+What's changed since v1.9.0:
 
 - General improvements:
   - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,22 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.10.0
+
+Whats's changed since v1.9.0:
+
+- General improvements:
+  - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)
+  - Added `HasSchema` expression to check the schema of an object. [#860](https://github.com/microsoft/PSRule/issues/860)
+    - See [about_PSRule_Expressions] for details.
+- Bug fixes:
+  - Fixed `$Assert.HasJsonSchema` accepts empty value. [#859](https://github.com/microsoft/PSRule/issues/859)
+  - Fixed module configuration is not loaded when case does not match. [#864](https://github.com/microsoft/PSRule/issues/864)
+
+What's changed since pre-release v1.10.0-B2112002:
+
+- No additional changes.
+
 ## v1.10.0-B2112002 (pre-release)
 
 What's changed since pre-release v1.10.0-B2111024:


### PR DESCRIPTION
## PR Summary

What's changed since v1.9.0:

- General improvements:
  - Added JSON support for reading rules and selectors from pipeline. #857
  - Added `HasSchema` expression to check the schema of an object. #860
- Bug fixes:
  - Fixed `$Assert.HasJsonSchema` accepts empty value. #859
  - Fixed module configuration is not loaded when case does not match. #864

What's changed since pre-release v1.10.0-B2112002:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
