### PR TITLE
Require rule sources from current working directory to be explicitly included

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -11,6 +11,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2201135:
+
+- Engineering:
+  - **Breaking change:** Require rule sources from current working directory to be explicitly included. [#760](https://github.com/microsoft/PSRule/issues/760)
+    - From v2 onwards, `$PWD` is not included by default unless `-Path .` or `-Path $PWD` is explicitly specified.
+    - See [upgrade notes][1] for details.
+
 ## v2.0.0-B2201135 (pre-release)
 
 What's changed since pre-release v2.0.0-B2201117:

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -17,6 +17,8 @@ What's changed since pre-release v2.0.0-B2201135:
   - **Breaking change:** Require rule sources from current working directory to be explicitly included. [#760](https://github.com/microsoft/PSRule/issues/760)
     - From v2 onwards, `$PWD` is not included by default unless `-Path .` or `-Path $PWD` is explicitly specified.
     - See [upgrade notes][1] for details.
+- Bug fixes:
+  - Fixed rule source loading twice from `$PWD` and `.ps-rule/`. [#939](https://github.com/microsoft/PSRule/issues/939)
 
 ## v2.0.0-B2201135 (pre-release)
 

--- a/docs/commands/PSRule/en-US/Assert-PSRule.md
+++ b/docs/commands/PSRule/en-US/Assert-PSRule.md
@@ -433,7 +433,6 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for rule definitions within.
-If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -442,7 +441,7 @@ Aliases: p
 
 Required: False
 Position: 0
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Export-PSRuleBaseline.md
+++ b/docs/commands/PSRule/en-US/Export-PSRuleBaseline.md
@@ -55,7 +55,6 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for baselines within.
-If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -64,7 +63,7 @@ Aliases: p
 
 Required: False
 Position: 1
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Get-PSRule.md
+++ b/docs/commands/PSRule/en-US/Get-PSRule.md
@@ -106,7 +106,6 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for rule definitions within.
-If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -115,7 +114,7 @@ Aliases: p
 
 Required: False
 Position: 0
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
+++ b/docs/commands/PSRule/en-US/Get-PSRuleBaseline.md
@@ -72,7 +72,6 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for baselines within.
-If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -81,7 +80,7 @@ Aliases: p
 
 Required: False
 Position: 1
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Invoke-PSRule.md
+++ b/docs/commands/PSRule/en-US/Invoke-PSRule.md
@@ -147,7 +147,6 @@ Accept wildcard characters: False
 ### -Path
 
 One or more paths to search for rule definitions within.
-If no sources are specified by `-Path`, `-Module`, or options, the current working directory is used.
 
 ```yaml
 Type: String[]
@@ -156,7 +155,7 @@ Aliases: p
 
 Required: False
 Position: 0
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -145,7 +145,6 @@ Accept wildcard characters: False
 ### -Path
 
 The path to a YAML file containing options.
-By default the current working path (`$PWD`) is used.
 
 Either a directory or file path can be specified.
 When a directory is used, `ps-rule.yaml` will be used as the file name.
@@ -159,7 +158,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -59,7 +59,7 @@ If the file does not exist, a new file is created.
 
 ### -Path
 
-The path to a YAML file where options will be set. By default the current working path (`$PWD`) is used.
+The path to a YAML file where options will be set.
 
 Either a directory or file path can be specified.
 When a directory is used, `ps-rule.yaml` will be used as the file name.
@@ -77,7 +77,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
+++ b/docs/commands/PSRule/en-US/Test-PSRuleTarget.md
@@ -62,8 +62,6 @@ Evaluate a simple hashtable on the pipeline against rules loaded from the curren
 
 One or more paths to search for rule definitions within.
 
-If this parameter is not specified the current working path will be used, unless the `-Module` parameter is used.
-
 If the `-Module` parameter is used, rule definitions from the currently working path will not be included by default.
 
 ```yaml
@@ -73,7 +71,7 @@ Aliases: p
 
 Required: False
 Position: 1
-Default value: $PWD
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -110,6 +110,49 @@ M1.Rule1                            TestModule               Synopsis en-AU.
 M1.Rule2                            TestModule               This is the default
 ```
 
+### Require source discovery from current working directory to be explicitly included
+
+Previously in PSRule _v1.11.0_ and prior versions, rule sources from the current working directory without the `-Path` and `-Module` parameters were automatically included.
+This behavior has no been removed from _v2.0.0_.
+
+Rules sources in the current working directory are only included if `-Path .` or `-Path $PWD` is specified.
+
+The old behavior:
+
+```powershell
+Set-Location docs\scenarios\azure-resources
+Get-PSRule
+
+RuleName                            ModuleName                 Synopsis
+--------                            ----------                 --------
+appServicePlan.MinInstanceCount                                App Service Plan has multiple instances
+appServicePlan.MinPlan                                         Use at least a Standard App Service Plan
+appServiceApp.ARRAffinity                                      Disable client affinity for stateless services
+appServiceApp.UseHTTPS                                         Use HTTPS only
+storageAccounts.UseHttps                                       Configure storage accounts to only accept encrypted traffic i.e. HTTPS/SMB
+storageAccounts.UseEncryption                                  Use at-rest storage encryption
+```
+
+The new behavior:
+
+```powershell
+Set-Location docs\scenarios\azure-resources
+Get-PSRule
+
+# No output, need to specify -Path explicitly
+
+Get-PSRule -Path $PWD
+
+RuleName                            ModuleName                 Synopsis
+--------                            ----------                 --------
+appServicePlan.MinInstanceCount                                App Service Plan has multiple instances
+appServicePlan.MinPlan                                         Use at least a Standard App Service Plan
+appServiceApp.ARRAffinity                                      Disable client affinity for stateless services
+appServiceApp.UseHTTPS                                         Use HTTPS only
+storageAccounts.UseHttps                                       Configure storage accounts to only accept encrypted traffic i.e. HTTPS/SMB
+storageAccounts.UseEncryption      
+```
+
 ## Upgrading to v1.4.0
 
 Follow these notes to upgrade to PSRule _v1.4.0_ from previous versions.

--- a/src/PSRule/Common/StringExtensions.cs
+++ b/src/PSRule/Common/StringExtensions.cs
@@ -73,5 +73,10 @@ namespace PSRule
         {
             return !string.IsNullOrEmpty(str) ? char.ToLowerInvariant(str[0]) + str.Substring(1) : string.Empty;
         }
+
+        public static bool Contains(this string source, string value, StringComparison comparison)
+        {
+            return source?.IndexOf(value, comparison) >= 0;
+        }
     }
 }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -67,7 +67,7 @@ function Invoke-PSRule {
         # A list of paths to check for rule definitions
         [Parameter(Mandatory = $False, Position = 0)]
         [Alias('p')]
-        [String[]]$Path = $PWD,
+        [String[]]$Path,
 
         # Filter to rules with the following names
         [Parameter(Mandatory = $False)]
@@ -117,9 +117,7 @@ function Invoke-PSRule {
         if ($PSBoundParameters.ContainsKey('Module')) {
             $sourceParams['Module'] = $Module;
         }
-        if ($sourceParams.Count -eq 0) {
-            $sourceParams['UsePWD'] = $True;
-        }
+
         $sourceParams['Option'] = $Option;
         [PSRule.Pipeline.Source[]]$sourceFiles = GetSource @sourceParams -Verbose:$VerbosePreference;
 
@@ -226,7 +224,7 @@ function Test-PSRuleTarget {
         # A list of paths to check for rule definitions
         [Parameter(Mandatory = $False, Position = 0)]
         [Alias('p')]
-        [String[]]$Path = $PWD,
+        [String[]]$Path,
 
         # Filter to rules with the following names
         [Parameter(Mandatory = $False)]
@@ -276,9 +274,7 @@ function Test-PSRuleTarget {
         if ($PSBoundParameters.ContainsKey('Module')) {
             $sourceParams['Module'] = $Module;
         }
-        if ($sourceParams.Count -eq 0) {
-            $sourceParams['UsePWD'] = $True;
-        }
+
         $sourceParams['Option'] = $Option;
         [PSRule.Pipeline.Source[]]$sourceFiles = GetSource @sourceParams -Verbose:$VerbosePreference;
 
@@ -489,7 +485,7 @@ function Assert-PSRule {
         # A list of paths to check for rule definitions
         [Parameter(Mandatory = $False, Position = 0)]
         [Alias('p')]
-        [String[]]$Path = $PWD,
+        [String[]]$Path,
 
         # Filter to rules with the following names
         [Parameter(Mandatory = $False)]
@@ -549,9 +545,7 @@ function Assert-PSRule {
         if ($PSBoundParameters.ContainsKey('Module')) {
             $sourceParams['Module'] = $Module;
         }
-        if ($sourceParams.Count -eq 0) {
-            $sourceParams['UsePWD'] = $True;
-        }
+
         $sourceParams['Option'] = $Option;
         [PSRule.Pipeline.Source[]]$sourceFiles = GetSource @sourceParams -Verbose:$VerbosePreference;
 
@@ -659,7 +653,7 @@ function Get-PSRule {
         # A list of paths to check for rule definitions
         [Parameter(Mandatory = $False, Position = 0)]
         [Alias('p')]
-        [String[]]$Path = $PWD,
+        [String[]]$Path,
 
         # Filter to rules with the following names
         [Parameter(Mandatory = $False)]
@@ -704,9 +698,7 @@ function Get-PSRule {
         if ($PSBoundParameters.ContainsKey('ListAvailable')) {
             $sourceParams['ListAvailable'] = $ListAvailable;
         }
-        if ($sourceParams.Count -eq 0) {
-            $sourceParams['UsePWD'] = $True;
-        }
+
         $sourceParams['Option'] = $Option;
         [PSRule.Pipeline.Source[]]$sourceFiles = GetSource @sourceParams -Verbose:$VerbosePreference;
 
@@ -781,7 +773,7 @@ function Get-PSRuleBaseline {
 
         [Parameter(Mandatory = $False, Position = 0)]
         [Alias('p')]
-        [String[]]$Path = $PWD,
+        [String[]]$Path,
 
         [Parameter(Mandatory = $False)]
         [Alias('n')]
@@ -825,9 +817,7 @@ function Get-PSRuleBaseline {
         if ($PSBoundParameters.ContainsKey('ListAvailable')) {
             $sourceParams['ListAvailable'] = $ListAvailable;
         }
-        if ($sourceParams.Count -eq 0) {
-            $sourceParams['UsePWD'] = $True;
-        }
+
         $sourceParams['Option'] = $Option;
         [PSRule.Pipeline.Source[]]$sourceFiles = GetSource @sourceParams -Verbose:$VerbosePreference;
 
@@ -883,7 +873,7 @@ function Export-PSRuleBaseline {
 
         [Parameter(Mandatory = $False, Position = 0)]
         [Alias('p')]
-        [String[]]$Path = $PWD,
+        [String[]]$Path,
 
         [Parameter(Mandatory = $False)]
         [Alias('n')]
@@ -931,10 +921,6 @@ function Export-PSRuleBaseline {
 
         if ($PSBoundParameters.ContainsKey('Module')) {
             $sourceParams['Module'] = $Module;
-        }
-
-        if ($sourceParams.Count -eq 0) {
-            $sourceParams['UsePWD'] = $True;
         }
 
         $sourceParams['Option'] = $Option;
@@ -1008,7 +994,7 @@ function Get-PSRuleHelp {
         # A path to check documentation for.
         [Parameter(Mandatory = $False)]
         [Alias('p')]
-        [String]$Path = $PWD,
+        [String]$Path,
 
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.PSRuleOption]$Option,
@@ -1034,22 +1020,17 @@ function Get-PSRuleHelp {
         # Discover scripts in the specified paths
         $sourceParams = @{ };
         $sourceParams['PreferModule'] = $True;
-        $sourceParams['PreferPath'] = $True;
 
         if ($PSBoundParameters.ContainsKey('Path')) {
             $sourceParams['Path'] = $Path;
-            $sourceParams['PreferModule'] = $False;
         }
         if ($PSBoundParameters.ContainsKey('Module')) {
             $sourceParams['Module'] = $Module;
-            $sourceParams['PreferPath'] = $False;
         }
         if ($PSBoundParameters.ContainsKey('Culture')) {
             $sourceParams['Culture'] = $Culture;
         }
-        if ($sourceParams['PreferPath']) {
-            $sourceParams['UsePWD'] = $True;
-        }
+
         $sourceParams['Option'] = $Option;
         [PSRule.Pipeline.Source[]]$sourceFiles = GetSource @sourceParams -Verbose:$VerbosePreference;
 
@@ -1117,7 +1098,7 @@ function New-PSRuleOption {
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Creates an in memory object only')]
     param (
         [Parameter(Position = 0, Mandatory = $False, ParameterSetName = 'FromPath')]
-        [String]$Path = $PWD,
+        [String]$Path,
 
         [Parameter(Mandatory = $True, ParameterSetName = 'FromOption')]
         [PSRule.Configuration.PSRuleOption]$Option,
@@ -1384,7 +1365,7 @@ function Set-PSRuleOption {
     param (
         # The path to a YAML file where options will be set
         [Parameter(Position = 0, Mandatory = $False)]
-        [String]$Path = $PWD,
+        [String]$Path,
 
         [Parameter(Mandatory = $False, ValueFromPipeline = $True)]
         [PSRule.Configuration.PSRuleOption]$Option,
@@ -1953,28 +1934,13 @@ function GetSource {
         [String]$Culture,
 
         [Parameter(Mandatory = $False)]
-        [Switch]$PreferPath = $False,
-
-        [Parameter(Mandatory = $False)]
         [Switch]$PreferModule = $False,
 
         [Parameter(Mandatory = $True)]
-        [PSRule.Configuration.PSRuleOption]$Option,
-
-        [Parameter(Mandatory = $False)]
-        [Switch]$UsePWD
+        [PSRule.Configuration.PSRuleOption]$Option
     )
     process {
         $builder = [PSRule.Pipeline.PipelineBuilder]::RuleSource($Option, $PSCmdlet, $ExecutionContext);
-
-        if ($PSBoundParameters.ContainsKey('Path')) {
-            try {
-                $builder.Directory($Path);
-            }
-            catch {
-                throw $_.Exception.GetBaseException();
-            }
-        }
 
         $moduleParams = @{};
         if ($PSBoundParameters.ContainsKey('Module')) {
@@ -2012,9 +1978,14 @@ function GetSource {
             $builder.Module($modules);
         }
 
-        # Ensure module files are discovered before loose files in PWD
-        if ($UsePWD) {
-            $builder.UsePWD();
+        # Ensure module files are discovered before loose files in Path
+        if ($PSBoundParameters.ContainsKey('Path')) {
+            try {
+                $builder.Directory($Path);
+            }
+            catch {
+                throw $_.Exception.GetBaseException();
+            }
         }
 
         $builder.Build();

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1981,7 +1981,7 @@ function GetSource {
         # Ensure module files are discovered before loose files in Path
         if ($PSBoundParameters.ContainsKey('Path')) {
             try {
-                $builder.Directory($Path);
+                $builder.Directory($Path, $True);
             }
             catch {
                 throw $_.Exception.GetBaseException();

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -168,7 +168,6 @@ namespace PSRule.Pipeline
         private readonly HostContext _HostContext;
         private readonly HostPipelineWriter _Writer;
         private readonly bool _UseDefaultPath;
-        private readonly bool _NoSourcesConfigured;
 
         internal SourcePipelineBuilder(HostContext hostContext, PSRuleOption option)
         {
@@ -177,7 +176,6 @@ namespace PSRule.Pipeline
             _Writer = new HostPipelineWriter(hostContext, option);
             _Writer.EnterScope("[Discovery.Source]");
             _UseDefaultPath = option == null || option.Include == null || option.Include.Path == null;
-            _NoSourcesConfigured = option == null || option.Include == null || (option.Include.Path == null && option.Include.Module == null);
 
             // Include paths from options
             if (!_UseDefaultPath)
@@ -208,14 +206,6 @@ namespace PSRule.Pipeline
                 return;
 
             _Writer.WriteVerbose(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ScanModule, moduleName));
-        }
-
-        public void UsePWD()
-        {
-            if (!_NoSourcesConfigured)
-                return;
-
-            Directory(PSRuleOption.GetWorkingPath());
         }
 
         /// <summary>

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -344,21 +344,20 @@ namespace PSRule.Pipeline
 
         private static SourceFile[] IncludePath(string path, string helpPath, string moduleName, bool excludeDefaultRulePath)
         {
-            if (excludeDefaultRulePath)
+            if (!excludeDefaultRulePath)
             {
-                var filteredFiles = FilterFiles(
-                    path,
-                    directoryFilter: dir => !dir.Contains(
-                        DefaultRulePath.TrimEnd(Path.AltDirectorySeparatorChar),
-                        StringComparison.OrdinalIgnoreCase),
-                    filePattern: "*.Rule.*");
-
-                return GetSourceFiles(filteredFiles, helpPath, moduleName);
+                var allFiles = System.IO.Directory.EnumerateFiles(path, "*.Rule.*", SearchOption.AllDirectories);
+                return GetSourceFiles(allFiles, helpPath, moduleName);
             }
 
-            var allFiles = System.IO.Directory.EnumerateFiles(path, "*.Rule.*", SearchOption.AllDirectories);
+            var filteredFiles = FilterFiles(
+                path,
+                directoryFilter: dir => !dir.Contains(
+                    DefaultRulePath.TrimEnd(Path.AltDirectorySeparatorChar),
+                    StringComparison.OrdinalIgnoreCase),
+                filePattern: "*.Rule.*");
 
-            return GetSourceFiles(allFiles, helpPath, moduleName);
+            return GetSourceFiles(filteredFiles, helpPath, moduleName);
         }
 
         private static SourceFile[] GetSourceFiles(IEnumerable<string> files, string helpPath, string moduleName)

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -350,14 +350,13 @@ namespace PSRule.Pipeline
                 return GetSourceFiles(allFiles, helpPath, moduleName);
             }
 
-            var filteredFiles = FilterFiles(
-                path,
-                directoryFilter: dir => !dir.Contains(
-                    DefaultRulePath.TrimEnd(Path.AltDirectorySeparatorChar),
-                    StringComparison.OrdinalIgnoreCase),
-                filePattern: "*.Rule.*");
-
+            var filteredFiles = FilterFiles(path, "*.Rule.*", dir => !PathContainsDefaultRulePath(dir));
             return GetSourceFiles(filteredFiles, helpPath, moduleName);
+        }
+
+        private static bool PathContainsDefaultRulePath(string path)
+        {
+            return path.Contains(DefaultRulePath.TrimEnd(Path.AltDirectorySeparatorChar), StringComparison.OrdinalIgnoreCase);
         }
 
         private static SourceFile[] GetSourceFiles(IEnumerable<string> files, string helpPath, string moduleName)
@@ -377,7 +376,7 @@ namespace PSRule.Pipeline
             return result.ToArray();
         }
 
-        private static IEnumerable<string> FilterFiles(string path, Func<string, bool> directoryFilter, string filePattern)
+        private static IEnumerable<string> FilterFiles(string path, string filePattern, Func<string, bool> directoryFilter)
         {
             foreach (var file in System.IO.Directory.GetFiles(path, filePattern, SearchOption.TopDirectoryOnly))
                 yield return file;
@@ -388,7 +387,7 @@ namespace PSRule.Pipeline
 
             foreach (var directory in filteredDirectories)
             {
-                foreach (var file in FilterFiles(directory, directoryFilter, filePattern))
+                foreach (var file in FilterFiles(directory, filePattern, directoryFilter))
                     yield return file;
             }
         }

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -179,7 +179,7 @@ namespace PSRule.Pipeline
 
             // Include paths from options
             if (!_UseDefaultPath)
-                Directory(option.Include.Path, excludeDefaultRulePath: false);
+                Directory(option.Include.Path);
         }
 
         public bool ShouldLoadModule => _HostContext.GetAutoLoadingPreference() == PSModuleAutoLoadingPreference.All;
@@ -212,7 +212,7 @@ namespace PSRule.Pipeline
         /// Add loose files as a source.
         /// </summary>
         /// <param name="path">A file or directory path containing one or more rule files.</param>
-        public void Directory(string[] path, bool excludeDefaultRulePath = true)
+        public void Directory(string[] path, bool excludeDefaultRulePath = false)
         {
             if (path == null || path.Length == 0)
                 return;
@@ -221,7 +221,7 @@ namespace PSRule.Pipeline
                 Directory(path[i], excludeDefaultRulePath);
         }
 
-        public void Directory(string path, bool excludeDefaultRulePath)
+        public void Directory(string path, bool excludeDefaultRulePath = false)
         {
             if (string.IsNullOrEmpty(path))
                 return;
@@ -291,7 +291,7 @@ namespace PSRule.Pipeline
         private void Default()
         {
             if (_UseDefaultPath)
-                Directory(DefaultRulePath, excludeDefaultRulePath: false);
+                Directory(DefaultRulePath);
         }
 
         private void Source(Source source)

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1754,7 +1754,7 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         It 'Returns rules in current path' {
             try {
                 Push-Location -Path $searchPath;
-                $result = @(Get-PSRule -Option @{ 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule  -Path $PWD -Option @{ 'Execution.InvariantCultureWarning' = $False })
                 $result | Should -Not -BeNullOrEmpty;
                 $result.Length | Should -Be 3;
                 $result.RuleName | Should -BeIn 'M1.Rule1', 'M1.Rule2', 'M1.YamlTestName';
@@ -1869,7 +1869,7 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         It 'Uses rules with include option' {
             Push-Location -Path (Join-Path -Path $here -ChildPath 'rules/')
             try {
-                $result = @(Get-PSRule -Option @{ 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path $PWD -Option @{ 'Execution.InvariantCultureWarning' = $False })
                 $result.Length | Should -Be 4;
 
                 $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCultureWarning' = $False })
@@ -2296,7 +2296,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         It 'Docs from imported module' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -Option $options -WarningVariable outWarnings -WarningAction SilentlyContinue);
+                $result = @(Get-PSRuleHelp -Path $PWD -Option $options -WarningVariable outWarnings -WarningAction SilentlyContinue);
                 $result.Length | Should -Be 3;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2321,7 +2321,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         It 'Using wildcard in name' {
             try {
                 Push-Location $searchPath;
-                $result = @(Get-PSRuleHelp -Name M1.* -Option $options -WarningVariable outWarnings -WarningAction SilentlyContinue);
+                $result = @(Get-PSRuleHelp -Path $PWD -Name M1.* -Option $options -WarningVariable outWarnings -WarningAction SilentlyContinue);
                 $result.Length | Should -Be 3;
                 $result[0].Name | Should -Be 'M1.Rule1';
                 $result[1].Name | Should -Be 'M1.Rule2';
@@ -2350,7 +2350,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
 
             try {
                 Push-Location $searchPath;
-                { Get-PSRuleHelp } | Should -Throw "A rule with the same id '.\M1.Rule2' already exists.";
+                { Get-PSRuleHelp -Path $PWD } | Should -Throw "A rule with the same id '.\M1.Rule2' already exists.";
             }
             finally {
                 Pop-Location;


### PR DESCRIPTION
## PR Summary

Fixes #760
Fixes #939

Added code changes to remove `$PWD` from `-Path` by default. 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [ ] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
