### PR TITLE
Clean up #755 #648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Change log
 
-See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+See [upgrade notes][1] for helpful information when upgrading from previous versions.
 
-[upgrade-notes]: docs/upgrade-notes.md
+  [1]: https://microsoft.github.io/PSRule/latest/upgrade-notes/
+
+## Next release
+
+- v2 **Comming soon** - Please check out [upgrade notes][1] to get prepared for the next release.
 
 ## Current release
 
-- [v1](docs/CHANGELOG-v1.md)
+- [v1](https://microsoft.github.io/PSRule/latest/CHANGELOG-v1/)
 
 ## Prior releases
 
-- [v0](docs/CHANGELOG-v0.md)
+- [v0](https://microsoft.github.io/PSRule/latest/CHANGELOG-v0/)

--- a/docs/CHANGELOG-v0.md
+++ b/docs/CHANGELOG-v0.md
@@ -1,8 +1,8 @@
 # Change log
 
-See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+See [upgrade notes][1] for helpful information when upgrading from previous versions.
 
-[upgrade-notes]: upgrade-notes.md
+  [1]: https://microsoft.github.io/PSRule/latest/upgrade-notes/
 
 ## v0.22.0
 

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -1,8 +1,8 @@
 # Change log
 
-See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+See [upgrade notes][1] for helpful information when upgrading from previous versions.
 
-[upgrade-notes]: upgrade-notes.md
+  [1]: https://microsoft.github.io/PSRule/latest/upgrade-notes/
 
 **Important notes**:
 
@@ -21,6 +21,14 @@ What's changed since v1.11.0:
     - See [about_PSRule_Assert] for details.
   - Improve tracking of suppressed objects. [#794](https://github.com/microsoft/PSRule/issues/794)
     - Added `Execution.SuppressedRuleWarning` option to output warning for suppressed rules.
+- Engineering:
+  - **Breaking change:** Removal of deprecated default baseline from module manifest. [#755](https://github.com/microsoft/PSRule/issues/755)
+    - Set the default module baseline using module configuration.
+    - See [upgrade notes][1] for details.
+  - **Breaking change:** Require `apiVersion` on YAML and JSON to be specified. [#648](https://github.com/microsoft/PSRule/issues/648)
+    - Resources should use `github.com/microsoft/PSRule/v1` as the `apiVersion`.
+    - Resources that do not specify an `apiVersion` will be ignored.
+    - See [upgrade notes][1] for details.
 
 ## v1.11.0
 

--- a/docs/authoring/packaging-rules/Enterprise.Rules/Enterprise.Rules.psd1
+++ b/docs/authoring/packaging-rules/Enterprise.Rules/Enterprise.Rules.psd1
@@ -108,9 +108,6 @@ PrivateData = @{
         # ReleaseNotes = ''
 
     } # End of PSData hashtable
-    PSRule = @{
-        Baseline = 'Enterprise.Default'
-    }
 } # End of PrivateData hashtable
 
 # HelpInfo URI of this module

--- a/docs/authoring/packaging-rules/Enterprise.Rules/rules/Config.Rule.yaml
+++ b/docs/authoring/packaging-rules/Enterprise.Rules/rules/Config.Rule.yaml
@@ -19,3 +19,5 @@ spec:
       resourceId: [ 'ResourceId' ]
       subscriptionId: [ 'SubscriptionId' ]
       resourceGroupName: [ 'ResourceGroupName' ]
+  rule:
+    baseline: 'Enterprise.Default'

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -9,7 +9,7 @@ Follow these notes to upgrade to PSRule _v2.0.0_ from previous versions.
 ### Setting default module baseline
 
 When packaging rules in a module, you can set the default baseline.
-The default baseline from the module will be automatically used unless overriden.
+The default baseline from the module will be automatically used unless overridden.
 
 Prior to _v1.9.0_ the default baseline was set by configuring the module manifest `.psd1` file.
 From _v1.9.0_ the default baseline can be configured by within a module configuration.
@@ -36,7 +36,7 @@ A module configuration can be defined in YAML.
 
 When creating YAML and JSON resources you define a resource by specifying the `apiVersion` and `kind`.
 An `apiVersion` was added as a requirement from _v1.2.0_.
-For compability resources without an `apiVersion` were supported however deprecated for removal in _v2.0.0_.
+For compatibility resources without an `apiVersion` were supported however deprecated for removal in _v2.0.0_.
 This has now been removed from _v2.0.0_.
 
 When defining resource specify an `apiVersion`.

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -2,9 +2,85 @@
 
 This document contains notes to help upgrade from previous versions of PSRule.
 
+## Upgrading to v2.0.0
+
+Follow these notes to upgrade to PSRule _v2.0.0_ from previous versions.
+
+### Setting default module baseline
+
+When packaging rules in a module, you can set the default baseline.
+The default baseline from the module will be automatically used unless overriden.
+
+Prior to _v1.9.0_ the default baseline was set by configuring the module manifest `.psd1` file.
+From _v1.9.0_ the default baseline can be configured by within a module configuration.
+Using module configuration is the recommended method.
+Setting the default baseline from module manifest and has been removed from _v2.0.0_.
+
+A module configuration can be defined in YAML.
+
+!!! Example
+
+    ```yaml hl_lines="8-9"
+    ---
+    # Synopsis: Example module configuration for Enterprise.Rules module.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: ModuleConfig
+    metadata:
+      name: Enterprise.Rules
+    spec:
+      rule:
+        baseline: Enterprise.Default
+    ```
+
+### Setting resource API version
+
+When creating YAML and JSON resources you define a resource by specifying the `apiVersion` and `kind`.
+An `apiVersion` was added as a requirement from _v1.2.0_.
+For compability resources without an `apiVersion` were supported however deprecated for removal in _v2.0.0_.
+This has now been removed from _v2.0.0_.
+
+When defining resource specify an `apiVersion`.
+Currently this must be set to `github.com/microsoft/PSRule/v1`.
+
+=== "YAML"
+
+    ```yaml hl_lines="3-4"
+    ---
+    # Synopsis: An example rule to require TLS.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: Rule
+    metadata:
+      name: 'Local.YAML.RequireTLS'
+    spec:
+      condition:
+        field: 'configure.supportsHttpsTrafficOnly'
+        equals: true
+    ```
+
+=== "JSON"
+
+    ```json hl_lines="4-5"
+    [
+        {
+            // Synopsis: An example rule to require TLS.
+            "apiVersion": "github.com/microsoft/PSRule/v1",
+            "kind": "Rule",
+            "metadata": {
+                "name": "Local.JSON.RequireTLS"
+            },
+            "spec": {
+                "condition": {
+                    "field": "configure.supportsHttpsTrafficOnly",
+                    "equals": true
+                }
+            }
+        }
+    ]
+    ```
+
 ## Upgrading to v1.4.0
 
-Follow these notes to upgrade from PSRule version _v1.3.0_ to _v1.4.0_.
+Follow these notes to upgrade to PSRule _v1.4.0_ from previous versions.
 
 ### Change in default output styles
 
@@ -53,7 +129,7 @@ variables:
 
 ## Upgrading to v1.0.0
 
-Follow these notes to upgrade from PSRule version _v0.22.0_ to _v1.0.0_.
+Follow these notes to upgrade to PSRule _v1.0.0_ from previous versions.
 
 ### Replaced $Rule target properties
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,7 +58,7 @@ nav:
       - Change log:
         - v1: 'CHANGELOG-v1.md'
         - v0: 'CHANGELOG-v0.md'
-      - Upgrade guide: upgrade-notes.md
+      - Upgrade notes: upgrade-notes.md
       # - Deprecations: deprecations.md
     - Support: support.md
   # - Setup:

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -545,12 +545,6 @@ namespace PSRule
                         comment: comment,
                         spec: deserializedSpec
                     );
-
-                    if (string.IsNullOrEmpty(apiVersion))
-                    {
-                        spec.SetApiVersionIssue();
-                    }
-
                     return true;
                 }
             }

--- a/src/PSRule/Common/ResourceExtensions.cs
+++ b/src/PSRule/Common/ResourceExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using PSRule.Definitions;
@@ -8,23 +8,14 @@ namespace PSRule
 {
     internal static class ResourceExtensions
     {
-        internal static void SetApiVersionIssue(this IResource resource)
+        internal static bool TryValidateResourceAnnotation(this IResource resource, out ValidateResourceAnnotation value)
         {
-            if (!(resource is IAnnotated<ResourceAnnotation> annotated))
-                return;
-
-            var validate = annotated.RequireAnnotation<ResourceAnnotation, ValidateResourceAnnotation>();
-            validate.ApiVersionNotSet = true;
-            annotated.SetAnnotation(validate);
-        }
-
-        internal static bool GetApiVersionIssue(this IResource resource)
-        {
+            value = null;
             if (!(resource is IAnnotated<ResourceAnnotation> annotated))
                 return false;
 
-            var validate = annotated.GetAnnotation<ValidateResourceAnnotation>();
-            return validate != null && validate.ApiVersionNotSet;
+            value = annotated.GetAnnotation<ValidateResourceAnnotation>();
+            return value != null;
         }
 
         internal static bool Match(this IResourceFilter filter, Baseline resource)

--- a/src/PSRule/Common/YamlConverters.cs
+++ b/src/PSRule/Common/YamlConverters.cs
@@ -599,9 +599,6 @@ namespace PSRule
                     return false;
 
                 spec = descriptor.CreateInstance(RunspaceContext.CurrentThread.Source.File, metadata, comment, value);
-                if (string.IsNullOrEmpty(apiVersion))
-                    spec.SetApiVersionIssue();
-
                 return true;
             }
             return false;

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -71,14 +71,20 @@ namespace PSRule.Definitions
         }
     }
 
+    /// <summary>
+    /// A base resource annotation.
+    /// </summary>
     internal abstract class ResourceAnnotation
     {
 
     }
 
+    /// <summary>
+    /// Annotation used to flag validation issues.
+    /// </summary>
     internal sealed class ValidateResourceAnnotation : ResourceAnnotation
     {
-        public bool ApiVersionNotSet { get; internal set; }
+
     }
 
     public sealed class ResourceObject

--- a/src/PSRule/Definitions/Spec.cs
+++ b/src/PSRule/Definitions/Spec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using PSRule.Definitions.Baselines;
@@ -16,9 +16,6 @@ namespace PSRule.Definitions
 
         public static string GetFullName(string apiVersion, string name)
         {
-            if (string.IsNullOrEmpty(apiVersion))
-                apiVersion = Specs.V1;
-
             return string.Concat(apiVersion, FullNameSeparator, name);
         }
     }

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -112,8 +112,7 @@ namespace PSRule.Pipeline
 
         internal enum ResourceIssueType
         {
-            Unknown,
-            MissingApiVersion
+            Unknown
         }
 
         internal sealed class ResourceIssue
@@ -161,9 +160,7 @@ namespace PSRule.Pipeline
 
         internal void Import(IResource resource)
         {
-            if (resource.GetApiVersionIssue())
-                _TrackedIssues.Add(new ResourceIssue(resource.Kind, resource.Id, ResourceIssueType.MissingApiVersion));
-
+            TrackIssue(resource);
             if (TryBaseline(resource, out Baseline baseline) && TryBaselineRef(resource.Id, out BaselineRef baselineRef))
             {
                 _Unresolved.Remove(baselineRef);
@@ -181,6 +178,12 @@ namespace PSRule.Pipeline
                 }
                 Baseline.Add(new OptionContext.ConfigScope(OptionContext.ScopeType.Module, resource.Module, moduleConfig.Spec));
             }
+        }
+
+        private void TrackIssue(IResource resource)
+        {
+            //if (resource.TryValidateResourceAnnotation())
+            //    _TrackedIssues.Add(new ResourceIssue(resource.Kind, resource.Id, ResourceIssueType.MissingApiVersion));
         }
 
         private bool TryBaselineRef(string resourceId, out BaselineRef baselineRef)
@@ -221,12 +224,18 @@ namespace PSRule.Pipeline
 
         internal void Begin(RunspaceContext runspaceContext)
         {
-            for (var i = 0; _TrackedIssues != null && i < _TrackedIssues.Count; i++)
-            {
-                if (_TrackedIssues[i].Issue == ResourceIssueType.MissingApiVersion)
-                    runspaceContext.WarnMissingApiVersion(_TrackedIssues[i].Kind, _TrackedIssues[i].Id);
-            }
+            ReportIssue(runspaceContext);
             Baseline.Init(runspaceContext);
+        }
+
+        /// <summary>
+        /// Report any tracked issues.
+        /// </summary>
+        private void ReportIssue(RunspaceContext runspaceContext)
+        {
+            //for (var i = 0; _TrackedIssues != null && i < _TrackedIssues.Count; i++)
+            //if (_TrackedIssues[i].Issue == ResourceIssueType.MissingApiVersion)
+            //    runspaceContext.WarnMissingApiVersion(_TrackedIssues[i].Kind, _TrackedIssues[i].Id);
         }
 
         #region IBindingContext

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -11,7 +11,6 @@ using System.Management.Automation;
 using System.Threading;
 using Newtonsoft.Json;
 using PSRule.Configuration;
-using PSRule.Definitions;
 using PSRule.Pipeline.Output;
 using PSRule.Resources;
 using YamlDotNet.Serialization;
@@ -117,9 +116,6 @@ namespace PSRule.Pipeline
                 Name = info.Name;
                 Version = info.Version?.ToString();
                 ProjectUri = info.ProjectUri?.ToString();
-                if (TryPrivateData(info, FIELD_PSRULE, out Hashtable moduleData))
-                    Baseline = moduleData.ContainsKey(FIELD_BASELINE) ? ResourceHelper.GetIdString(Name, moduleData[FIELD_BASELINE] as string) : null;
-
                 if (TryPrivateData(info, FIELD_PSDATA, out Hashtable psData) && psData.ContainsKey(FIELD_PRERELEASE))
                     Version = string.Concat(Version, PRERELEASE_SEPARATOR, psData[FIELD_PRERELEASE].ToString());
             }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources
-{
+namespace PSRule.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,713 +22,580 @@ namespace PSRule.Resources
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class PSRuleResources
-    {
-
+    internal class PSRuleResources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal PSRuleResources()
-        {
+        internal PSRuleResources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.PSRuleResources", typeof(PSRuleResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The baseline &apos;{0}&apos; is obsolete. Consider switching to an alternative baseline..
         /// </summary>
-        internal static string BaselineObsolete
-        {
-            get
-            {
+        internal static string BaselineObsolete {
+            get {
                 return ResourceManager.GetString("BaselineObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Binding functions are not supported in this language mode..
         /// </summary>
-        internal static string ConstrainedTargetBinding
-        {
-            get
-            {
+        internal static string ConstrainedTargetBinding {
+            get {
                 return ResourceManager.GetString("ConstrainedTargetBinding", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}: The property &apos;${1}.{2}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string DebugPropertyObsolete
-        {
-            get
-            {
+        internal static string DebugPropertyObsolete {
+            get {
                 return ResourceManager.GetString("DebugPropertyObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target failed If precondition.
         /// </summary>
-        internal static string DebugTargetIfMismatch
-        {
-            get
-            {
+        internal static string DebugTargetIfMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetIfMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target failed Type precondition.
         /// </summary>
-        internal static string DebugTargetTypeMismatch
-        {
-            get
-            {
+        internal static string DebugTargetTypeMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetTypeMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A circular rule dependency was detected. The rule &apos;{0}&apos; depends on &apos;{1}&apos; which also depend on &apos;{0}&apos;..
         /// </summary>
-        internal static string DependencyCircularReference
-        {
-            get
-            {
+        internal static string DependencyCircularReference {
+            get {
                 return ResourceManager.GetString("DependencyCircularReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The dependency &apos;{0}&apos; for &apos;{1}&apos; could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path..
         /// </summary>
-        internal static string DependencyNotFound
-        {
-            get
-            {
+        internal static string DependencyNotFound {
+            get {
                 return ResourceManager.GetString("DependencyNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleId
-        {
-            get
-            {
+        internal static string DuplicateRuleId {
+            get {
                 return ResourceManager.GetString("DuplicateRuleId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} : Reported &apos;{1}&apos;. At {2}:{3} char:{4}.
         /// </summary>
-        internal static string ErrorDetailMessage
-        {
-            get
-            {
+        internal static string ErrorDetailMessage {
+            get {
                 return ResourceManager.GetString("ErrorDetailMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more errors occured..
         /// </summary>
-        internal static string ErrorPipelineException
-        {
-            get
-            {
+        internal static string ErrorPipelineException {
+            get {
                 return ResourceManager.GetString("ErrorPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exists: {0}.
         /// </summary>
-        internal static string ExistsTrue
-        {
-            get
-            {
+        internal static string ExistsTrue {
+            get {
                 return ResourceManager.GetString("ExistsTrue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to File.
         /// </summary>
-        internal static string FileSourceType
-        {
-            get
-            {
+        internal static string FileSourceType {
+            get {
                 return ResourceManager.GetString("FileSourceType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
         /// </summary>
-        internal static string FoundModules
-        {
-            get
-            {
+        internal static string FoundModules {
+            get {
                 return ResourceManager.GetString("FoundModules", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported..
         /// </summary>
-        internal static string InvalidErrorAction
-        {
-            get
-            {
+        internal static string InvalidErrorAction {
+            get {
                 return ResourceManager.GetString("InvalidErrorAction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule nesting was detected for rule at {0}. Rules must not be nested..
         /// </summary>
-        internal static string InvalidRuleNesting
-        {
-            get
-            {
+        internal static string InvalidRuleNesting {
+            get {
                 return ResourceManager.GetString("InvalidRuleNesting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An invalid rule result was returned for {0}. Conditions must return boolean $True or $False..
         /// </summary>
-        internal static string InvalidRuleResult
-        {
-            get
-            {
+        internal static string InvalidRuleResult {
+            get {
                 return ResourceManager.GetString("InvalidRuleResult", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string KeywordConditionScope
-        {
-            get
-            {
+        internal static string KeywordConditionScope {
+            get {
                 return ResourceManager.GetString("KeywordConditionScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block or script precondition..
         /// </summary>
-        internal static string KeywordRuleScope
-        {
-            get
-            {
+        internal static string KeywordRuleScope {
+            get {
                 return ResourceManager.GetString("KeywordRuleScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can not be nested in a Rule block..
         /// </summary>
-        internal static string KeywordSourceScope
-        {
-            get
-            {
+        internal static string KeywordSourceScope {
+            get {
                 return ResourceManager.GetString("KeywordSourceScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1} {0} {2}.
         /// </summary>
-        internal static string LanguageExpressionTrace
-        {
-            get
-            {
+        internal static string LanguageExpressionTrace {
+            get {
                 return ResourceManager.GetString("LanguageExpressionTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please open your browser to the following location: {0}.
         /// </summary>
-        internal static string LaunchBrowser
-        {
-            get
-            {
+        internal static string LaunchBrowser {
+            get {
                 return ResourceManager.GetString("LaunchBrowser", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Wildcard match requires exactly one name..
         /// </summary>
-        internal static string MatchSingleName
-        {
-            get
-            {
+        internal static string MatchSingleName {
+            get {
                 return ResourceManager.GetString("MatchSingleName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Matches: {0}.
         /// </summary>
-        internal static string MatchTrue
-        {
-            get
-            {
+        internal static string MatchTrue {
+            get {
                 return ResourceManager.GetString("MatchTrue", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The {0} resource {1} does not have an apiVersion set. An apiVersion will be required in the next major version..
-        /// </summary>
-        internal static string MissingApiVersion
-        {
-            get
-            {
-                return ResourceManager.GetString("MissingApiVersion", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Update module &apos;{0}&apos; to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config..
         /// </summary>
-        internal static string ModuleManifestBaseline
-        {
-            get
-            {
+        internal static string ModuleManifestBaseline {
+            get {
                 return ResourceManager.GetString("ModuleManifestBaseline", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target object &apos;{0}&apos; has not been processed because no matching rules were found..
         /// </summary>
-        internal static string ObjectNotProcessed
-        {
-            get
-            {
+        internal static string ObjectNotProcessed {
+            get {
                 return ResourceManager.GetString("ObjectNotProcessed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Options file does not exist..
         /// </summary>
-        internal static string OptionsNotFound
-        {
-            get
-            {
+        internal static string OptionsNotFound {
+            get {
                 return ResourceManager.GetString("OptionsNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to # Source: {0}.
         /// </summary>
-        internal static string OptionsSourceComment
-        {
-            get
-            {
+        internal static string OptionsSourceComment {
+            get {
                 return ResourceManager.GetString("OptionsSourceComment", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
-        internal static string OutcomeError
-        {
-            get
-            {
+        internal static string OutcomeError {
+            get {
                 return ResourceManager.GetString("OutcomeError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Fail.
         /// </summary>
-        internal static string OutcomeFail
-        {
-            get
-            {
+        internal static string OutcomeFail {
+            get {
                 return ResourceManager.GetString("OutcomeFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Pass.
         /// </summary>
-        internal static string OutcomePass
-        {
-            get
-            {
+        internal static string OutcomePass {
+            get {
                 return ResourceManager.GetString("OutcomePass", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRuleFail
-        {
-            get
-            {
+        internal static string OutcomeRuleFail {
+            get {
                 return ResourceManager.GetString("OutcomeRuleFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PASS] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRulePass
-        {
-            get
-            {
+        internal static string OutcomeRulePass {
+            get {
                 return ResourceManager.GetString("OutcomeRulePass", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
-        internal static string OutcomeUnknown
-        {
-            get
-            {
+        internal static string OutcomeUnknown {
+            get {
                 return ResourceManager.GetString("OutcomeUnknown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The property &apos;${0}.{1}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string PropertyObsolete
-        {
-            get
-            {
+        internal static string PropertyObsolete {
+            get {
                 return ResourceManager.GetString("PropertyObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize the file &apos;{0}&apos;: {1}.
         /// </summary>
-        internal static string ReadFileFailed
-        {
-            get
-            {
+        internal static string ReadFileFailed {
+            get {
                 return ResourceManager.GetString("ReadFileFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
-        internal static string ReadJsonFailed
-        {
-            get
-            {
+        internal static string ReadJsonFailed {
+            get {
                 return ResourceManager.GetString("ReadJsonFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The module version &apos;{1}&apos; for &apos;{0}&apos; does not match the required version &apos;{2}&apos;. To continue, first update the module to match the version requirement..
         /// </summary>
-        internal static string RequiredVersionMismatch
-        {
-            get
-            {
+        internal static string RequiredVersionMismatch {
+            get {
                 return ResourceManager.GetString("RequiredVersionMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to One or more rules reported errors..
+        ///   Looks up a localized string similar to {0} rule/s were suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleErrorPipelineException
-        {
-            get
-            {
-                return ResourceManager.GetString("RuleErrorPipelineException", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to One or more rules reported failure..
-        /// </summary>
-        internal static string RuleFailPipelineException
-        {
-            get
-            {
-                return ResourceManager.GetString("RuleFailPipelineException", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
-        /// </summary>
-        internal static string RuleInconclusive
-        {
-            get
-            {
-                return ResourceManager.GetString("RuleInconclusive", resourceCulture);
-            }
-        }
-
-        internal static string RuleSuppressed
-        {
-            get
-            {
-                return ResourceManager.GetString("RuleSuppressed", resourceCulture);
-            }
-        }
-
-        internal static string RuleCountSuppressed
-        {
-            get
-            {
+        internal static string RuleCountSuppressed {
+            get {
                 return ResourceManager.GetString("RuleCountSuppressed", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One or more rules reported errors..
+        /// </summary>
+        internal static string RuleErrorPipelineException {
+            get {
+                return ResourceManager.GetString("RuleErrorPipelineException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to One or more rules reported failure..
+        /// </summary>
+        internal static string RuleFailPipelineException {
+            get {
+                return ResourceManager.GetString("RuleFailPipelineException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
+        /// </summary>
+        internal static string RuleInconclusive {
+            get {
+                return ResourceManager.GetString("RuleInconclusive", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find a matching rule. Please check that Path, Name and Tag parameters are correct..
         /// </summary>
-        internal static string RuleNotFound
-        {
-            get
-            {
+        internal static string RuleNotFound {
+            get {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find required rule definition parameter &apos;{0}&apos; on rule at {1}..
         /// </summary>
-        internal static string RuleParameterNotFound
-        {
-            get
-            {
+        internal static string RuleParameterNotFound {
+            get {
                 return ResourceManager.GetString("RuleParameterNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No matching .Rule.ps1 files were found. Rule definitions should be saved into script files with the .Rule.ps1 extension..
         /// </summary>
-        internal static string RulePathNotFound
-        {
-            get
-            {
+        internal static string RulePathNotFound {
+            get {
                 return ResourceManager.GetString("RulePathNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to at Rule &apos;{0}&apos;, {1}: line {2}.
         /// </summary>
-        internal static string RuleStackTrace
-        {
-            get
-            {
+        internal static string RuleStackTrace {
+            get {
                 return ResourceManager.GetString("RuleStackTrace", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed for &apos;{1}&apos;..
+        /// </summary>
+        internal static string RuleSuppressed {
+            get {
+                return ResourceManager.GetString("RuleSuppressed", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
         /// </summary>
-        internal static string ScanModule
-        {
-            get
-            {
+        internal static string ScanModule {
+            get {
                 return ResourceManager.GetString("ScanModule", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files: {0}.
         /// </summary>
-        internal static string ScanSource
-        {
-            get
-            {
+        internal static string ScanSource {
+            get {
                 return ResourceManager.GetString("ScanSource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The script was not found..
         /// </summary>
-        internal static string ScriptNotFound
-        {
-            get
-            {
+        internal static string ScriptNotFound {
+            get {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}.
         /// </summary>
-        internal static string SelectorMatchTrace
-        {
-            get
-            {
+        internal static string SelectorMatchTrace {
+            get {
                 return ResourceManager.GetString("SelectorMatchTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1}.
         /// </summary>
-        internal static string SelectorTrace
-        {
-            get
-            {
+        internal static string SelectorTrace {
+            get {
                 return ResourceManager.GetString("SelectorTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Can not serialize a null PSObject..
         /// </summary>
-        internal static string SerializeNullPSObject
-        {
-            get
-            {
+        internal static string SerializeNullPSObject {
+            get {
                 return ResourceManager.GetString("SerializeNullPSObject", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Create path.
         /// </summary>
-        internal static string ShouldCreatePath
-        {
-            get
-            {
+        internal static string ShouldCreatePath {
+            get {
                 return ResourceManager.GetString("ShouldCreatePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Write file.
         /// </summary>
-        internal static string ShouldWriteFile
-        {
-            get
-            {
+        internal static string ShouldWriteFile {
+            get {
                 return ResourceManager.GetString("ShouldWriteFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The source was not found..
         /// </summary>
-        internal static string SourceNotFound
-        {
-            get
-            {
+        internal static string SourceNotFound {
+            get {
                 return ResourceManager.GetString("SourceNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Using invariant culture may cause rule infomation to be displayed incorrectly. Consider using -Culture or set the Output.Culture option..
         /// </summary>
-        internal static string UsingInvariantCulture
-        {
-            get
-            {
+        internal static string UsingInvariantCulture {
+            get {
                 return ResourceManager.GetString("UsingInvariantCulture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The variable &apos;${0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string VariableConditionScope
-        {
-            get
-            {
+        internal static string VariableConditionScope {
+            get {
                 return ResourceManager.GetString("VariableConditionScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The version constraint &apos;{0}&apos; is not valid..
         /// </summary>
-        internal static string VersionConstraintInvalid
-        {
-            get
-            {
+        internal static string VersionConstraintInvalid {
+            get {
                 return ResourceManager.GetString("VersionConstraintInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The Within parameter Value must be a string when the Like parameter is used..
         /// </summary>
-        internal static string WithinLikeNotString
-        {
-            get
-            {
+        internal static string WithinLikeNotString {
+            get {
                 return ResourceManager.GetString("WithinLikeNotString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Within: {0}.
         /// </summary>
-        internal static string WithinTrue
-        {
-            get
-            {
+        internal static string WithinTrue {
+            get {
                 return ResourceManager.GetString("WithinTrue", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -191,9 +191,6 @@
   <data name="MatchTrue" xml:space="preserve">
     <value>Matches: {0}</value>
   </data>
-  <data name="MissingApiVersion" xml:space="preserve">
-    <value>The {0} resource {1} does not have an apiVersion set. An apiVersion will be required in the next major version.</value>
-  </data>
   <data name="ModuleManifestBaseline" xml:space="preserve">
     <value>Update module '{0}' to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config.</value>
   </data>

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -268,14 +268,6 @@ namespace PSRule.Runtime
             Writer.WriteDebug(PSRuleResources.DebugPropertyObsolete, RuleBlock.RuleName, variableName, propertyName);
         }
 
-        public void WarnMissingApiVersion(ResourceKind kind, string resourceId)
-        {
-            if (Writer == null || !Writer.ShouldWriteWarning())
-                return;
-
-            Writer.WriteWarning(PSRuleResources.MissingApiVersion, kind.ToString(), resourceId);
-        }
-
         public void ErrorInvaildRuleResult()
         {
             if (Writer == null || !Writer.ShouldWriteError())

--- a/tests/PSRule.Tests/Baseline.Rule.yaml
+++ b/tests/PSRule.Tests/Baseline.Rule.yaml
@@ -72,6 +72,7 @@ spec:
 
 ---
 # Synopsis: This is an example obsolete baseline
+apiVersion: github.com/microsoft/PSRule/v1
 kind: Baseline
 metadata:
   name: TestBaseline5

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -31,7 +31,6 @@ namespace PSRule
             Assert.Equal("github.com/microsoft/PSRule/v1", baseline[0].ApiVersion);
             Assert.Equal("value", baseline[0].Metadata.Annotations["key"]);
             Assert.False(baseline[0].Obsolete);
-            Assert.False(baseline[0].GetApiVersionIssue());
 
             var config = baseline[0].Spec.Configuration["key2"] as Array;
             Assert.NotNull(config);
@@ -46,7 +45,6 @@ namespace PSRule
             Assert.Equal("TestBaseline5", baseline[4].Name);
             Assert.Equal("github.com/microsoft/PSRule/v1", baseline[4].ApiVersion);
             Assert.True(baseline[4].Obsolete);
-            Assert.True(baseline[4].GetApiVersionIssue());
         }
 
         [Fact]
@@ -61,7 +59,6 @@ namespace PSRule
             Assert.Equal("github.com/microsoft/PSRule/v1", baseline[0].ApiVersion);
             Assert.Equal("value", baseline[0].Metadata.Annotations["key"]);
             Assert.False(baseline[0].Obsolete);
-            Assert.False(baseline[0].GetApiVersionIssue());
         }
 
         [Fact]

--- a/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Baseline.Tests.ps1
@@ -702,14 +702,11 @@ Describe 'Baseline' -Tag 'Baseline' {
             # Not obsolete
             $Null = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline1' -WarningVariable outWarn -WarningAction SilentlyContinue);
             $warnings = @($outWarn);
-            $warnings.Length | Should -Be 1;
-            $warnings | Should -BeLike "The * resource * does not have an apiVersion set.*";
+            $warnings.Length | Should -Be 0;
 
             # Obsolete
             $Null = @($testObject | Invoke-PSRule -Path $ruleFilePath,$baselineFilePath -Baseline 'TestBaseline5' -WarningVariable outWarn -WarningAction SilentlyContinue);
-            $warnings = @($outWarn | Where-Object {
-                $_ -notlike "The * resource * does not have an apiVersion set.*"
-            });
+            $warnings = @($outWarn);
             $warnings.Length | Should -Be 1;
             $warnings[0] | Should -BeExactly "The baseline 'TestBaseline5' is obsolete. Consider switching to an alternative baseline.";
         }
@@ -803,8 +800,7 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result.Length | Should -Be 1;
             $result[0].RuleName | Should -Be 'M6.Rule1';
             $warnings = @($outWarn);
-            $warnings.Length | Should -Be 1;
-            $warnings | Should -BeExactly "Update module 'TestModule6' to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config.";
+            $warnings.Length | Should -Be 0;
 
             # Module default via manifest
             $Null = Import-Module (Join-Path $here -ChildPath 'TestModule7') -Force;
@@ -813,8 +809,7 @@ Describe 'Baseline' -Tag 'Baseline' {
             $result.Length | Should -Be 1;
             $result[0].RuleName | Should -Be 'M7.Rule2';
             $warnings = @($outWarn);
-            $warnings.Length | Should -Be 1;
-            $warnings | Should -BeExactly "Update module 'TestModule7' to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config.";
+            $warnings.Length | Should -Be 0;
         }
     }
 

--- a/tests/PSRule.Tests/TestModule6/TestModule6.psd1
+++ b/tests/PSRule.Tests/TestModule6/TestModule6.psd1
@@ -106,9 +106,6 @@ PrivateData = @{
         # ReleaseNotes of this module
         # ReleaseNotes = ''
     } # End of PSData hashtable
-    PSRule = @{
-        Baseline = 'Module6b'
-    }
 } # End of PrivateData hashtable
 
 # HelpInfo URI of this module

--- a/tests/PSRule.Tests/TestModule7/TestModule7.psd1
+++ b/tests/PSRule.Tests/TestModule7/TestModule7.psd1
@@ -106,9 +106,6 @@ PrivateData = @{
         # ReleaseNotes of this module
         # ReleaseNotes = ''
     } # End of PSData hashtable
-    PSRule = @{
-        Baseline = 'Module7'
-    }
 } # End of PrivateData hashtable
 
 # HelpInfo URI of this module


### PR DESCRIPTION
## PR Summary

- **Breaking change:** Removal of deprecated default baseline from module manifest. #755
  - Set the default module baseline using module configuration.
- **Breaking change:** Require `apiVersion` on YAML and JSON to be specified. #648
  - Resources should use `github.com/microsoft/PSRule/v1` as the `apiVersion`.
  - Resources that do not specify an `apiVersion` will be ignored.

Fixes #755 
Fixes #648 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
