### PR TITLE
Release v1.11.0

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,22 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.11.0
+
+What's changed since v1.10.0:
+
+- General improvements:
+  - Added `version` expression to check semantic version constraints. [#861](https://github.com/microsoft/PSRule/issues/861)
+    - See [about_PSRule_Expressions] for details.
+  - Added `hasDefault` expression to check field default value. [#870](https://github.com/microsoft/PSRule/issues/870)
+    - See [about_PSRule_Expressions] for details.
+- Bug fixes:
+  - Fixed `GetReason()` not returning results for a failed assertion. [#874](https://github.com/microsoft/PSRule/issues/874)
+
+What's changed since pre-release v1.11.0-B2112016:
+
+- No additional changes.
+
 ## v1.11.0-B2112016 (pre-release)
 
 What's changed since v1.10.0:


### PR DESCRIPTION
## PR Summary

What's changed since v1.10.0:

- General improvements:
  - Added `version` expression to check semantic version constraints. #861
  - Added `hasDefault` expression to check field default value. #870
- Bug fixes:
  - Fixed `GetReason()` not returning results for a failed assertion. #874

What's changed since pre-release v1.11.0-B2112016:

- No additional changes.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
