### PR TITLE
Added support for Suppression Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Next release
 
-- v2 **Comming soon** - Please check out [upgrade notes][1] to get prepared for the next release.
+- v2 **Coming soon** - Please check out [upgrade notes][1] to get prepared for the next release.
 
 ## Current release
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Suppression](docs/concepts/PSRule/en-US/about_PSRule_Options.md#suppression)
 - [Rules](docs/concepts/PSRule/en-US/about_PSRule_Rules.md)
 - [Selectors](docs/concepts/PSRule/en-US/about_PSRule_Selectors.md)
+- [Suppression Groups](docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md)
 - [Variables](docs/concepts/PSRule/en-US/about_PSRule_Variables.md)
   - [$Assert](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#assert)
   - [$Configuration](docs/concepts/PSRule/en-US/about_PSRule_Variables.md#configuration)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -13,7 +13,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v2.0.0-B2201075:
 
-- General improvements:
+- New features:
   - Add support for suppression groups. [#793](https://github.com/microsoft/PSRule/issues/793)
     - New `SuppressionGroup` resource has been included.
     - See [about_PSRule_SuppressionGroups] for details.

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2201075:
+
+- General improvements:
+  - Add support for suppression groups. [#793](https://github.com/microsoft/PSRule/issues/793)
+    - New `SuppressionGroup` resource has been included.
+    - See [about_PSRule_SuppressionGroups] for details.
+
 ## v2.0.0-B2201075 (pre-release)
 
 What's changed since pre-release v2.0.0-B2201054:
@@ -835,3 +842,4 @@ What's changed since v0.22.0:
 [about_PSRule_Rules]: concepts/PSRule/en-US/about_PSRule_Rules.md
 [about_PSRule_Badges]: concepts/PSRule/en-US/about_PSRule_Badges.md
 [about_PSRule_Expressions]: concepts/PSRule/en-US/about_PSRule_Expressions.md
+[about_PSRule_SuppressionGroups]: concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md

--- a/docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
@@ -1,0 +1,154 @@
+# PSRule_SuppressionGroups
+
+## about_PSRule_SuppressionGroups
+
+## SHORT DESCRIPTION
+
+Describes PSRule Suppression Groups including how to use and author them.
+
+## LONG DESCRIPTION
+
+PSRule executes rules to validate an object from input.
+When an evaluating an object from input, PSRule can use suppression groups to suppress rules based on a [Selector](about_PSRule_Selectors.md).
+
+## Defining suppression groups
+
+Suppression groups can be defined with either YAML or JSON format, and can be included with a module or a standalone `.Rule.yaml` or `.Rule.jsonc` file.
+In either case, define a selector within a file ending with the `.Rule.yaml` or `.Rule.jsonc` extension.
+A suppression group can be defined side-by-side with other resources such as rules, baselines or module configurations.
+
+Suppression groups can also be defined within `.json` files.
+We recommend using `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
+
+Use the following template to define a suppression group:
+
+```yaml
+---
+# Synopsis: {{ Synopsis }}
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: '{{ Name }}'
+spec:
+  rule: []
+  if: { }
+```
+
+```jsonc
+[
+  {
+    // Synopsis: {{ Synopsis }}
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "SuppressionGroup",
+    "metadata": {
+      "name": "{{ Name }}"
+    },
+    "spec": {
+      "rule": [],
+      "if": {}
+    }
+  }
+]
+```
+
+Within the `rule` array, one or more rule names can be used.
+Within the `if` object, one or more conditions or logical operators can be used.
+
+## EXAMPLES
+
+### Example SuppressionGroups.Rule.yaml
+
+```yaml
+# Example SuppressionGroups.Rule.yaml
+
+---
+# Synopsis: Suppress with target name
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithTargetName
+spec:
+  rule:
+  - 'FromFile1'
+  - 'FromFile2'
+  if:
+    name: '.'
+    in:
+    - 'TestObject1'
+    - 'TestObject2'
+
+---
+# Synopsis: Suppress with target type
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithTestType
+spec:
+  rule:
+  - 'FromFile3'
+  - 'FromFile5'
+  if:
+    type: '.'
+    equals: 'TestType'
+```
+
+### Example SuppressionGroups.Rule.jsonc
+
+```jsonc
+// Example SuppressionGroups.Rule.jsonc
+[
+  {
+    // Synopsis: Suppress with target name
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "SuppressionGroup",
+    "metadata": {
+      "name": "SuppressWithTargetName"
+    },
+    "spec": {
+      "rule": [
+        "FromFile1",
+        "FromFile2"
+      ],
+      "if": {
+        "name": ".",
+        "in": [
+          "TestObject1",
+          "TestObject2"
+        ]
+      }
+    }
+  },
+  {
+    // Synopsis: Suppress with target type
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "SuppressionGroup",
+    "metadata": {
+      "name": "SuppressWithTestType"
+    },
+    "spec": {
+      "rule": [
+        "FromFile3",
+        "FromFile5"
+      ],
+      "if": {
+        "type": ".",
+        "equals": "TestType"
+      }
+    }
+  }
+]
+```
+
+## NOTE
+
+An online version of this document is available at https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md.
+
+## SEE ALSO
+
+- [Invoke-PSRule](https://microsoft.github.io/PSRule/commands/PSRule/en-US/Invoke-PSRule.html)
+
+## KEYWORDS
+
+- SuppressionGroups
+- Selectors
+- PSRule

--- a/docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
@@ -14,7 +14,7 @@ When an evaluating an object from input, PSRule can use suppression groups to su
 ## Defining suppression groups
 
 Suppression groups can be defined with either YAML or JSON format, and can be included with a module or a standalone `.Rule.yaml` or `.Rule.jsonc` file.
-In either case, define a selector within a file ending with the `.Rule.yaml` or `.Rule.jsonc` extension.
+In either case, define a suppression group within a file ending with the `.Rule.yaml` or `.Rule.jsonc` extension.
 A suppression group can be defined side-by-side with other resources such as rules, baselines or module configurations.
 
 Suppression groups can also be defined within `.json` files.
@@ -52,7 +52,9 @@ spec:
 ```
 
 Within the `rule` array, one or more rule names can be used.
+If no rules are specified, suppression will occur for all rules.
 Within the `if` object, one or more conditions or logical operators can be used.
+When the `if` condition is `true` the object will be suppressed for the current rule.
 
 ## EXAMPLES
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -26,6 +26,7 @@ def replace_maml(markdown: str, page: mkdocs.structure.nav.Page, config: mkdocs.
     markdown = markdown.replace("## about_PSRule_Options", "")
     markdown = markdown.replace("## about_PSRule_Rules", "")
     markdown = markdown.replace("## about_PSRule_Selectors", "")
+    markdown = markdown.replace("## about_PSRule_SuppressionGroups", "")
     markdown = markdown.replace("## about_PSRule_Variables", "")
     markdown = markdown.replace("# PSRule_Assert", "# Assertion helpers")
     markdown = markdown.replace("# PSRule_Baseline", "# Baselines")
@@ -37,6 +38,7 @@ def replace_maml(markdown: str, page: mkdocs.structure.nav.Page, config: mkdocs.
     markdown = markdown.replace("# PSRule_Options", "# Options")
     markdown = markdown.replace("# PSRule_Rules", "# Rules")
     markdown = markdown.replace("# PSRule_Selectors", "# Selectors")
+    markdown = markdown.replace("# PSRule_SuppressionGroups", "# Suppression Groups")
     markdown = markdown.replace("# PSRule_Variables", "# Variables")
 
     # Rules

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
     - Options: concepts/PSRule/en-US/about_PSRule_Options.md
     - Rules: concepts/PSRule/en-US/about_PSRule_Rules.md
     - Selectors: concepts/PSRule/en-US/about_PSRule_Selectors.md
+    - Suppression Groups: concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
     - Variables: concepts/PSRule/en-US/about_PSRule_Variables.md
   - Addons:
     - Additional modules: addon-modules.md

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -12,6 +12,9 @@
         },
         {
             "$ref": "#/definitions/selector-v1"
+        },
+        {
+            "$ref": "#/definitions/suppressionGroup-v1"
         }
     ],
     "definitions": {
@@ -435,6 +438,68 @@
             "title": "Spec",
             "description": "PSRule selector specification.",
             "properties": {
+                "if": {
+                    "type": "object",
+                    "$ref": "#/definitions/selectorExpression"
+                }
+            },
+            "required": [
+                "if"
+            ],
+            "additionalProperties": false
+        },
+        "suppressionGroup-v1": {
+            "type": "object",
+            "title": "SuppressionGroup",
+            "description": "A PSRule Suppression Group",
+            "markdownDescription": "A PSRule Suppression Group. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.html)",
+            "properties": {
+                "apiVersion": {
+                    "type": "string",
+                    "title": "API Version",
+                    "description": "The API Version for the PSRule resources.",
+                    "enum": [
+                        "github.com/microsoft/PSRule/v1"
+                    ]
+                },
+                "kind": {
+                    "type": "string",
+                    "title": "Kind",
+                    "description": "A PSRule SuppressionGroup resource.",
+                    "enum": [
+                        "SuppressionGroup"
+                    ]
+                },
+                "metadata": {
+                    "type": "object",
+                    "$ref": "#/definitions/resource-metadata"
+                },
+                "spec": {
+                    "type": "object",
+                    "$ref": "#/definitions/suppressionGroupSpec"
+                }
+            },
+            "required": [
+                "apiVersion",
+                "kind",
+                "metadata",
+                "spec"
+            ]
+        },
+        "suppressionGroupSpec": {
+            "type": "object",
+            "title": "Spec",
+            "description": "PSRule Suppression Group specification.",
+            "properties": {
+                "rule": {
+                    "type": "array",
+                    "title": "Rule pre-condition",
+                    "description": "This only applies to rules that match the specified rule names",
+                    "items": {
+                        "type": "string"
+                    },
+                    "uniqueItems": true
+                },
                 "if": {
                     "type": "object",
                     "$ref": "#/definitions/selectorExpression"

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -452,7 +452,7 @@
             "type": "object",
             "title": "SuppressionGroup",
             "description": "A PSRule Suppression Group",
-            "markdownDescription": "A PSRule Suppression Group. [See help](https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.html)",
+            "markdownDescription": "A PSRule Suppression Group. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_SuppressionGroups/)",
             "properties": {
                 "apiVersion": {
                     "type": "string",

--- a/schemas/PSRule-resources.schema.json
+++ b/schemas/PSRule-resources.schema.json
@@ -16,6 +16,9 @@
             },
             {
                 "$ref": "https://raw.githubusercontent.com/microsoft/PSRule/main/schemas/PSRule-language.schema.json#/definitions/selector-v1"
+            },
+            {
+                "$ref": "https://raw.githubusercontent.com/microsoft/PSRule/main/schemas/PSRule-language.schema.json#/definitions/suppressionGroup-v1"
             }
         ]
     }

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -253,14 +253,21 @@ namespace PSRule.Definitions.Expressions
             if (rule == null || rule.Length == 0)
                 return true;
 
-            var comparer = RunspaceContext.CurrentThread.Pipeline.Baseline.GetTargetBinding().IgnoreCase
+            var context = RunspaceContext.CurrentThread;
+
+            var stringComparer = context.Pipeline.Baseline.GetTargetBinding().IgnoreCase
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
 
-            var ruleName = RunspaceContext.CurrentThread.RuleRecord.RuleName;
+            var resourceIdComparer = new ResourceIdEqualityComparer();
+
+            var ruleRecord = context.RuleRecord;
+            var ruleName = ruleRecord.RuleName;
+            var ruleId = ruleRecord.RuleId;
+
             for (var i = 0; i < rule.Length; i++)
             {
-                if (comparer.Equals(ruleName, rule[i]))
+                if (stringComparer.Equals(ruleName, rule[i]) || resourceIdComparer.Equals(ruleId, rule[i]))
                     return true;
             }
             return false;

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -251,9 +251,7 @@ namespace PSRule.Definitions.Expressions
         private static bool AcceptsRule(string[] rule)
         {
             if (rule == null || rule.Length == 0)
-            {
                 return true;
-            }
 
             var comparer = RunspaceContext.CurrentThread.Pipeline.Baseline.GetTargetBinding().IgnoreCase
                 ? StringComparer.OrdinalIgnoreCase
@@ -263,9 +261,7 @@ namespace PSRule.Definitions.Expressions
             for (var i = 0; i < rule.Length; i++)
             {
                 if (comparer.Equals(ruleName, rule[i]))
-                {
                     return true;
-                }
             }
             return false;
         }

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -73,6 +73,7 @@ namespace PSRule.Definitions.Expressions
 
         private string[] _With;
         private string[] _Type;
+        private string[] _Rule;
 
         public LanguageExpressionBuilder(bool debugger = true)
         {
@@ -97,12 +98,21 @@ namespace PSRule.Definitions.Expressions
             return this;
         }
 
-        public LanguageExpressionOuterFn Build(LanguageIf selectorIf)
+        public LanguageExpressionBuilder WithRule(string[] rule)
         {
-            return Precondition(Expression(string.Empty, selectorIf.Expression), _With, _Type);
+            if (rule == null || rule.Length == 0)
+                return this;
+
+            _Rule = rule;
+            return this;
         }
 
-        private static LanguageExpressionOuterFn Precondition(LanguageExpressionOuterFn expression, string[] with, string[] type)
+        public LanguageExpressionOuterFn Build(LanguageIf selectorIf)
+        {
+            return Precondition(Expression(string.Empty, selectorIf.Expression), _With, _Type, _Rule);
+        }
+
+        private static LanguageExpressionOuterFn Precondition(LanguageExpressionOuterFn expression, string[] with, string[] type, string[] rule)
         {
             var fn = expression;
             if (type != null)
@@ -111,7 +121,24 @@ namespace PSRule.Definitions.Expressions
             if (with != null)
                 fn = PreconditionSelector(with, fn);
 
+            if (rule != null)
+                fn = PreconditionRule(rule, fn);
+
             return fn;
+        }
+
+        private static LanguageExpressionOuterFn PreconditionRule(string[] rule, LanguageExpressionOuterFn fn)
+        {
+            return (context, o) =>
+            {
+                // Evaluate selector rule pre-condition
+                if (!AcceptsRule(rule))
+                {
+                    context.Debug(PSRuleResources.DebugTargetRuleMismatch);
+                    return null;
+                }
+                return fn(context, o);
+            };
         }
 
         private static LanguageExpressionOuterFn PreconditionSelector(string[] with, LanguageExpressionOuterFn fn)
@@ -217,6 +244,28 @@ namespace PSRule.Definitions.Expressions
             {
                 if (RunspaceContext.CurrentThread.TrySelector(with[i]))
                     return true;
+            }
+            return false;
+        }
+
+        private static bool AcceptsRule(string[] rule)
+        {
+            if (rule == null || rule.Length == 0)
+            {
+                return true;
+            }
+
+            var comparer = RunspaceContext.CurrentThread.Pipeline.Baseline.GetTargetBinding().IgnoreCase
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+
+            var ruleName = RunspaceContext.CurrentThread.RuleRecord.RuleName;
+            for (var i = 0; i < rule.Length; i++)
+            {
+                if (comparer.Equals(ruleName, rule[i]))
+                {
+                    return true;
+                }
             }
             return false;
         }

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -44,7 +44,12 @@ namespace PSRule.Definitions
         /// <summary>
         /// A convention.
         /// </summary>
-        Convention = 5
+        Convention = 5,
+
+        /// <summary>
+        /// A suppression group.
+        /// </summary>
+        SuppressionGroup = 6
     }
 
     [Flags]

--- a/src/PSRule/Definitions/ResourceId.cs
+++ b/src/PSRule/Definitions/ResourceId.cs
@@ -148,7 +148,7 @@ namespace PSRule.Definitions
     }
 
     /// <summary>
-    /// Compares to resource identifiers to determine if they are equal.
+    /// Compares two resource identifiers to determine if they are equal.
     /// </summary>
     internal sealed class ResourceIdEqualityComparer : IEqualityComparer<ResourceId>, IEqualityComparer<string>
     {

--- a/src/PSRule/Definitions/ResourceIndex.cs
+++ b/src/PSRule/Definitions/ResourceIndex.cs
@@ -53,5 +53,10 @@ namespace PSRule.Definitions
             }
             return results.ToArray();
         }
+
+        public bool IsEmpty()
+        {
+            return _Items == null || _Items.Length == 0;
+        }
     }
 }

--- a/src/PSRule/Definitions/Spec.cs
+++ b/src/PSRule/Definitions/Spec.cs
@@ -5,6 +5,7 @@ using PSRule.Definitions.Baselines;
 using PSRule.Definitions.ModuleConfigs;
 using PSRule.Definitions.Rules;
 using PSRule.Definitions.Selectors;
+using PSRule.Definitions.SuppressionGroups;
 
 namespace PSRule.Definitions
 {
@@ -28,6 +29,7 @@ namespace PSRule.Definitions
         internal const string Baseline = "Baseline";
         internal const string ModuleConfig = "ModuleConfig";
         internal const string Selector = "Selector";
+        internal const string SuppressionGroup = "SuppressionGroup";
 
         public readonly static ISpecDescriptor[] BuiltinTypes = new ISpecDescriptor[]
         {
@@ -35,6 +37,7 @@ namespace PSRule.Definitions
             new SpecDescriptor<Baseline, BaselineSpec>(V1, Baseline),
             new SpecDescriptor<ModuleConfigV1, ModuleConfigV1Spec>(V1, ModuleConfig),
             new SpecDescriptor<SelectorV1, SelectorV1Spec>(V1, Selector),
+            new SpecDescriptor<SuppressionGroupV1, SuppressionGroupV1Spec>(V1, SuppressionGroup)
         };
     }
 }

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroup.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroup.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Definitions.Expressions;
+using PSRule.Pipeline;
+
+namespace PSRule.Definitions.SuppressionGroups
+{
+    [Spec(Specs.V1, Specs.SuppressionGroup)]
+    internal sealed class SuppressionGroupV1 : InternalResource<SuppressionGroupV1Spec>
+    {
+        public SuppressionGroupV1(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, SuppressionGroupV1Spec spec)
+            : base(ResourceKind.SuppressionGroup, apiVersion, source, metadata, info, spec) { }
+    }
+
+    internal interface ISuppressionGroupSpec
+    {
+        string[] Rule { get; }
+
+        LanguageIf If { get; }
+    }
+
+    internal sealed class SuppressionGroupV1Spec : Spec, ISuppressionGroupSpec
+    {
+        public string[] Rule { get; set; }
+
+        public LanguageIf If { get; set; }
+    }
+}

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
@@ -11,20 +11,23 @@ namespace PSRule.Definitions.SuppressionGroups
     {
         private readonly LanguageExpressionOuterFn _Fn;
 
-        public Guid InstanceId { get; }
-
         public string Module { get; }
 
         public string Id { get; }
+
+        public Guid InstanceId { get; }
+
+        public string[] Rule { get; }
 
         public SuppressionGroupVisitor(string module, string id, ISuppressionGroupSpec spec)
         {
             Module = module;
             Id = id;
             InstanceId = Guid.NewGuid();
+            Rule = spec.Rule;
             var builder = new LanguageExpressionBuilder();
             _Fn = builder
-                .WithRule(spec.Rule)
+                .WithRule(Rule)
                 .Build(spec.If);
         }
 

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using PSRule.Definitions.Expressions;
+using PSRule.Resources;
+
+namespace PSRule.Definitions.SuppressionGroups
+{
+    internal sealed class SuppressionGroupVisitor
+    {
+        private readonly LanguageExpressionOuterFn _Fn;
+
+        public Guid InstanceId { get; }
+
+        public string Module { get; }
+
+        public string Id { get; }
+
+        public SuppressionGroupVisitor(string module, string id, ISuppressionGroupSpec spec)
+        {
+            Module = module;
+            Id = id;
+            InstanceId = Guid.NewGuid();
+            var builder = new LanguageExpressionBuilder();
+            _Fn = builder
+                .WithRule(spec.Rule)
+                .Build(spec.If);
+        }
+
+        public bool Match(object o)
+        {
+            var context = new ExpressionContext(Module);
+            context.Debug(PSRuleResources.SelectorMatchTrace, Id);
+            return _Fn(context, o).GetValueOrDefault(false);
+        }
+    }
+}

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -14,6 +14,7 @@ using PSRule.Definitions;
 using PSRule.Definitions.Baselines;
 using PSRule.Definitions.ModuleConfigs;
 using PSRule.Definitions.Selectors;
+using PSRule.Definitions.SuppressionGroups;
 using PSRule.Host;
 using PSRule.Runtime;
 using PSRule.Runtime.ObjectPath;
@@ -49,6 +50,7 @@ namespace PSRule.Pipeline
         internal readonly Dictionary<string, object> ExpressionCache;
         internal readonly Dictionary<string, PSObject[]> ContentCache;
         internal readonly Dictionary<string, SelectorVisitor> Selector;
+        internal readonly Dictionary<string, SuppressionGroupVisitor> SuppressionGroup;
         internal readonly OptionContext Baseline;
         internal readonly HostContext HostContext;
         internal readonly PipelineReader Reader;
@@ -84,6 +86,7 @@ namespace PSRule.Pipeline
             ExpressionCache = new Dictionary<string, object>();
             ContentCache = new Dictionary<string, PSObject[]>();
             Selector = new Dictionary<string, SelectorVisitor>();
+            SuppressionGroup = new Dictionary<string, SuppressionGroupVisitor>();
             Baseline = baseline;
             _Unresolved = unresolved ?? new List<ResourceRef>();
             _TrackedIssues = new List<ResourceIssue>();
@@ -177,6 +180,14 @@ namespace PSRule.Pipeline
                         _Unresolved.Add(new BaselineRef(baselineId, OptionContext.ScopeType.Module));
                 }
                 Baseline.Add(new OptionContext.ConfigScope(OptionContext.ScopeType.Module, resource.Module, moduleConfig.Spec));
+            }
+            else if (resource.Kind == ResourceKind.SuppressionGroup && resource is SuppressionGroupV1 suppressionGroup)
+            {
+                SuppressionGroup[suppressionGroup.Id.Value] = new SuppressionGroupVisitor(
+                    module: resource.Module,
+                    id: suppressionGroup.Id.Value,
+                    spec: suppressionGroup.Spec
+                );
             }
         }
 

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -50,7 +50,7 @@ namespace PSRule.Pipeline
         internal readonly Dictionary<string, object> ExpressionCache;
         internal readonly Dictionary<string, PSObject[]> ContentCache;
         internal readonly Dictionary<string, SelectorVisitor> Selector;
-        internal readonly Dictionary<string, SuppressionGroupVisitor> SuppressionGroup;
+        internal readonly List<SuppressionGroupVisitor> SuppressionGroup;
         internal readonly OptionContext Baseline;
         internal readonly HostContext HostContext;
         internal readonly PipelineReader Reader;
@@ -86,7 +86,7 @@ namespace PSRule.Pipeline
             ExpressionCache = new Dictionary<string, object>();
             ContentCache = new Dictionary<string, PSObject[]>();
             Selector = new Dictionary<string, SelectorVisitor>();
-            SuppressionGroup = new Dictionary<string, SuppressionGroupVisitor>();
+            SuppressionGroup = new List<SuppressionGroupVisitor>();
             Baseline = baseline;
             _Unresolved = unresolved ?? new List<ResourceRef>();
             _TrackedIssues = new List<ResourceIssue>();
@@ -183,11 +183,12 @@ namespace PSRule.Pipeline
             }
             else if (resource.Kind == ResourceKind.SuppressionGroup && resource is SuppressionGroupV1 suppressionGroup)
             {
-                SuppressionGroup[suppressionGroup.Id.Value] = new SuppressionGroupVisitor(
+                var suppressionGroupVisitor = new SuppressionGroupVisitor(
                     module: resource.Module,
                     id: suppressionGroup.Id.Value,
                     spec: suppressionGroup.Spec
                 );
+                SuppressionGroup.Add(suppressionGroupVisitor);
             }
         }
 

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -8,10 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources {
+namespace PSRule.Resources
+{
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,598 +23,762 @@ namespace PSRule.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class PSRuleResources {
-        
+    internal class PSRuleResources
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal PSRuleResources() {
+        internal PSRuleResources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.PSRuleResources", typeof(PSRuleResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The {0} resource &apos;{1}&apos; is currently referencing &apos;{2}&apos; using the alias &apos;{3}&apos;. Consider updating the reference to use name or id directly..
         /// </summary>
-        internal static string AliasReference {
-            get {
+        internal static string AliasReference
+        {
+            get
+            {
                 return ResourceManager.GetString("AliasReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Suppression for the rule &apos;{0}&apos; was configured using the alias &apos;{1}&apos;. Consider updating the suppression to use the name or id directly..
         /// </summary>
-        internal static string AliasSuppression {
-            get {
+        internal static string AliasSuppression
+        {
+            get
+            {
                 return ResourceManager.GetString("AliasSuppression", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Binding functions are not supported in this language mode..
         /// </summary>
-        internal static string ConstrainedTargetBinding {
-            get {
+        internal static string ConstrainedTargetBinding
+        {
+            get
+            {
                 return ResourceManager.GetString("ConstrainedTargetBinding", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0}: The property &apos;${1}.{2}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string DebugPropertyObsolete {
-            get {
+        internal static string DebugPropertyObsolete
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugPropertyObsolete", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target failed If precondition.
         /// </summary>
-        internal static string DebugTargetIfMismatch {
-            get {
+        internal static string DebugTargetIfMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugTargetIfMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target failed Type precondition.
         /// </summary>
-        internal static string DebugTargetTypeMismatch {
-            get {
+        internal static string DebugTargetTypeMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugTargetTypeMismatch", resourceCulture);
             }
         }
-        
+
+        internal static string DebugTargetRuleMismatch
+        {
+            get
+            {
+                return ResourceManager.GetString("DebugTargetRuleMismatch", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to A circular rule dependency was detected. The rule &apos;{0}&apos; depends on &apos;{1}&apos; which also depend on &apos;{0}&apos;..
         /// </summary>
-        internal static string DependencyCircularReference {
-            get {
+        internal static string DependencyCircularReference
+        {
+            get
+            {
                 return ResourceManager.GetString("DependencyCircularReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The dependency &apos;{0}&apos; for &apos;{1}&apos; could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path..
         /// </summary>
-        internal static string DependencyNotFound {
-            get {
+        internal static string DependencyNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("DependencyNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleId {
-            get {
+        internal static string DuplicateRuleId
+        {
+            get
+            {
                 return ResourceManager.GetString("DuplicateRuleId", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} : Reported &apos;{1}&apos;. At {2}:{3} char:{4}.
         /// </summary>
-        internal static string ErrorDetailMessage {
-            get {
+        internal static string ErrorDetailMessage
+        {
+            get
+            {
                 return ResourceManager.GetString("ErrorDetailMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to One or more errors occured..
         /// </summary>
-        internal static string ErrorPipelineException {
-            get {
+        internal static string ErrorPipelineException
+        {
+            get
+            {
                 return ResourceManager.GetString("ErrorPipelineException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Exists: {0}.
         /// </summary>
-        internal static string ExistsTrue {
-            get {
+        internal static string ExistsTrue
+        {
+            get
+            {
                 return ResourceManager.GetString("ExistsTrue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to File.
         /// </summary>
-        internal static string FileSourceType {
-            get {
+        internal static string FileSourceType
+        {
+            get
+            {
                 return ResourceManager.GetString("FileSourceType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
         /// </summary>
-        internal static string FoundModules {
-            get {
+        internal static string FoundModules
+        {
+            get
+            {
                 return ResourceManager.GetString("FoundModules", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported..
         /// </summary>
-        internal static string InvalidErrorAction {
-            get {
+        internal static string InvalidErrorAction
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidErrorAction", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Rule nesting was detected for rule at {0}. Rules must not be nested..
         /// </summary>
-        internal static string InvalidRuleNesting {
-            get {
+        internal static string InvalidRuleNesting
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidRuleNesting", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An invalid rule result was returned for {0}. Conditions must return boolean $True or $False..
         /// </summary>
-        internal static string InvalidRuleResult {
-            get {
+        internal static string InvalidRuleResult
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidRuleResult", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string KeywordConditionScope {
-            get {
+        internal static string KeywordConditionScope
+        {
+            get
+            {
                 return ResourceManager.GetString("KeywordConditionScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block or script precondition..
         /// </summary>
-        internal static string KeywordRuleScope {
-            get {
+        internal static string KeywordRuleScope
+        {
+            get
+            {
                 return ResourceManager.GetString("KeywordRuleScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can not be nested in a Rule block..
         /// </summary>
-        internal static string KeywordSourceScope {
-            get {
+        internal static string KeywordSourceScope
+        {
+            get
+            {
                 return ResourceManager.GetString("KeywordSourceScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1} {0} {2}.
         /// </summary>
-        internal static string LanguageExpressionTrace {
-            get {
+        internal static string LanguageExpressionTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("LanguageExpressionTrace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Please open your browser to the following location: {0}.
         /// </summary>
-        internal static string LaunchBrowser {
-            get {
+        internal static string LaunchBrowser
+        {
+            get
+            {
                 return ResourceManager.GetString("LaunchBrowser", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Wildcard match requires exactly one name..
         /// </summary>
-        internal static string MatchSingleName {
-            get {
+        internal static string MatchSingleName
+        {
+            get
+            {
                 return ResourceManager.GetString("MatchSingleName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Matches: {0}.
         /// </summary>
-        internal static string MatchTrue {
-            get {
+        internal static string MatchTrue
+        {
+            get
+            {
                 return ResourceManager.GetString("MatchTrue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Update module &apos;{0}&apos; to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config..
         /// </summary>
-        internal static string ModuleManifestBaseline {
-            get {
+        internal static string ModuleManifestBaseline
+        {
+            get
+            {
                 return ResourceManager.GetString("ModuleManifestBaseline", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target object &apos;{0}&apos; has not been processed because no matching rules were found..
         /// </summary>
-        internal static string ObjectNotProcessed {
-            get {
+        internal static string ObjectNotProcessed
+        {
+            get
+            {
                 return ResourceManager.GetString("ObjectNotProcessed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Options file does not exist..
         /// </summary>
-        internal static string OptionsNotFound {
-            get {
+        internal static string OptionsNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("OptionsNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to # Source: {0}.
         /// </summary>
-        internal static string OptionsSourceComment {
-            get {
+        internal static string OptionsSourceComment
+        {
+            get
+            {
                 return ResourceManager.GetString("OptionsSourceComment", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
-        internal static string OutcomeError {
-            get {
+        internal static string OutcomeError
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Fail.
         /// </summary>
-        internal static string OutcomeFail {
-            get {
+        internal static string OutcomeFail
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeFail", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pass.
         /// </summary>
-        internal static string OutcomePass {
-            get {
+        internal static string OutcomePass
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomePass", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRuleFail {
-            get {
+        internal static string OutcomeRuleFail
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeRuleFail", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PASS] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRulePass {
-            get {
+        internal static string OutcomeRulePass
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeRulePass", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
-        internal static string OutcomeUnknown {
-            get {
+        internal static string OutcomeUnknown
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeUnknown", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The property &apos;${0}.{1}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string PropertyObsolete {
-            get {
+        internal static string PropertyObsolete
+        {
+            get
+            {
                 return ResourceManager.GetString("PropertyObsolete", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize the file &apos;{0}&apos;: {1}.
         /// </summary>
-        internal static string ReadFileFailed {
-            get {
+        internal static string ReadFileFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("ReadFileFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
-        internal static string ReadJsonFailed {
-            get {
+        internal static string ReadJsonFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("ReadJsonFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The module version &apos;{1}&apos; for &apos;{0}&apos; does not match the required version &apos;{2}&apos;. To continue, first update the module to match the version requirement..
         /// </summary>
-        internal static string RequiredVersionMismatch {
-            get {
+        internal static string RequiredVersionMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("RequiredVersionMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The {0} &apos;{1}&apos; is obsolete. Consider switching to an alternative {0}..
         /// </summary>
-        internal static string ResourceObsolete {
-            get {
+        internal static string ResourceObsolete
+        {
+            get
+            {
                 return ResourceManager.GetString("ResourceObsolete", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleCountSuppressed {
-            get {
+        internal static string RuleCountSuppressed
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleCountSuppressed", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        /// Looks up localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;.
+        /// </summary>
+        /// <value></value>
+        internal static string RuleSuppressionGroup
+        {
+            get
+            {
+                return ResourceManager.GetString("RuleSuppressionGroup", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;.
+        /// </summary>
+        /// <value></value>
+        internal static string RuleSuppressionGroupCount
+        {
+            get
+            {
+                return ResourceManager.GetString("RuleSuppressionGroupCount", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported errors..
         /// </summary>
-        internal static string RuleErrorPipelineException {
-            get {
+        internal static string RuleErrorPipelineException
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleErrorPipelineException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported failure..
         /// </summary>
-        internal static string RuleFailPipelineException {
-            get {
+        internal static string RuleFailPipelineException
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleFailPipelineException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
         /// </summary>
-        internal static string RuleInconclusive {
-            get {
+        internal static string RuleInconclusive
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleInconclusive", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find a matching rule. Please check that Path, Name and Tag parameters are correct..
         /// </summary>
-        internal static string RuleNotFound {
-            get {
+        internal static string RuleNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find required rule definition parameter &apos;{0}&apos; on rule at {1}..
         /// </summary>
-        internal static string RuleParameterNotFound {
-            get {
+        internal static string RuleParameterNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleParameterNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No matching .Rule.ps1 files were found. Rule definitions should be saved into script files with the .Rule.ps1 extension..
         /// </summary>
-        internal static string RulePathNotFound {
-            get {
+        internal static string RulePathNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("RulePathNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to at Rule &apos;{0}&apos;, {1}: line {2}.
         /// </summary>
-        internal static string RuleStackTrace {
-            get {
+        internal static string RuleStackTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleStackTrace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleSuppressed {
-            get {
+        internal static string RuleSuppressed
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleSuppressed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
         /// </summary>
-        internal static string ScanModule {
-            get {
+        internal static string ScanModule
+        {
+            get
+            {
                 return ResourceManager.GetString("ScanModule", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files: {0}.
         /// </summary>
-        internal static string ScanSource {
-            get {
+        internal static string ScanSource
+        {
+            get
+            {
                 return ResourceManager.GetString("ScanSource", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The script was not found..
         /// </summary>
-        internal static string ScriptNotFound {
-            get {
+        internal static string ScriptNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}.
         /// </summary>
-        internal static string SelectorMatchTrace {
-            get {
+        internal static string SelectorMatchTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("SelectorMatchTrace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1}.
         /// </summary>
-        internal static string SelectorTrace {
-            get {
+        internal static string SelectorTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("SelectorTrace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Can not serialize a null PSObject..
         /// </summary>
-        internal static string SerializeNullPSObject {
-            get {
+        internal static string SerializeNullPSObject
+        {
+            get
+            {
                 return ResourceManager.GetString("SerializeNullPSObject", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Create path.
         /// </summary>
-        internal static string ShouldCreatePath {
-            get {
+        internal static string ShouldCreatePath
+        {
+            get
+            {
                 return ResourceManager.GetString("ShouldCreatePath", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Write file.
         /// </summary>
-        internal static string ShouldWriteFile {
-            get {
+        internal static string ShouldWriteFile
+        {
+            get
+            {
                 return ResourceManager.GetString("ShouldWriteFile", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The source was not found..
         /// </summary>
-        internal static string SourceNotFound {
-            get {
+        internal static string SourceNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("SourceNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Using invariant culture may cause rule infomation to be displayed incorrectly. Consider using -Culture or set the Output.Culture option..
         /// </summary>
-        internal static string UsingInvariantCulture {
-            get {
+        internal static string UsingInvariantCulture
+        {
+            get
+            {
                 return ResourceManager.GetString("UsingInvariantCulture", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The variable &apos;${0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string VariableConditionScope {
-            get {
+        internal static string VariableConditionScope
+        {
+            get
+            {
                 return ResourceManager.GetString("VariableConditionScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The version constraint &apos;{0}&apos; is not valid..
         /// </summary>
-        internal static string VersionConstraintInvalid {
-            get {
+        internal static string VersionConstraintInvalid
+        {
+            get
+            {
                 return ResourceManager.GetString("VersionConstraintInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The Within parameter Value must be a string when the Like parameter is used..
         /// </summary>
-        internal static string WithinLikeNotString {
-            get {
+        internal static string WithinLikeNotString
+        {
+            get
+            {
                 return ResourceManager.GetString("WithinLikeNotString", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Within: {0}.
         /// </summary>
-        internal static string WithinTrue {
-            get {
+        internal static string WithinTrue
+        {
+            get
+            {
                 return ResourceManager.GetString("WithinTrue", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -133,6 +133,9 @@
   <data name="DebugTargetTypeMismatch" xml:space="preserve">
     <value>Target failed Type precondition</value>
   </data>
+  <data name="DebugTargetRuleMismatch" xml:space="preserve">
+    <value>Target failed Rule precondition</value>
+  </data>
   <data name="DependencyCircularReference" xml:space="preserve">
     <value>A circular rule dependency was detected. The rule '{0}' depends on '{1}' which also depend on '{0}'.</value>
     <comment>Occurs when rules interdepend on each other.</comment>
@@ -248,6 +251,12 @@
   </data>
   <data name="RuleCountSuppressed" xml:space="preserve">
     <value>{0} rule/s were suppressed for '{1}'.</value>
+  </data>
+  <data name="RuleSuppressionGroup" xml:space="preserve">
+    <value>Rule '{0}' was suppressed by suppression group '{1}' for '{2}'.</value>
+  </data>
+  <data name="RuleSuppressionGroupCount" xml:space="preserve">
+    <value>{0} rule/s were suppressed by suppression group '{1}' for '{2}'.</value>
   </data>
   <data name="RuleNotFound" xml:space="preserve">
     <value>Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.</value>

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -634,23 +634,6 @@ namespace PSRule.Runtime
             return result;
         }
 
-        public bool MatchSuppressionGroup(out string suppressionGroupId)
-        {
-            suppressionGroupId = string.Empty;
-            foreach (var keyValuePair in Pipeline.SuppressionGroup)
-            {
-                var groupId = keyValuePair.Key;
-                var visitor = keyValuePair.Value;
-
-                if (visitor.Match(TargetObject.Value))
-                {
-                    suppressionGroupId = groupId;
-                    return true;
-                }
-            }
-            return false;
-        }
-
         /// <summary>
         /// Enter the rule block scope.
         /// </summary>

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -261,6 +261,26 @@ namespace PSRule.Runtime
             Writer.WriteWarning(PSRuleResources.RuleCountSuppressed, ruleCount, Binding.TargetName);
         }
 
+        public void WarnRuleSuppressionGroup(string ruleId, string suppressionGroupId)
+        {
+            if (Writer == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
+            {
+                return;
+            }
+
+            Writer.WriteWarning(PSRuleResources.RuleSuppressionGroup, ruleId, suppressionGroupId, Binding.TargetName);
+        }
+
+        public void WarnRuleSuppressionGroupCount(int ruleCount, string suppressionGroupId)
+        {
+            if (Writer == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
+            {
+                return;
+            }
+
+            Writer.WriteWarning(PSRuleResources.RuleSuppressionGroupCount, ruleCount, suppressionGroupId, Binding.TargetName);
+        }
+
         public void ErrorInvaildRuleResult()
         {
             if (Writer == null || !Writer.ShouldWriteError())
@@ -612,6 +632,23 @@ namespace PSRule.Runtime
             result = selector.Match(TargetObject.Value);
             annotation.SetSelectorResult(selector, result);
             return result;
+        }
+
+        public bool MatchSuppressionGroup(out string suppressionGroupId)
+        {
+            suppressionGroupId = string.Empty;
+            foreach (var keyValuePair in Pipeline.SuppressionGroup)
+            {
+                var groupId = keyValuePair.Key;
+                var visitor = keyValuePair.Value;
+
+                if (visitor.Match(TargetObject.Value))
+                {
+                    suppressionGroupId = groupId;
+                    return true;
+                }
+            }
+            return false;
         }
 
         /// <summary>

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1207,9 +1207,15 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $testObject = @(
                 [PSCustomObject]@{
                     Name = "TestObject1"
+                    Tags = @{
+                        Env = 'dev'
+                    }
                 }
                 [PSCustomObject]@{
                     Name = "TestObject2"
+                    Tags = @{
+                        Env = 'test'
+                    }
                 }
             )
             [PSRule.Configuration.PSRuleOption]::UseCurrentCulture('en-AU');
@@ -1228,25 +1234,29 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             It 'Show warnings' {
                 $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail;
 
-                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
                 $warningMessages = $outwarnings.ToArray();
-                $warningMessages.Length | Should -Be 4;
+                $warningMessages.Length | Should -Be 6;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages[0].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject1'.";
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages[1].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject1'.";
                 $warningMessages[2] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[2].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
+                $warningMessages[2].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject1'.";
                 $warningMessages[3] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[3].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
+                $warningMessages[3].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
+                $warningMessages[4] | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages[4].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
+                $warningMessages[5] | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages[5].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'.";
             }
 
             It 'No warnings' {
                 $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Detail;
 
-                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
                 $warningMessages = $outwarnings.ToArray();
                 $warningMessages.Length | Should -Be 0;
@@ -1257,21 +1267,25 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             It 'Show warnings' {
                 $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary;
 
-                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
                 $warningMessages = $outwarnings.ToArray();
-                $warningMessages.Length | Should -Be 2;
+                $warningMessages.Length | Should -Be 4;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages[0].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject1'.";
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[1].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject2'.";
+                $warningMessages[1].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject1'.";
+                $warningMessages[2] | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages[2].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject2'.";
+                $warningMessages[3] | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages[3].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'.";
             }
 
             It 'No warnings' {
                 $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Summary;
 
-                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5' -WarningVariable outWarnings -WarningAction SilentlyContinue;
+                $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
                 $warningMessages = $outwarnings.ToArray();
                 $warningMessages.Length | Should -Be 0;

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -94,6 +94,9 @@
     <None Update="Selectors.Rule.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="SuppressionGroups.Rule.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/PSRule.Tests/SuppressionFilterTests.cs
+++ b/tests/PSRule.Tests/SuppressionFilterTests.cs
@@ -24,7 +24,8 @@ namespace PSRule
             context.Init(GetSource());
             context.Begin();
             var rules = HostHelper.GetRule(GetSource(), context, includeDependencies: false);
-            var filter = new SuppressionFilter(context, option.Suppression, rules);
+            var resourceIndex = new ResourceIndex(rules);
+            var filter = new SuppressionFilter(context, option.Suppression, resourceIndex);
 
             Assert.True(filter.Match(new ResourceId(".", "YAML.RuleWithAlias1", ResourceIdKind.Unknown), "TestObject1"));
             Assert.False(filter.Match(new ResourceId(".", "JSON.RuleWithAlias1", ResourceIdKind.Unknown), "TestObject1"));

--- a/tests/PSRule.Tests/SuppressionGroupTests.cs
+++ b/tests/PSRule.Tests/SuppressionGroupTests.cs
@@ -23,9 +23,10 @@ namespace PSRule
             context.Begin();
             var suppressionGroup = HostHelper.GetSuppressionGroupYaml(GetSource(), context).ToArray();
             Assert.NotNull(suppressionGroup);
-            Assert.Equal(2, suppressionGroup.Length);
+            Assert.Equal(3, suppressionGroup.Length);
             Assert.Equal("SuppressWithTargetName", suppressionGroup[0].Name);
             Assert.Equal("SuppressWithTestType", suppressionGroup[1].Name);
+            Assert.Equal("SuppressWithNonProdTag", suppressionGroup[2].Name);
         }
 
         #region Helper methods

--- a/tests/PSRule.Tests/SuppressionGroupTests.cs
+++ b/tests/PSRule.Tests/SuppressionGroupTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using PSRule.Configuration;
+using PSRule.Host;
+using PSRule.Pipeline;
+using PSRule.Runtime;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace PSRule
+{
+    public sealed class SuppressionGroupTests
+    {
+        [Fact]
+        public void ReadSuppressionGroup()
+        {
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, new OptionContext(), null), null);
+            context.Init(GetSource());
+            context.Begin();
+            var suppressionGroup = HostHelper.GetSuppressionGroupYaml(GetSource(), context).ToArray();
+            Assert.NotNull(suppressionGroup);
+            Assert.Equal(2, suppressionGroup.Length);
+            Assert.Equal("SuppressWithTargetName", suppressionGroup[0].Name);
+            Assert.Equal("SuppressWithTestType", suppressionGroup[1].Name);
+        }
+
+        #region Helper methods
+
+        private static PSRuleOption GetOption()
+        {
+            return new PSRuleOption();
+        }
+
+        private static Source[] GetSource(string path = "SuppressionGroups.Rule.yaml")
+        {
+            var builder = new SourcePipelineBuilder(null, null);
+            builder.Directory(GetSourcePath(path));
+            return builder.Build();
+        }
+
+        private static string GetSourcePath(string fileName)
+        {
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
+++ b/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
@@ -34,7 +34,7 @@ spec:
     equals: 'TestType'
 
 ---
-# Synopsis: Suppress with non-production 
+# Synopsis: Suppress with non-production tag
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:

--- a/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
+++ b/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
@@ -32,3 +32,19 @@ spec:
   if:
     type: '.'
     equals: 'TestType'
+
+---
+# Synopsis: Suppress with non-production 
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithNonProdTag
+spec:
+  rule:
+  - '.\WithTag2'
+  - '.\WithTag3'
+  if:
+    field: 'tags.env'
+    in:
+    - 'dev'
+    - 'test'

--- a/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
+++ b/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Suppression groups for unit testing
+
+---
+# Synopsis: Suppress with target name
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithTargetName
+spec:
+  rule:
+  - 'FromFile1'
+  - 'FromFile2'
+  if:
+    name: '.'
+    in:
+    - 'TestObject1'
+    - 'TestObject2'
+
+---
+# Synopsis: Suppress with target type
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithTestType
+spec:
+  rule:
+  - 'FromFile3'
+  - 'FromFile5'
+  if:
+    type: '.'
+    equals: 'TestType'


### PR DESCRIPTION
## PR Summary

Fix #793.

Added `SuppressionGroup` resource which can suppress rules based on selector expression.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
