### PR TITLE
Added waiting-feedback label for stale issues

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -25,5 +25,5 @@ jobs:
           days-before-close: 7
           days-before-pr-close: -1
 
-          any-of-labels: 'question,duplicate,incomplete'
+          any-of-labels: 'question,duplicate,incomplete,waiting-feedback'
           stale-issue-label: stale


### PR DESCRIPTION
## PR Summary

- Added `waiting-feedback` label to stale issue management.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
