### PR TITLE
Pre-release v2.0.0-B2201146

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -11,6 +11,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.0.0-B2201146 (pre-release)
+
 What's changed since pre-release v2.0.0-B2201135:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v2.0.0-B2201135:

- Engineering:
  - **Breaking change:** Require rule sources from current working directory to be explicitly included. #760
    - From v2 onwards, `$PWD` is not included by default unless `-Path .` or `-Path $PWD` is explicitly specified.
- Bug fixes:
  - Fixed rule source loading twice from `$PWD` and `.ps-rule/`. #939

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
