### PR TITLE
Fix suppression group undefined or empty rules

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -19,6 +19,9 @@ What's changed since pre-release v2.0.0-B2201117:
     - Warning is shown for duplicate rule names, and exception is thrown for duplicate rule Ids.
     - See [upgrade notes][1] for details.
   - Added more tests for JSON resources. [#929](https://github.com/microsoft/PSRule/issues/929)
+- Bug fixes:
+  - Empty suppression group rules property applies to no rules. [#931](https://github.com/microsoft/PSRule/issues/931)
+  - Object reference for suppression group will rule not defined. [#932](https://github.com/microsoft/PSRule/issues/932)
 
 ## v2.0.0-B2201117 (pre-release)
 

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -259,7 +259,7 @@ namespace PSRule.Definitions.Expressions
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
 
-            var resourceIdComparer = new ResourceIdEqualityComparer();
+            var resourceIdComparer = ResourceIdEqualityComparer.Default;
 
             var ruleRecord = context.RuleRecord;
             var ruleName = ruleRecord.RuleName;

--- a/src/PSRule/Definitions/ResourceIndex.cs
+++ b/src/PSRule/Definitions/ResourceIndex.cs
@@ -14,7 +14,7 @@ namespace PSRule.Definitions
             _Items = Load(items);
         }
 
-        private sealed class IndexEntry
+        internal sealed class IndexEntry
         {
             public readonly ResourceId Id;
             public readonly ResourceId Target;
@@ -57,6 +57,11 @@ namespace PSRule.Definitions
         public bool IsEmpty()
         {
             return _Items == null || _Items.Length == 0;
+        }
+
+        public IndexEntry[] GetItems()
+        {
+            return _Items;
         }
     }
 }

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1218,9 +1218,14 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $testObject[1].PSObject.TypeNames.Insert(0, 'TestType');
 
             $suppressionGroupPath = Join-Path -Path $here -ChildPath 'SuppressionGroups.Rule.yaml';
+            $suppressionGroupPath2 = Join-Path -Path $here -ChildPath 'SuppressionGroups2.Rule.yaml';
 
             $invokeParams = @{
                 Path = $ruleFilePath, $suppressionGroupPath
+            }
+
+            $invokeParams2 = @{
+                Path = $ruleFilePath, $suppressionGroupPath2
             }
         }
 
@@ -1245,6 +1250,18 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages[4].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
                 $warningMessages[5] | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages[5].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'.";
+            }
+
+            It 'Show warnings for all rules when rule property is null or empty' {
+                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False;
+
+                $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
+
+                $warningMessages = $outwarnings.ToArray();
+                $warningMessages.Length | Should -Be 146;
+
+                $warningMessages | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages.Message | Should -MatchExactly "Rule '.\\[a-zA-Z0-9]+' was suppressed by suppression group '.\\SuppressWithTargetNameAnd(Null|Empty)Rule' for 'TestObject[1-2]'."
             }
 
             It 'No warnings' {
@@ -1274,6 +1291,20 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages[2].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject2'.";
                 $warningMessages[3] | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages[3].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'.";
+            }
+
+            It 'Show warnings for all rules when rule property is null or empty' {
+                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False;
+
+                $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
+
+                $warningMessages = $outwarnings.ToArray();
+                $warningMessages.Length | Should -Be 2;
+
+                $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages[0].Message | Should -BeExactly "73 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'."
+                $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
+                $warningMessages[1].Message | Should -BeExactly "73 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'."
             }
 
             It 'No warnings' {

--- a/tests/PSRule.Tests/SuppressionGroups2.Rule.yaml
+++ b/tests/PSRule.Tests/SuppressionGroups2.Rule.yaml
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Suppression groups for unit testing
+
+---
+# Synopsis: Suppress with target name for all(null) rules
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithTargetNameAndNullRule
+spec:
+  if:
+    name: '.'
+    equals: 'TestObject1'
+
+---
+# Synopsis: Suppress with target name for all(empty) rules
+apiVersion: github.com/microsoft/PSRule/v1
+kind: SuppressionGroup
+metadata:
+  name: SuppressWithTargetNameAndEmptyRule
+spec:
+  rule: []
+  if:
+    name: '.'
+    equals: 'TestObject2'


### PR DESCRIPTION
## PR Summary

Fixes #931
Fixes #932

Added code changes to handle undefined rules and `rule: []`. Both run suppression group against all rules where the selector matches.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
