### PR TITLE
Prefer module sources over loose files

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -11,6 +11,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2201117:
+
+- Engineering:
+  - **Breaking change:** Prefer module sources over loose files. [#610](https://github.com/microsoft/PSRule/issues/610)
+    - Module sources are discovered before loose files.
+    - Warning is shown for duplicate rule names, and exception is thrown for duplicate rule Ids.
+
 ## v2.0.0-B2201117 (pre-release)
 
 What's changed since pre-release v2.0.0-B2201093:

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -17,6 +17,7 @@ What's changed since pre-release v2.0.0-B2201117:
   - **Breaking change:** Prefer module sources over loose files. [#610](https://github.com/microsoft/PSRule/issues/610)
     - Module sources are discovered before loose files.
     - Warning is shown for duplicate rule names, and exception is thrown for duplicate rule Ids.
+    - See [upgrade notes][1] for details.
 
 ## v2.0.0-B2201117 (pre-release)
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -81,11 +81,11 @@ Currently this must be set to `github.com/microsoft/PSRule/v1`.
 
 ### Change in source file discovery for Get-PSRuleHelp
 
-Previously in PSRule _v.1.11.0_ and prior versions, rules would show up twice when running `Get-PSRuleHelp` in the context of a module and in the same working directory of the module.
+Previously in PSRule _v1.11.0_ and prior versions, rules would show up twice when running `Get-PSRuleHelp` in the context of a module and in the same working directory of the module.
 This behavior has no been removed from _v2.0.0_.
 
 Module files are now preferred over loose files, and rules are only shown once in the output.
-Any duplicate rule names that are from loose files are now outputted as a warning instead.
+Any duplicate rule names from loose files are outputted as a warning instead.
 
 The old behavior:
 

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -79,6 +79,37 @@ Currently this must be set to `github.com/microsoft/PSRule/v1`.
     ]
     ```
 
+### Change in source file discovery for Get-PSRuleHelp
+
+Previously in PSRule _v.1.11.0_ and prior versions, rules would show up twice when running `Get-PSRuleHelp` in the context of a module and in the same working directory of the module.
+This behavior has no been removed from _v2.0.0_.
+
+Module files are now preferred over loose files, and rules are only shown once in the output.
+Any duplicate rule names that are from loose files are now outputted as a warning instead.
+
+The old behavior:
+
+```powershell
+Name                                ModuleName               Synopsis
+----                                ----------               --------
+M1.Rule1                                                     This is the default
+M1.Rule2                                                     This is the default
+M1.Rule1                            TestModule               Synopsis en-AU.
+M1.Rule2                            TestModule               This is the default
+```
+
+The new behavior:
+
+```powershell
+WARNING: A rule with the same name 'M1.Rule1' already exists.
+WARNING: A rule with the same name 'M1.Rule2' already exists.
+
+Name                                ModuleName               Synopsis
+----                                ----------               --------
+M1.Rule1                            TestModule               Synopsis en-AU.
+M1.Rule2                            TestModule               This is the default
+```
+
 ## Upgrading to v1.4.0
 
 Follow these notes to upgrade to PSRule _v1.4.0_ from previous versions.

--- a/src/PSRule/Common/RunspaceContextExtensions.cs
+++ b/src/PSRule/Common/RunspaceContextExtensions.cs
@@ -39,6 +39,14 @@ namespace PSRule
             context.Writer.WriteWarning(PSRuleResources.RuleNotFound);
         }
 
+        public static void WarnDuplicateRuleName(this RunspaceContext context, string ruleName)
+        {
+            if (context.Writer == null || !context.Writer.ShouldWriteWarning())
+                return;
+
+            context.Writer.WriteWarning(PSRuleResources.DuplicateRuleName, ruleName);
+        }
+
         public static void DebugPropertyObsolete(this RunspaceContext context, string variableName, string propertyName)
         {
             if (context.Writer == null || !context.Writer.ShouldWriteDebug())

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -439,7 +439,7 @@ namespace PSRule.Host
 
             // Keep track of rule names and ids that have been added
             var seenRuleNames = new HashSet<string>();
-            var seenRuleIds = new HashSet<ResourceId>(new ResourceIdEqualityComparer());
+            var seenRuleIds = new HashSet<ResourceId>();
 
             try
             {

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1966,9 +1966,7 @@ function GetSource {
     )
     process {
         $builder = [PSRule.Pipeline.PipelineBuilder]::RuleSource($Option, $PSCmdlet, $ExecutionContext);
-        if ($UsePWD) {
-            $builder.UsePWD();
-        }
+
         if ($PSBoundParameters.ContainsKey('Path')) {
             try {
                 $builder.Directory($Path);
@@ -2013,6 +2011,12 @@ function GetSource {
             $modules = @(GetRuleModule @moduleParams);
             $builder.Module($modules);
         }
+
+        # Ensure module files are discovered before loose files in PWD
+        if ($UsePWD) {
+            $builder.UsePWD();
+        }
+
         $builder.Build();
     }
 }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -166,13 +166,24 @@ namespace PSRule.Resources
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
+        ///   Looks up a localized string similar to A rule with the same id &apos;{0}&apos; already exists..
         /// </summary>
         internal static string DuplicateRuleId
         {
             get
             {
                 return ResourceManager.GetString("DuplicateRuleId", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
+        /// </summary>
+        internal static string DuplicateRuleName
+        {
+            get
+            {
+                return ResourceManager.GetString("DuplicateRuleName", resourceCulture);
             }
         }
 

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -145,6 +145,10 @@
     <comment>Occurs when a rule dependency is not discovered.</comment>
   </data>
   <data name="DuplicateRuleId" xml:space="preserve">
+    <value>A rule with the same id '{0}' already exists.</value>
+    <comment>Occurs when the same rule id is used.</comment>
+  </data>
+  <data name="DuplicateRuleName" xml:space="preserve">
     <value>A rule with the same name '{0}' already exists.</value>
     <comment>Occurs when the same rule name is used.</comment>
   </data>

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -2259,12 +2259,13 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         BeforeAll {
             # Get a list of rules
             $searchPath = Join-Path -Path $here -ChildPath 'TestModule';
+            $options = @{ 'Execution.InvariantCultureWarning' = $False }
         }
 
         It 'Docs from imported module' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -WarningVariable outWarnings -WarningAction SilentlyContinue);
+                $result = @(Get-PSRuleHelp -Option $options -WarningVariable outWarnings -WarningAction SilentlyContinue);
                 $result.Length | Should -Be 3;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2289,7 +2290,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         It 'Using wildcard in name' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -Name M1.* -WarningVariable outWarnings -WarningAction SilentlyContinue);
+                $result = @(Get-PSRuleHelp -Name M1.* -Option $options -WarningVariable outWarnings -WarningAction SilentlyContinue);
                 $result.Length | Should -Be 3;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';

--- a/tests/PSRule.Tests/TestModule8/TestModule8.psd1
+++ b/tests/PSRule.Tests/TestModule8/TestModule8.psd1
@@ -1,0 +1,131 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# A module for Pester testing for PSRule
+#
+
+@{
+
+# Script module or binary module file associated with this manifest.
+# RootModule = ''
+
+# Version number of this module.
+ModuleVersion = '0.0.1'
+
+# Supported PSEditions
+# CompatiblePSEditions = @()
+
+# ID used to uniquely identify this module
+GUID = 'ff869216-0ca8-42e8-930f-5728719d4f5d'
+
+# Author of this module
+Author = 'Armaan Mcleod'
+
+# Company or vendor of this module
+CompanyName = 'Armaan Mcleod'
+
+# Copyright statement for this module
+Copyright = '(c) Armaan Mcleod. All rights reserved.'
+
+# Description of the functionality provided by this module
+Description = 'A module for Pester testing for PSRule.'
+
+# Minimum version of the PowerShell engine required by this module
+# PowerShellVersion = ''
+
+# Name of the PowerShell host required by this module
+# PowerShellHostName = ''
+
+# Minimum version of the PowerShell host required by this module
+# PowerShellHostVersion = ''
+
+# Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+# DotNetFrameworkVersion = ''
+
+# Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
+# ClrVersion = ''
+
+# Processor architecture (None, X86, Amd64) required by this module
+# ProcessorArchitecture = ''
+
+# Modules that must be imported into the global environment prior to importing this module
+# RequiredModules = @()
+
+# Assemblies that must be loaded prior to importing this module
+# RequiredAssemblies = @()
+
+# Script files (.ps1) that are run in the caller's environment prior to importing this module.
+# ScriptsToProcess = @()
+
+# Type files (.ps1xml) to be loaded when importing this module
+# TypesToProcess = @()
+
+# Format files (.ps1xml) to be loaded when importing this module
+# FormatsToProcess = @()
+
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
+# NestedModules = @()
+
+# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+FunctionsToExport = @()
+
+# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+CmdletsToExport = @()
+
+# Variables to export from this module
+VariablesToExport = '*'
+
+# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+AliasesToExport = @()
+
+# DSC resources to export from this module
+# DscResourcesToExport = @()
+
+# List of all modules packaged with this module
+# ModuleList = @()
+
+# List of all files packaged with this module
+# FileList = @()
+
+# Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
+PrivateData = @{
+
+    PSData = @{
+
+        # Tags applied to this module. These help with module discovery in online galleries.
+        # Tags = @()
+
+        # A URL to the license for this module.
+        # LicenseUri = ''
+
+        # A URL to the main website for this project.
+        # ProjectUri = ''
+
+        # A URL to an icon representing this module.
+        # IconUri = ''
+
+        # ReleaseNotes of this module
+        # ReleaseNotes = ''
+
+        # Prerelease string of this module
+        # Prerelease = ''
+
+        # Flag to indicate whether the module requires explicit user acceptance for install/update/save
+        # RequireLicenseAcceptance = $false
+
+        # External dependent modules of this module
+        # ExternalModuleDependencies = @()
+
+    } # End of PSData hashtable
+
+} # End of PrivateData hashtable
+
+# HelpInfo URI of this module
+# HelpInfoURI = ''
+
+# Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
+# DefaultCommandPrefix = ''
+
+}
+

--- a/tests/PSRule.Tests/TestModule8/rules/Test.Rule.ps1
+++ b/tests/PSRule.Tests/TestModule8/rules/Test.Rule.ps1
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# A set of test rules in a module
+#
+
+# Synopsis: This is the default
+Rule 'M1.Rule1' {
+    # This is a test rule
+}
+
+# Synopsis: This is the default
+Rule 'M1.Rule2' {
+    # This is a test rule
+}
+
+# Synopsis: This is the default
+Rule 'M1.Rule2' {
+    # This is a test rule
+}


### PR DESCRIPTION
## PR Summary

Fix #610.

Added code change to prefer module sources over loose files. 

Ensured loose files detected by PWD is moved after module sources are discovered, to ensure modules are looked at first.

Also used a hashset approach to keep track rule names and ids, then add a warning for duplicate rule names and throw an error for duplicate rule IDs if any are found.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
