### PR TITLE
Added version and hasDefault expression #861 #870

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [StartsWith](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#startswith)
   - [Subset](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#subset)
   - [Type](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#type)
+  - [Version](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#version)
 - [Options](docs/concepts/PSRule/en-US/about_PSRule_Options.md)
   - [Binding.Field](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingfield)
   - [Binding.IgnoreCase](docs/concepts/PSRule/en-US/about_PSRule_Options.md#bindingignorecase)

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Field](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#field)
   - [Greater](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#greater)
   - [GreaterOrEquals](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#greaterorequals)
+  - [HasDefault](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#hasdefault)
   - [HasSchema](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#hasschema)
   - [HasValue](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#hasvalue)
   - [In](docs/concepts/PSRule/en-US/about_PSRule_Expressions.md#in)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -16,6 +16,8 @@ What's changed since v1.10.0:
 - General improvements:
   - Added `version` expression to check semantic version constraints. [#861](https://github.com/microsoft/PSRule/issues/861)
     - See [about_PSRule_Expressions] for details.
+  - Added `hasDefault` expression to check field default value. [#870](https://github.com/microsoft/PSRule/issues/870)
+    - See [about_PSRule_Expressions] for details.
 
 ## v1.10.0
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.10.0:
+
+- General improvements:
+  - Added `version` expression to check semantic version constraints. [#861](https://github.com/microsoft/PSRule/issues/861)
+    - See [about_PSRule_Expressions] for details.
+
 ## v1.10.0
 
 What's changed since v1.9.0:
@@ -19,6 +25,8 @@ What's changed since v1.9.0:
   - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)
   - Added `HasSchema` expression to check the schema of an object. [#860](https://github.com/microsoft/PSRule/issues/860)
     - See [about_PSRule_Expressions] for details.
+- Engineering:
+  - Bump Microsoft.SourceLink.GitHub to 1.1.1. [#856](https://github.com/microsoft/PSRule/pull/856)
 - Bug fixes:
   - Fixed `$Assert.HasJsonSchema` accepts empty value. [#859](https://github.com/microsoft/PSRule/issues/859)
   - Fixed module configuration is not loaded when case does not match. [#864](https://github.com/microsoft/PSRule/issues/864)
@@ -42,6 +50,8 @@ What's changed since v1.9.0:
   - Added JSON support for reading rules and selectors from pipeline. [#857](https://github.com/microsoft/PSRule/issues/857)
   - Added `HasSchema` expression to check the schema of an object. [#860](https://github.com/microsoft/PSRule/issues/860)
     - See [about_PSRule_Expressions] for details.
+- Engineering:
+  - Bump Microsoft.SourceLink.GitHub to 1.1.1. [#856](https://github.com/microsoft/PSRule/pull/856)
 - Bug fixes:
   - Fixed `$Assert.HasJsonSchema` accepts empty value. [#859](https://github.com/microsoft/PSRule/issues/859)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -20,6 +20,7 @@ The following conditions are available:
 - [Exists](#exists)
 - [Greater](#greater)
 - [GreaterOrEquals](#greaterorequals)
+- [HasDefault](#hasdefault)
 - [HasSchema](#hasschema)
 - [HasValue](#hasvalue)
 - [In](#in)
@@ -456,6 +457,47 @@ spec:
   if:
     field: 'Name'
     greaterOrEquals: 3
+```
+
+### HasDefault
+
+The `hasDefault` condition determines if the field exists that it is set to the specified value.
+If the field does not exist, the condition will return `true`.
+
+The following properties are accepted:
+
+- `caseSensitive` - Optionally, a case-sensitive comparison can be performed for string values.
+  By default, case-insensitive comparison is performed.
+
+Syntax:
+
+```yaml
+hasDefault: <string | int | bool>
+caseSensitive: <bool>
+```
+
+For example:
+
+```yaml
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: 'ExampleHasDefault'
+spec:
+  condition:
+    field: 'enabled'
+    hasDefault: true
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleHasDefault'
+spec:
+  if:
+    field: 'enabled'
+    hasDefault: true
 ```
 
 ### HasSchema

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -35,6 +35,7 @@ The following conditions are available:
 - [SetOf](#setof)
 - [StartsWith](#startswith)
 - [Subset](#subset)
+- [Version](#version)
 
 The following operators are available:
 
@@ -1192,6 +1193,54 @@ spec:
     in:
     - 'Microsoft.Storage/storageAccounts'
     - 'Microsoft.Storage/storageAccounts/blobServices'
+```
+
+### Version
+
+The `version` condition determines if the operand is a valid semantic version.
+A constraint can optionally be provided to require the semantic version to be within a range.
+Supported version constraints for expression are the same as the `$Assert.Version` assertion helper.
+
+Syntax:
+
+```yaml
+version: <string>
+includePrerelease: <bool>
+```
+
+For example:
+
+```yaml
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: 'ExampleVersion'
+spec:
+  condition:
+    field: 'engine.version'
+    version: '^1.2.3'
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleAnyVersion'
+spec:
+  if:
+    field: 'engine.version'
+    version: ''
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleVersionIncludingPrerelease'
+spec:
+  if:
+    field: 'engine.version'
+    version: '>=1.5.0'
+    includePrerelease: true
 ```
 
 ## NOTE

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -26,6 +26,7 @@ The following conditions are available:
 - [Exists](about_PSRule_Expressions.md#exists)
 - [Greater](about_PSRule_Expressions.md#greater)
 - [GreaterOrEquals](about_PSRule_Expressions.md#greaterorequals)
+- [HasDefault](about_PSRule_Expressions.md#hasdefault)
 - [HasSchema](about_PSRule_Expressions.md#hasschema)
 - [HasValue](about_PSRule_Expressions.md#hasvalue)
 - [In](about_PSRule_Expressions.md#in)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Selectors.md
@@ -17,35 +17,43 @@ When evaluating an object from input, PSRule can use selectors to perform comple
 - Optionally a condition can be nested in an operator.
 - Operators can be nested within other operators.
 
-Conditions and operators available for use include:
+The following conditions are available:
 
-- AllOf
-- AnyOf
-- Contains
-- Equals
-- EndsWith
-- Exists
-- Greater
-- GreaterOrEquals
-- HasValue
-- In
-- IsLower
-- IsString
-- IsUpper
-- Less
-- LessOrEquals
-- Match
-- Not
-- NotEquals
-- NotIn
-- NotMatch
-- StartsWith
+- [Contains](about_PSRule_Expressions.md#contains)
+- [Count](about_PSRule_Expressions.md#count)
+- [Equals](about_PSRule_Expressions.md#equals)
+- [EndsWith](about_PSRule_Expressions.md#endswith)
+- [Exists](about_PSRule_Expressions.md#exists)
+- [Greater](about_PSRule_Expressions.md#greater)
+- [GreaterOrEquals](about_PSRule_Expressions.md#greaterorequals)
+- [HasSchema](about_PSRule_Expressions.md#hasschema)
+- [HasValue](about_PSRule_Expressions.md#hasvalue)
+- [In](about_PSRule_Expressions.md#in)
+- [IsLower](about_PSRule_Expressions.md#islower)
+- [IsString](about_PSRule_Expressions.md#isstring)
+- [IsUpper](about_PSRule_Expressions.md#isupper)
+- [Less](about_PSRule_Expressions.md#less)
+- [LessOrEquals](about_PSRule_Expressions.md#lessorequals)
+- [Match](about_PSRule_Expressions.md#match)
+- [NotEquals](about_PSRule_Expressions.md#notequals)
+- [NotIn](about_PSRule_Expressions.md#notin)
+- [NotMatch](about_PSRule_Expressions.md#notmatch)
+- [SetOf](about_PSRule_Expressions.md#setof)
+- [StartsWith](about_PSRule_Expressions.md#startswith)
+- [Subset](about_PSRule_Expressions.md#subset)
+- [Version](about_PSRule_Expressions.md#version)
+
+The following operators are available:
+
+- [AllOf](about_PSRule_Expressions.md#allof)
+- [AnyOf](about_PSRule_Expressions.md#anyof)
+- [Not](about_PSRule_Expressions.md#not)
 
 The following comparison properties are available:
 
-- Field
-- Name
-- Type
+- [Field](about_PSRule_Expressions.md#field)
+- [Name](about_PSRule_Expressions.md#name)
+- [Type](about_PSRule_Expressions.md#type)
 
 To learn more about conditions, operators, and properties see [about_PSRule_Expressions](about_PSRule_Expressions.md).
 

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -586,6 +586,9 @@
                 },
                 {
                     "$ref": "#/definitions/selectorConditionVersion"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionHasDefault"
                 }
             ]
         },
@@ -656,7 +659,7 @@
             "properties": {
                 "allOf": {
                     "type": "array",
-                    "title": "AllOf",
+                    "title": "All Of",
                     "description": "All of the expressions must be true.",
                     "markdownDescription": "All of the expressions must be true. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#allof)",
                     "items": {
@@ -674,7 +677,7 @@
             "properties": {
                 "anyOf": {
                     "type": "array",
-                    "title": "AnyOf",
+                    "title": "Any Of",
                     "description": "One of the expressions must be true.",
                     "markdownDescription": "All of the expressions must be true. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#anyof)",
                     "items": {
@@ -727,26 +730,10 @@
             "type": "object",
             "properties": {
                 "equals": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "title": "Equals",
-                            "description": "Must have the specified value.",
-                            "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)"
-                        },
-                        {
-                            "type": "integer",
-                            "title": "Equals",
-                            "description": "Must have the specified value.",
-                            "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)"
-                        },
-                        {
-                            "type": "boolean",
-                            "title": "Equals",
-                            "description": "Must have the specified value.",
-                            "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)"
-                        }
-                    ]
+                    "title": "Equals",
+                    "description": "Must have the specified value.",
+                    "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#equals)",
+                    "$ref": "#/definitions/selectorExpressionValue"
                 }
             },
             "required": [
@@ -762,26 +749,10 @@
             "type": "object",
             "properties": {
                 "notEquals": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "title": "Not Equals",
-                            "description": "Must not have the specified value.",
-                            "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)"
-                        },
-                        {
-                            "type": "integer",
-                            "title": "Not Equals",
-                            "description": "Must not have the specified value.",
-                            "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)"
-                        },
-                        {
-                            "type": "boolean",
-                            "title": "Not Equals",
-                            "description": "Must not have the specified value.",
-                            "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)"
-                        }
-                    ]
+                    "title": "Not Equals",
+                    "description": "Must not have the specified value.",
+                    "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#notequals)",
+                    "$ref": "#/definitions/selectorExpressionValue"
                 }
             },
             "required": [
@@ -900,8 +871,8 @@
                 "caseSensitive": {
                     "type": "boolean",
                     "title": "Case sensitive",
-                    "description": "Determines comparing values is case-sensitive.",
-                    "markdownDescription": "Determines comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#setof)",
+                    "description": "Determines if comparing values is case-sensitive.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#setof)",
                     "default": false
                 }
             },
@@ -926,15 +897,15 @@
                 "caseSensitive": {
                     "type": "boolean",
                     "title": "Case sensitive",
-                    "description": "Determines comparing values is case-sensitive.",
-                    "markdownDescription": "Determines comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#subset)",
+                    "description": "Determines if comparing values is case-sensitive.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#subset)",
                     "default": false
                 },
                 "unique": {
                     "type": "boolean",
                     "title": "Unique",
-                    "description": "Determines each of the field values must be unique.",
-                    "markdownDescription": "Determines each of the field values must be unique. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#subset)",
+                    "description": "Determines if each of the field values must be unique.",
+                    "markdownDescription": "Determines if each of the field values must be unique. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#subset)",
                     "default": false
                 }
             },
@@ -1185,8 +1156,8 @@
                 "caseSensitive": {
                     "type": "boolean",
                     "title": "Case sensitive",
-                    "description": "Determines comparing schemas is case-sensitive.",
-                    "markdownDescription": "Determines comparing schemas is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
+                    "description": "Determines if comparing schemas is case-sensitive.",
+                    "markdownDescription": "Determines if comparing schemas is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
                     "default": false
                 }
             },
@@ -1226,6 +1197,32 @@
                 }
             ]
         },
+        "selectorConditionHasDefault": {
+            "type": "object",
+            "properties": {
+                "hasDefault": {
+                    "title": "Has Default",
+                    "description": "The field must either not exist or be set to the configured value.",
+                    "markdownDescription": "The field must either not exist or be set to the configured value. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasdefault)",
+                    "$ref": "#/definitions/selectorExpressionValue"
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines if comparing values is case-sensitive.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasdefault)",
+                    "default": false
+                }
+            },
+            "required": [
+                "hasDefault"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
         "selectorExpressionValueMultiString": {
             "oneOf": [
                 {
@@ -1237,6 +1234,19 @@
                         "type": "string"
                     },
                     "uniqueItems": true
+                }
+            ]
+        },
+        "selectorExpressionValue": {
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "boolean"
+                },
+                {
+                    "type": "integer"
                 }
             ]
         }

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -583,6 +583,9 @@
                 },
                 {
                     "$ref": "#/definitions/selectorConditionHasSchema"
+                },
+                {
+                    "$ref": "#/definitions/selectorConditionVersion"
                 }
             ]
         },
@@ -1167,7 +1170,7 @@
                         "type": "string",
                         "title": "Has schema",
                         "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
-                    "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
+                        "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#hasschema)",
                         "minLength": 1
                     },
                     "uniqueItems": true
@@ -1189,6 +1192,33 @@
             },
             "required": [
                 "hasSchema"
+            ],
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/selectorProperties"
+                }
+            ]
+        },
+        "selectorConditionVersion": {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "title": "Version",
+                    "description": "Must be a valid semantic version. A constraint can optionally be provided to require the semantic version to be within a range.",
+                    "markdownDescription": "Must be a valid semantic version. A constraint can optionally be provided to require the semantic version to be within a range. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#version)",
+                    "default": ""
+                },
+                "includePrerelease": {
+                    "type": "boolean",
+                    "title": "Include pre-release",
+                    "description": "Determines if pre-release versions are included. By default, pre-release versions are not included.",
+                    "markdownDescription": "Determines if pre-release versions are included. By default, pre-release versions are not included. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Selectors.html#version)",
+                    "default": false
+                }
+            },
+            "required": [
+                "version"
             ],
             "oneOf": [
                 {

--- a/src/PSRule/Common/ExpressionHelpers.cs
+++ b/src/PSRule/Common/ExpressionHelpers.cs
@@ -453,7 +453,7 @@ namespace PSRule
 
         internal static bool AnySchema(string actualValue, Array expectedValue, bool ignoreScheme, bool caseSensitive)
         {
-            var actualNormal =  NormalizeSchemaUri(actualValue, ignoreScheme);
+            var actualNormal = NormalizeSchemaUri(actualValue, ignoreScheme);
             var comparer = caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
             for (var i = 0; expectedValue != null && i < expectedValue.Length; i++)
             {

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -231,6 +231,8 @@ namespace PSRule.Definitions.Expressions
         private const string EXISTS = "exists";
         private const string EQUALS = "equals";
         private const string NOTEQUALS = "notEquals";
+        private const string HASDEFAULT = "hasDefault";
+        private const string HASSCHEMA = "hasSchema";
         private const string HASVALUE = "hasValue";
         private const string MATCH = "match";
         private const string NOTMATCH = "notMatch";
@@ -249,7 +251,6 @@ namespace PSRule.Definitions.Expressions
         private const string SETOF = "setOf";
         private const string SUBSET = "subset";
         private const string COUNT = "count";
-        private const string HASSCHEMA = "hasSchema";
         private const string VERSION = "version";
 
         // Operators
@@ -307,6 +308,7 @@ namespace PSRule.Definitions.Expressions
             new LanguageExpresssionDescriptor(COUNT, LanguageExpressionType.Condition, Count),
             new LanguageExpresssionDescriptor(HASSCHEMA, LanguageExpressionType.Condition, HasSchema),
             new LanguageExpresssionDescriptor(VERSION, LanguageExpressionType.Condition, Version),
+            new LanguageExpresssionDescriptor(HASDEFAULT, LanguageExpressionType.Condition, HasDefault),
         };
 
         #region Operators
@@ -403,6 +405,28 @@ namespace PSRule.Definitions.Expressions
             return Condition(
                 context,
                 !ExpressionHelpers.Equal(propertyValue, operand.Value, caseSensitive: false, convertExpected: true),
+                operand,
+                ReasonStrings.Assert_IsSetTo,
+                operand.Value
+            );
+        }
+
+        internal static bool HasDefault(ExpressionContext context, ExpressionInfo info, object[] args, object o)
+        {
+            var properties = GetProperties(args);
+            if (!TryPropertyAny(properties, HASDEFAULT, out object propertyValue))
+                return Invalid(context, HASDEFAULT);
+
+            GetCaseSensitive(properties, out bool caseSensitive);
+            if (TryFieldNotExists(context, o, properties))
+                return Pass();
+
+            if (!TryOperand(context, HASDEFAULT, o, properties, out IOperand operand))
+                return Invalid(context, HASDEFAULT);
+
+            return Condition(
+                context,
+                ExpressionHelpers.Equal(propertyValue, operand.Value, caseSensitive, convertExpected: true),
                 operand,
                 ReasonStrings.Assert_IsSetTo,
                 operand.Value

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -25,7 +25,7 @@ namespace PSRule
             context.Begin();
             var selector = HostHelper.GetSelectorYaml(GetSource(), context).ToArray();
             Assert.NotNull(selector);
-            Assert.Equal(55, selector.Length);
+            Assert.Equal(58, selector.Length);
 
             Assert.Equal("BasicSelector", selector[0].Name);
             Assert.Equal("YamlAllOf", selector[4].Name);
@@ -803,6 +803,45 @@ namespace PSRule
             Assert.False(hasSchema.Match(actual4));
             Assert.False(hasSchema.Match(actual5));
             Assert.False(hasSchema.Match(actual6));
+        }
+
+        [Fact]
+        public void Version()
+        {
+            var actual1 = GetObject((name: "version", value: "1.2.3"));
+            var actual2 = GetObject((name: "version", value: "0.2.3"));
+            var actual3 = GetObject((name: "version", value: "2.2.3"));
+            var actual4 = GetObject((name: "version", value: "1.1.3"));
+            var actual5 = GetObject((name: "version", value: "1.3.3-preview.1"));
+            var actual6 = GetObject();
+            var actual7 = GetObject((name: "version", value: "a.b.c"));
+
+            var version = GetSelectorVisitor("YamlVersion", out _);
+            Assert.True(version.Match(actual1));
+            Assert.False(version.Match(actual2));
+            Assert.False(version.Match(actual3));
+            Assert.False(version.Match(actual4));
+            Assert.False(version.Match(actual5));
+            Assert.False(version.Match(actual6));
+            Assert.False(version.Match(actual7));
+
+            version = GetSelectorVisitor("YamlVersionWithPrerelease", out _);
+            Assert.True(version.Match(actual1));
+            Assert.False(version.Match(actual2));
+            Assert.False(version.Match(actual3));
+            Assert.False(version.Match(actual4));
+            Assert.True(version.Match(actual5));
+            Assert.False(version.Match(actual6));
+            Assert.False(version.Match(actual7));
+
+            version = GetSelectorVisitor("YamlVersionAnyVersion", out _);
+            Assert.True(version.Match(actual1));
+            Assert.True(version.Match(actual2));
+            Assert.True(version.Match(actual3));
+            Assert.True(version.Match(actual4));
+            Assert.True(version.Match(actual5));
+            Assert.False(version.Match(actual6));
+            Assert.False(version.Match(actual7));
         }
 
         #endregion Conditions

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
+using Newtonsoft.Json.Linq;
 using PSRule.Configuration;
 using PSRule.Definitions.Selectors;
 using PSRule.Host;
@@ -25,7 +26,7 @@ namespace PSRule
             context.Begin();
             var selector = HostHelper.GetSelectorYaml(GetSource(), context).ToArray();
             Assert.NotNull(selector);
-            Assert.Equal(58, selector.Length);
+            Assert.Equal(59, selector.Length);
 
             Assert.Equal("BasicSelector", selector[0].Name);
             Assert.Equal("YamlAllOf", selector[4].Name);
@@ -842,6 +843,29 @@ namespace PSRule
             Assert.True(version.Match(actual5));
             Assert.False(version.Match(actual6));
             Assert.False(version.Match(actual7));
+        }
+
+        [Fact]
+        public void HasDefault()
+        {
+            var actual1 = GetObject((name: "integerValue", value: 100), (name: "boolValue", value: true), (name: "stringValue", value: "testValue"));
+            var actual2 = GetObject((name: "integerValue", value: 1));
+            var actual3 = GetObject((name: "boolValue", value: false));
+            var actual4 = GetObject((name: "stringValue", value: "TestValue"));
+            var actual5 = GetObject();
+            var actual6 = GetObject((name: "integerValue", value: new JValue(100)));
+            var actual7 = GetObject((name: "boolValue", value: new JValue(true)));
+            var actual8 = GetObject((name: "stringValue", value: new JValue("testValue")));
+
+            var hasDefault = GetSelectorVisitor("YamlHasDefault", out _);
+            Assert.True(hasDefault.Match(actual1));
+            Assert.False(hasDefault.Match(actual2));
+            Assert.False(hasDefault.Match(actual3));
+            Assert.False(hasDefault.Match(actual4));
+            Assert.True(hasDefault.Match(actual5));
+            Assert.True(hasDefault.Match(actual6));
+            Assert.True(hasDefault.Match(actual7));
+            Assert.True(hasDefault.Match(actual8));
         }
 
         #endregion Conditions

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -478,6 +478,40 @@ spec:
     field: '.'
     hasSchema: []
 
+---
+# Synopsis: Test version
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlVersion
+spec:
+  if:
+    field: 'version'
+    version: '^1.2.3'
+
+---
+# Synopsis: Test version with prerelease
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlVersionWithPrerelease
+spec:
+  if:
+    field: 'version'
+    version: '^1.2.3'
+    includePrerelease: true
+
+---
+# Synopsis: Test any valid version
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlVersionAnyVersion
+spec:
+  if:
+    field: 'version'
+    version: ''
+
 #region With type tests
 
 ---
@@ -573,9 +607,6 @@ spec:
     name: '.'
     notIn:
     - 'TargetObject1'
-
-
-
 
 ---
 # Synopsis: Test startsWith with name

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -512,6 +512,23 @@ spec:
     field: 'version'
     version: ''
 
+---
+# Synopsis: Test hasDefault
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlHasDefault
+spec:
+  if:
+    allOf:
+    - field: 'integerValue'
+      hasDefault: 100
+    - field: 'boolValue'
+      hasDefault: true
+    - field: 'stringValue'
+      hasDefault: 'testValue'
+      caseSensitive: true
+
 #region With type tests
 
 ---


### PR DESCRIPTION
## PR Summary

- Added `version` expression to check semantic version constraints. #861
- Added `hasDefault` expression to check field default value. #870

Fixes #861
Fixes #870

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
