### PR TITLE
Fix GetReason method returning no reasons #874

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -18,6 +18,8 @@ What's changed since v1.10.0:
     - See [about_PSRule_Expressions] for details.
   - Added `hasDefault` expression to check field default value. [#870](https://github.com/microsoft/PSRule/issues/870)
     - See [about_PSRule_Expressions] for details.
+- Bug fixes:
+  - Fixed `GetReason()` not returning results for a failed assertion. [#874](https://github.com/microsoft/PSRule/issues/874)
 
 ## v1.10.0
 

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -124,10 +124,7 @@ namespace PSRule.Runtime
         /// <returns>Returns an array of reasons. This will always return null when the Value is true.</returns>
         public string[] GetReason()
         {
-            if (!Result || _Reason == null || _Reason.Count == 0)
-                return Array.Empty<string>();
-
-            return _Reason.ToArray();
+            return (Result || IsNullOrEmptyReason()) ? Array.Empty<string>() : _Reason.ToArray();
         }
 
         /// <summary>
@@ -159,15 +156,17 @@ namespace PSRule.Runtime
 
         public override string ToString()
         {
-            if (_Reason == null)
-                return string.Empty;
-
-            return string.Join(" ", _Reason.ToArray());
+            return IsNullOrEmptyReason() ? string.Empty : string.Join(" ", _Reason.ToArray());
         }
 
         public bool ToBoolean()
         {
             return Result;
+        }
+
+        private bool IsNullOrEmptyReason()
+        {
+            return _Reason == null || _Reason.Count == 0;
         }
     }
 }

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -35,8 +35,10 @@ namespace PSRule
             var actual1 = assert.Create(false, "Test reason");
             var actual2 = assert.Create(true, "Test reason");
             Assert.Equal("Test reason", actual1.ToString());
+            Assert.Equal("Test reason", actual1.GetReason()[0]);
             Assert.False(actual1.Result);
             Assert.Equal(string.Empty, actual2.ToString());
+            Assert.Empty(actual2.GetReason());
             Assert.True(actual2.Result);
 
             // WithReason
@@ -49,15 +51,20 @@ namespace PSRule
             actual1.Reason("New {0}", "Reason");
             actual1.Reason("New New Reason");
             Assert.Equal("New New Reason", actual1.ToString());
+            Assert.Equal("New New Reason", actual1.GetReason()[0]);
             actual1.ReasonIf(false, "Not a reason");
             Assert.Equal("New New Reason", actual1.ToString());
+            Assert.Equal("New New Reason", actual1.GetReason()[0]);
             actual1.ReasonIf(true, "New New New Reason");
             Assert.Equal("New New New Reason", actual1.ToString());
+            Assert.Equal("New New New Reason", actual1.GetReason()[0]);
 
             var actual3 = assert.Fail("Fail reason");
             Assert.Equal("Fail reason", actual3.ToString());
+            Assert.Equal("Fail reason", actual3.GetReason()[0]);
             actual3 = assert.Fail("Fail {0}", "reason");
             Assert.Equal("Fail reason", actual3.ToString());
+            Assert.Equal("Fail reason", actual3.GetReason()[0]);
 
             // Aggregate results
             Assert.True(assert.AnyOf(actual2, actual3).Result);
@@ -66,12 +73,16 @@ namespace PSRule
             Assert.False(assert.AnyOf().Result);
 
             Assert.False(assert.AllOf(actual2, actual3).Result);
-            Assert.Equal("Fail reason", assert.AllOf(actual2, actual3).ToString());
-            Assert.Equal("New New New Reason Fail reason", assert.AllOf(actual1, actual2, actual3).ToString());
+            var test1 = assert.AllOf(actual2, actual3);
+            Assert.Equal("Fail reason", test1.ToString());
+            Assert.Equal("Fail reason", test1.GetReason()[0]);
+
+            var test2 = assert.AllOf(actual1, actual2, actual3);
+            Assert.Equal("New New New Reason Fail reason", test2.ToString());
+            Assert.Equal(new string[] { "New New New Reason", "Fail reason" }, test2.GetReason());
             Assert.True(assert.AllOf(actual2, actual2).Result);
             Assert.True(assert.AllOf(actual2).Result);
             Assert.False(assert.AllOf().Result);
-
         }
 
         [Fact]


### PR DESCRIPTION
## PR Summary

Fix #874

Also did some code refactoring and turned `GetReason()` and `ToString()` into ternary operators.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
