### PR TITLE
Added Invariant Culture Warning option

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,7 @@
     },
     "cSpell.words": [
         "APPSERVICEMININSTANCECOUNT",
+        "PSRULE",
         "Gitter",
         "Kubernetes",
         "cmdlet",

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.InconclusiveWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executioninconclusivewarning)
   - [Execution.NotProcessedWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionnotprocessedwarning)
   - [Execution.SuppressedRuleWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executionsuppressedrulewarning)
+  - [Execution.InvariantCultureWarning](docs/concepts/PSRule/en-US/about_PSRule_Options.md#executioninvariantculturewarning)
   - [Include.Module](docs/concepts/PSRule/en-US/about_PSRule_Options.md#includemodule)
   - [Include.Path](docs/concepts/PSRule/en-US/about_PSRule_Options.md#includepath)
   - [Input.Format](docs/concepts/PSRule/en-US/about_PSRule_Options.md#inputformat)

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -11,6 +11,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2201093:
+
+- New features:
+  - Add option to disable invariant culture warning. [#899](https://github.com/microsoft/PSRule/issues/899)
+    - Added `Execution.InvariantCultureWarning` option.
+    - See [about_PSRule_Options] for details.
+
 ## v2.0.0-B2201093 (pre-release)
 
 What's changed since pre-release v2.0.0-B2201075:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -19,6 +19,7 @@ The following workspace options are available for use:
 - [Execution.InconclusiveWarning](#executioninconclusivewarning)
 - [Execution.NotProcessedWarning](#executionnotprocessedwarning)
 - [Execution.SuppressedRuleWarning](#executionsuppressedrulewarning)
+- [Execution.InvariantCultureWarning](#executioninvariantculturewarning)
 - [Include.Module](#includemodule)
 - [Include.Path](#includepath)
 - [Input.Format](#inputformat)
@@ -913,6 +914,52 @@ env:
 # Azure Pipelines: Using environment variable
 variables:
 - name: PSRULE_EXECUTION_SUPPRESSEDRULEWARNING
+  value: false
+```
+
+### Execution.InvariantCultureWarning
+
+When evaluating rules inside a Linux CI host, if invariant culture is used, a warning is shown by default.
+You can suppress this warning if you set the culture with `-Culture` or the `Output.Culture` option.
+
+This warning can also be suppressed by using:
+
+```powershell
+# PowerShell: Using the InvariantCultureWarning parameter
+$option = New-PSRuleOption -InvariantCultureWarning $False;
+```
+
+```powershell
+# PowerShell: Using the Execution.InvariantCultureWarning hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.InvariantCultureWarning' = $False };
+```
+
+```powershell
+# PowerShell: Using the InvariantCultureWarning parameter to set YAML
+Set-PSRuleOption -InvariantCultureWarning $False;
+```
+
+```yaml
+# YAML: Using the execution/invariantCultureWarning property
+execution:
+  invariantCultureWarning: false
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_INVARIANTCULTUREWARNING=false
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_INVARIANTCULTUREWARNING: false
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_INVARIANTCULTUREWARNING
   value: false
 ```
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -919,7 +919,7 @@ variables:
 
 ### Execution.InvariantCultureWarning
 
-When evaluating rules inside a Linux CI host, if invariant culture is used, a warning is shown by default.
+When evaluating rules inside a CI host, if invariant culture is used, a warning is shown by default.
 You can suppress this warning if you set the culture with `-Culture` or the `Output.Culture` option.
 
 This warning can also be suppressed by using:

--- a/docs/scenarios/azure-tags/ps-rule.yaml
+++ b/docs/scenarios/azure-tags/ps-rule.yaml
@@ -8,3 +8,6 @@ configuration:
   - 'IT Operations'
   - 'Finance'
   - 'HR'
+
+execution:
+  invariantCultureWarning: false

--- a/docs/scenarios/kubernetes-resources/ps-rule.yaml
+++ b/docs/scenarios/kubernetes-resources/ps-rule.yaml
@@ -4,3 +4,6 @@ binding:
     - metadata.name
   targetType:
     - kind
+
+execution:
+  invariantCultureWarning: false

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -254,14 +254,16 @@ task TestModule Dependencies, {
             Path = $PWD;
             PassThru = $True;
         }
-        Output = @{
-            Verbosity = 'Detailed'
-        }
         TestResult = @{
             Enabled = $True;
             OutputFormat = 'NUnitXml';
             OutputPath = 'reports/pester-unit.xml';
         };
+    }
+
+    # Use Detailed output in CI(AzDO or Github Actions)
+    if ($env:TF_BUILD -eq 'true' -or $env:GITHUB_ACTIONS -eq 'true') {
+        $pesterOptions.Add('Output', @{ Verbosity = 'Detailed' });
     }
 
     if ($CodeCoverage) {

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -254,6 +254,9 @@ task TestModule Dependencies, {
             Path = $PWD;
             PassThru = $True;
         }
+        Output = @{
+            Verbosity = 'Detailed'
+        }
         TestResult = @{
             Enabled = $True;
             OutputFormat = 'NUnitXml';

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -149,6 +149,13 @@
                     "description": "Enable or disable warnings when an alias to a resource is used. The default is true.",
                     "markdownDescription": "Enable or disable warnings when an alias to a resource is used. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionaliasreferencewarning)",
                     "default": true
+                },
+                "invariantCultureWarning": {
+                    "type": "boolean",
+                    "title": "Warn on invariant culture",
+                    "description": "Enable or disable warning when invariant culture is used. The default is `true`.",
+                    "markdownDescription": "Enable or disable warning when invariant culture is used. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executioninvariantculturewarning)",
+                    "default": true
                 }
             },
             "additionalProperties": false

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -17,6 +17,7 @@ namespace PSRule.Configuration
         private const bool DEFAULT_NOTPROCESSEDWARNING = true;
         private const bool DEFAULT_SUPPRESSEDRULEWARNING = true;
         private const bool DEFAULT_ALIASREFERENCEWARNING = true;
+        private const bool DEFAULT_INVARIANTCULTUREWARNING = true;
 
         internal static readonly ExecutionOption Default = new ExecutionOption
         {
@@ -24,7 +25,8 @@ namespace PSRule.Configuration
             LanguageMode = DEFAULT_LANGUAGEMODE,
             InconclusiveWarning = DEFAULT_INCONCLUSIVEWARNING,
             NotProcessedWarning = DEFAULT_NOTPROCESSEDWARNING,
-            SuppressedRuleWarning = DEFAULT_SUPPRESSEDRULEWARNING
+            SuppressedRuleWarning = DEFAULT_SUPPRESSEDRULEWARNING,
+            InvariantCultureWarning = DEFAULT_INVARIANTCULTUREWARNING
         };
 
         public ExecutionOption()
@@ -34,6 +36,7 @@ namespace PSRule.Configuration
             InconclusiveWarning = null;
             NotProcessedWarning = null;
             SuppressedRuleWarning = null;
+            InvariantCultureWarning = null;
         }
 
         public ExecutionOption(ExecutionOption option)
@@ -46,6 +49,7 @@ namespace PSRule.Configuration
             InconclusiveWarning = option.InconclusiveWarning;
             NotProcessedWarning = option.NotProcessedWarning;
             SuppressedRuleWarning = option.SuppressedRuleWarning;
+            InvariantCultureWarning = option.InvariantCultureWarning;
         }
 
         public override bool Equals(object obj)
@@ -60,7 +64,8 @@ namespace PSRule.Configuration
                 LanguageMode == other.LanguageMode &&
                 InconclusiveWarning == other.InconclusiveWarning &&
                 NotProcessedWarning == other.NotProcessedWarning &&
-                SuppressedRuleWarning == other.NotProcessedWarning;
+                SuppressedRuleWarning == other.NotProcessedWarning &&
+                InvariantCultureWarning == other.InvariantCultureWarning;
         }
 
         public override int GetHashCode()
@@ -73,6 +78,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (InconclusiveWarning.HasValue ? InconclusiveWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (NotProcessedWarning.HasValue ? NotProcessedWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (SuppressedRuleWarning.HasValue ? SuppressedRuleWarning.Value.GetHashCode() : 0);
+                hash = hash * 23 + (InvariantCultureWarning.HasValue ? InvariantCultureWarning.Value.GetHashCode() : 0);
                 return hash;
             }
         }
@@ -86,6 +92,7 @@ namespace PSRule.Configuration
                 InconclusiveWarning = o1.InconclusiveWarning ?? o2.InconclusiveWarning,
                 NotProcessedWarning = o1.NotProcessedWarning ?? o2.NotProcessedWarning,
                 SuppressedRuleWarning = o1.SuppressedRuleWarning ?? o2.SuppressedRuleWarning,
+                InvariantCultureWarning = o1.InvariantCultureWarning ?? o2.InvariantCultureWarning
             };
             return result;
         }
@@ -120,6 +127,12 @@ namespace PSRule.Configuration
         [DefaultValue(null)]
         public bool? SuppressedRuleWarning { get; set; }
 
+        /// <summary>
+        /// Determines if warning is raised when invariant culture us used.
+        /// </summary>
+        [DefaultValue(null)]
+        public bool? InvariantCultureWarning { get; set; }
+
         internal void Load(EnvironmentHelper env)
         {
             if (env.TryBool("PSRULE_EXECUTION_ALIASREFERENCEWARNING", out var bvalue))
@@ -136,6 +149,9 @@ namespace PSRule.Configuration
 
             if (env.TryBool("PSRULE_EXECUTION_SUPPRESSEDRULEWARNING", out bvalue))
                 SuppressedRuleWarning = bvalue;
+
+            if (env.TryBool("PSRULE_EXECUTION_INVARIANTCULTUREWARNING", out bvalue))
+                InvariantCultureWarning = bvalue;
         }
 
         internal void Load(Dictionary<string, object> index)
@@ -154,6 +170,9 @@ namespace PSRule.Configuration
 
             if (index.TryPopBool("Execution.SuppressedRuleWarning", out bvalue))
                 SuppressedRuleWarning = bvalue;
+
+            if (index.TryPopBool("Execution.InvariantCultureWarning", out bvalue))
+                InvariantCultureWarning = bvalue;
         }
     }
 }

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -128,7 +128,7 @@ namespace PSRule.Configuration
         public bool? SuppressedRuleWarning { get; set; }
 
         /// <summary>
-        /// Determines if warning is raised when invariant culture us used.
+        /// Determines if warning is raised when invariant culture is used.
         /// </summary>
         [DefaultValue(null)]
         public bool? InvariantCultureWarning { get; set; }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1195,6 +1195,11 @@ function New-PSRuleOption {
         [Alias('ExecutionAliasReferenceWarning')]
         [System.Boolean]$AliasReferenceWarning = $True,
 
+        # Sets the Execution.InvariantCultureWarning option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInvariantCultureWarning')]
+        [System.Boolean]$InvariantCultureWarning = $True,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -1451,6 +1456,11 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionAliasReferenceWarning')]
         [System.Boolean]$AliasReferenceWarning = $True,
+
+        # Sets the Execution.InvariantCultureWarning option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInvariantCultureWarning')]
+        [System.Boolean]$InvariantCultureWarning = $True,
 
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
@@ -2151,6 +2161,11 @@ function SetOptions {
         [Alias('ExecutionAliasReferenceWarning')]
         [System.Boolean]$AliasReferenceWarning = $True,
 
+        # Sets the Execution.InvariantCultureWarning option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInvariantCultureWarning')]
+        [System.Boolean]$InvariantCultureWarning = $True,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -2317,6 +2332,11 @@ function SetOptions {
         # Sets option Execution.AliasReferenceWarning
         if ($PSBoundParameters.ContainsKey('AliasReferenceWarning')) {
             $Option.Execution.AliasReferenceWarning = $AliasReferenceWarning;
+        }
+
+        # Sets option Execution.InvariantCultureWarning
+        if ($PSBoundParameters.ContainsKey('InvariantCultureWarning')) {
+            $Option.Execution.InvariantCultureWarning = $InvariantCultureWarning;
         }
 
         # Sets option Include.Module

--- a/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
+++ b/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
@@ -33,6 +33,7 @@ namespace PSRule.Pipeline
                 return this;
 
             Option.Execution.LanguageMode = option.Execution.LanguageMode ?? ExecutionOption.Default.LanguageMode;
+            Option.Execution.InvariantCultureWarning = option.Execution.InvariantCultureWarning ?? ExecutionOption.Default.InvariantCultureWarning;
             Option.Output.Culture = GetCulture(option.Output.Culture);
 
             if (option.Rule != null)

--- a/src/PSRule/Pipeline/GetRulePipelineBuiler.cs
+++ b/src/PSRule/Pipeline/GetRulePipelineBuiler.cs
@@ -26,6 +26,7 @@ namespace PSRule.Pipeline
                 return this;
 
             Option.Execution.LanguageMode = option.Execution.LanguageMode ?? ExecutionOption.Default.LanguageMode;
+            Option.Execution.InvariantCultureWarning = option.Execution.InvariantCultureWarning ?? ExecutionOption.Default.InvariantCultureWarning;
             Option.Output.Culture = GetCulture(option.Output.Culture);
             Option.Output.Format = SuppressFormat(option.Output.Format);
             Option.Requires = new RequiresOption(option.Requires);

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -63,6 +63,7 @@ namespace PSRule.Pipeline
             Option.Execution.InconclusiveWarning = option.Execution.InconclusiveWarning ?? ExecutionOption.Default.InconclusiveWarning;
             Option.Execution.NotProcessedWarning = option.Execution.NotProcessedWarning ?? ExecutionOption.Default.NotProcessedWarning;
             Option.Execution.SuppressedRuleWarning = option.Execution.SuppressedRuleWarning ?? ExecutionOption.Default.SuppressedRuleWarning;
+            Option.Execution.InvariantCultureWarning = option.Execution.InvariantCultureWarning ?? ExecutionOption.Default.InvariantCultureWarning;
 
             Option.Logging.RuleFail = option.Logging.RuleFail ?? LoggingOption.Default.RuleFail;
             Option.Logging.RulePass = option.Logging.RulePass ?? LoggingOption.Default.RulePass;

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -76,6 +76,7 @@ namespace PSRule.Runtime
         private readonly bool _InconclusiveWarning;
         private readonly bool _NotProcessedWarning;
         private readonly bool _SuppressedRuleWarning;
+        private readonly bool _InvariantCultureWarning;
         private readonly OutcomeLogStream _FailStream;
         private readonly OutcomeLogStream _PassStream;
         private readonly Stack<RunspaceScope> _Scope;
@@ -109,6 +110,7 @@ namespace PSRule.Runtime
             _InconclusiveWarning = Pipeline.Option.Execution.InconclusiveWarning ?? ExecutionOption.Default.InconclusiveWarning.Value;
             _NotProcessedWarning = Pipeline.Option.Execution.NotProcessedWarning ?? ExecutionOption.Default.NotProcessedWarning.Value;
             _SuppressedRuleWarning = Pipeline.Option.Execution.SuppressedRuleWarning ?? ExecutionOption.Default.SuppressedRuleWarning.Value;
+            _InvariantCultureWarning = Pipeline.Option.Execution.InvariantCultureWarning ?? ExecutionOption.Default.InvariantCultureWarning.Value;
             _FailStream = Pipeline.Option.Logging.RuleFail ?? LoggingOption.Default.RuleFail.Value;
             _PassStream = Pipeline.Option.Logging.RulePass ?? LoggingOption.Default.RulePass.Value;
             _WarnOnce = new HashSet<string>();
@@ -803,7 +805,9 @@ namespace PSRule.Runtime
                 return null;
 
             var culture = Pipeline.Baseline.GetCulture();
-            if (!_RaisedUsingInvariantCulture && (culture == null || culture.Length == 0))
+            if (!_RaisedUsingInvariantCulture &&
+                (culture == null || culture.Length == 0) &&
+                _InvariantCultureWarning)
             {
                 Writer.WarnUsingInvariantCulture();
                 _RaisedUsingInvariantCulture = true;

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1146,7 +1146,6 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                     Name = "TestObject2"
                 }
             )
-            [PSRule.Configuration.PSRuleOption]::UseCurrentCulture('en-AU');
         }
 
         Context 'Detail' {
@@ -1196,10 +1195,6 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 0;
             }
         }
-
-        AfterAll {
-            [PSRule.Configuration.PSRuleOption]::UseCurrentCulture();
-        }
     }
 
     Context 'Suppression Group output warnings' {
@@ -1218,7 +1213,6 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                     }
                 }
             )
-            [PSRule.Configuration.PSRuleOption]::UseCurrentCulture('en-AU');
 
             $testObject[0].PSObject.TypeNames.Insert(0, 'TestType');
             $testObject[1].PSObject.TypeNames.Insert(0, 'TestType');
@@ -1290,10 +1284,6 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages = $outwarnings.ToArray();
                 $warningMessages.Length | Should -Be 0;
             }
-        }
-
-        AfterAll {
-            [PSRule.Configuration.PSRuleOption]::UseCurrentCulture();
         }
     }
 }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1150,7 +1150,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show Warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $True -OutputAs Detail;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1164,7 +1164,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $False -OutputAs Detail;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $False -OutputAs Detail -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1175,7 +1175,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $True -OutputAs Summary;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1187,7 +1187,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $False -OutputAs Summary;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $False -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1226,7 +1226,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail;
+                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1248,7 +1248,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Detail;
+                $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Detail -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1259,7 +1259,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary;
+                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1277,7 +1277,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Summary;
+                $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1723,7 +1723,7 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         It 'Returns rules in current path' {
             try {
                 Push-Location -Path $searchPath;
-                $result = @(Get-PSRule)
+                $result = @(Get-PSRule -Option @{ 'Execution.InvariantCultureWarning' = $False })
                 $result | Should -Not -BeNullOrEmpty;
                 $result.Length | Should -Be 3;
                 $result.RuleName | Should -BeIn 'M1.Rule1', 'M1.Rule2', 'M1.YamlTestName';
@@ -1838,7 +1838,7 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         It 'Uses rules with include option' {
             Push-Location -Path (Join-Path -Path $here -ChildPath 'rules/')
             try {
-                $result = @(Get-PSRule)
+                $result = @(Get-PSRule -Option @{ 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 4;
 
                 $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCultureWarning' = $False })

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -2259,13 +2259,12 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         BeforeAll {
             # Get a list of rules
             $searchPath = Join-Path -Path $here -ChildPath 'TestModule';
-            $option = New-PSRuleOption -Option @{ 'Execution.InvariantCultureWarning' = $False }
         }
 
         It 'Docs from imported module' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -Option $option);
+                $result = @(Get-PSRuleHelp);
                 $result.Length | Should -Be 6;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2283,7 +2282,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         It 'Using wildcard in name' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -Name M1.* -Option $option);
+                $result = @(Get-PSRuleHelp -Name M1.*);
                 $result.Length | Should -Be 6;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2305,7 +2304,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
                     Module = 'TestModule'
                     Name = 'M1.Rule1'
                 }
-                $result = @(Get-PSRuleHelp @getParams -Full -Option $option);
+                $result = @(Get-PSRuleHelp @getParams -Full);
                 $result | Should -Not -BeNullOrEmpty;
                 ($result | Get-Member).TypeName | Should -BeIn 'PSRule.Rules.RuleHelpInfo+Full';
             }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1841,28 +1841,28 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
                 $result = @(Get-PSRule)
                 $result.Length | Should -Be 4;
 
-                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/' })
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 1;
 
-                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/', 'extra/' })
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/', 'extra/'; 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 2;
 
-                $result = @(Get-PSRule -Option @{ 'Include.Path' = '.' })
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = '.'; 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 4;
 
-                $result = @(Get-PSRule -Path 'main/')
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 2;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = @() })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = @(); 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 1;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/' })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/'; 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 2;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/', '.ps-rule/' })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/', '.ps-rule/'; 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 3;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'main/' })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 1;
             }
             finally {
@@ -2259,12 +2259,13 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         BeforeAll {
             # Get a list of rules
             $searchPath = Join-Path -Path $here -ChildPath 'TestModule';
+            $option = New-PSRuleOption -Option @{ 'Execution.InvariantCultureWarning' = $False }
         }
 
         It 'Docs from imported module' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp);
+                $result = @(Get-PSRuleHelp -Option $option);
                 $result.Length | Should -Be 6;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2282,7 +2283,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         It 'Using wildcard in name' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -Name M1.*);
+                $result = @(Get-PSRuleHelp -Name M1.* -Option $option);
                 $result.Length | Should -Be 6;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2304,7 +2305,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
                     Module = 'TestModule'
                     Name = 'M1.Rule1'
                 }
-                $result = @(Get-PSRuleHelp @getParams -Full);
+                $result = @(Get-PSRuleHelp @getParams -Full -Option $option);
                 $result | Should -Not -BeNullOrEmpty;
                 ($result | Get-Member).TypeName | Should -BeIn 'PSRule.Rules.RuleHelpInfo+Full';
             }

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -780,6 +780,45 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Execution.InvariantCultureWarning' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.InvariantCultureWarning | Should -Be $True;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.InvariantCultureWarning' = $False };
+            $option.Execution.InvariantCultureWarning | Should -Be $False;
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.InvariantCultureWarning | Should -Be $False;
+        }
+
+        It 'from Environment' {
+            try {
+                # With bool
+                $Env:PSRULE_EXECUTION_INVARIANTCULTUREWARNING = 'false';
+                $option = New-PSRuleOption;
+                $option.Execution.InvariantCultureWarning | Should -Be $False;
+
+                # With int
+                $Env:PSRULE_EXECUTION_INVARIANTCULTUREWARNING = '0';
+                $option = New-PSRuleOption;
+                $option.Execution.InvariantCultureWarning | Should -Be $False;
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_INVARIANTCULTUREWARNING' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InvariantCultureWarning $False -Path $emptyOptionsFilePath;
+            $option.Execution.InvariantCultureWarning | Should -Be $False;
+        }
+    }
+
     Context 'Read Include.Path' {
         It 'from default' {
             $option = New-PSRuleOption -Default;

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -50,6 +50,7 @@ execution:
   inconclusiveWarning: false
   notProcessedWarning: false
   suppressedRuleWarning: false
+  invariantCultureWarning: false
 
 # Configure input options
 input:

--- a/tests/PSRule.Tests/PSRule.Tests10.yml
+++ b/tests/PSRule.Tests/PSRule.Tests10.yml
@@ -3,3 +3,6 @@
 # Configure output options
 output:
   jsonIndent: 1
+
+execution:
+  invariantCultureWarning: false

--- a/tests/PSRule.Tests/PSRule.Tests11.yml
+++ b/tests/PSRule.Tests/PSRule.Tests11.yml
@@ -3,3 +3,6 @@
 # Configure output options
 output:
   jsonIndent: 2
+
+execution:
+  invariantCultureWarning: false

--- a/tests/PSRule.Tests/PSRule.Tests12.yml
+++ b/tests/PSRule.Tests/PSRule.Tests12.yml
@@ -3,3 +3,6 @@
 # Configure output options
 output:
   jsonIndent: 3
+
+execution:
+  invariantCultureWarning: false

--- a/tests/PSRule.Tests/PSRule.Tests13.yml
+++ b/tests/PSRule.Tests/PSRule.Tests13.yml
@@ -3,3 +3,6 @@
 # Configure output options
 output:
   jsonIndent: 4
+
+execution:
+  invariantCultureWarning: false

--- a/tests/PSRule.Tests/PSRule.Tests5.yml
+++ b/tests/PSRule.Tests/PSRule.Tests5.yml
@@ -2,3 +2,4 @@
 # Options for processing with some rules
 execution:
   inconclusiveWarning: false
+  invariantCultureWarning: false

--- a/tests/PSRule.Tests/PSRule.Tests9.yml
+++ b/tests/PSRule.Tests/PSRule.Tests9.yml
@@ -3,3 +3,6 @@
 # Configure output options
 output:
   jsonIndent: 0
+
+execution:
+  invariantCultureWarning: false

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -72,6 +72,28 @@ namespace PSRule
         }
 
         [Fact]
+        public void PipelineWithInvariantCultureDisabled()
+        {
+            PSRuleOption.UseCurrentCulture(CultureInfo.InvariantCulture);
+            var option = new PSRuleOption();
+            option.Execution.InvariantCultureWarning = false;
+            var context = PipelineContext.New(option, null, null, null, null, null, new OptionContext(), null);
+            var writer = new TestWriter(option);
+            var pipeline = new GetRulePipeline(context, GetSource(), new PipelineReader(null, null), writer, false);
+            try
+            {
+                pipeline.Begin();
+                pipeline.Process(null);
+                pipeline.End();
+                Assert.DoesNotContain(writer.Warnings, (string s) => { return s == PSRuleResources.UsingInvariantCulture; });
+            }
+            finally
+            {
+                PSRuleOption.UseCurrentCulture();
+            }
+        }
+
+        [Fact]
         public void PipelineWithOptions()
         {
             var option = GetOption(GetSourcePath("PSRule.Tests.yml"));


### PR DESCRIPTION
## PR Summary

Fix #899.

Added `Execution.InvariantCultureWarning` option.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
