### PR TITLE
Added support for rule severity level #880

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -11,6 +11,16 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2201146:
+
+- New features:
+  - Added support for rule severity level. [#880](https://github.com/microsoft/PSRule/issues/880)
+    - Rules can be configured to be `Error`, `Warning`, or `Information`.
+    - Failing rules with the `Error` severity level will cause the pipeline to fail.
+    - Rules with the `Warning` severity level will be reported as warnings.
+    - Rules with the `Information` severity level will be reported as informational messages.
+    - By default, the severity level for a rule is `Error`.
+
 ## v2.0.0-B2201146 (pre-release)
 
 What's changed since pre-release v2.0.0-B2201135:

--- a/docs/authoring/writing-rules.md
+++ b/docs/authoring/writing-rules.md
@@ -228,7 +228,7 @@ By default, the severity level for a rule is `Error`.
 - `Warning` - A problem that should be addressed.
 - `Information` - A minor problem or an opportunity to improve the code.
 
-In a continious integration (CI) pipeline, severity level is particularly important.
+In a continuous integration (CI) pipeline, severity level is particularly important.
 If any rule fails with a severity level of `Error` the pipeline will fail.
 This helps prevent serious problems from being introduced into the code base or deployed.
 

--- a/docs/authoring/writing-rules.md
+++ b/docs/authoring/writing-rules.md
@@ -206,9 +206,91 @@ In the example a `minTLSVersion` configuration setting does not exist and is not
     1.  An additional, `$Assert.HasFieldValue` assertion helper method can be called.
         The rule will pass if all of the conditions return true.
 
-## Testing the rule
+## Testing
 
+### Testing manually
+
+To test the rule manually, run the following command.
 
 ```powershell
 Assert-PSRule -f ./settings.json
 ```
+
+## Advanced usage
+
+### Severity level
+
+When defining a rule, you can specify a severity level.
+The severity level is used if the rule fails.
+By default, the severity level for a rule is `Error`.
+
+- `Error` - A serious problem that must be addressed before going forward.
+- `Warning` - A problem that should be addressed.
+- `Information` - A minor problem or an opportunity to improve the code.
+
+In a continious integration (CI) pipeline, severity level is particularly important.
+If any rule fails with a severity level of `Error` the pipeline will fail.
+This helps prevent serious problems from being introduced into the code base or deployed.
+
+The following example shows how to set the severity level to `Warning`.
+
+=== "YAML"
+
+    ```yaml hl_lines="8"
+    ---
+    # Synopsis: An example rule to require TLS.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: Rule
+    metadata:
+      name: 'Local.YAML.RequireTLS'
+    spec:
+      level: Warning
+      condition:
+        allOf:
+        - field: 'configure.supportsHttpsTrafficOnly'
+          equals: true
+        - field: 'configure.minTLSVersion'
+          equals: '1.2'
+    ```
+
+=== "JSON"
+
+    ```json hl_lines="10"
+    [
+        {
+            // Synopsis: An example rule to require TLS.
+            "apiVersion": "github.com/microsoft/PSRule/v1",
+            "kind": "Rule",
+            "metadata": {
+                "name": "Local.JSON.RequireTLS"
+            },
+            "spec": {
+                "level": "Warning",
+                "condition": {
+                    "allOf": [
+                        {
+                            "field": "configure.supportsHttpsTrafficOnly",
+                            "equals": true
+                        },
+                        {
+                            "field": "configure.minTLSVersion",
+                            "equals": "1.2"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+    ```
+
+=== "PowerShell"
+
+    Update `.ps-rule/Local.Rule.ps1` in your repository with the following contents.
+
+    ```powershell hl_lines="2"
+    # Synopsis: An example rule to require TLS.
+    Rule 'Local.PS.RequireTLS' -Level Warning {
+        $Assert.HasFieldValue($TargetObject, 'configure.supportsHttpsTrafficOnly', $True)
+        $Assert.HasFieldValue($TargetObject, 'configure.minTLSVersion', '1.2')
+    }
+    ```

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -570,6 +570,18 @@
                     "markdownDescription": "A condition is made up of one or more [expressions](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/) that will determine if the rule passes or fails. [See help](https://microsoft.github.io/PSRule/v2/authoring/writing-rules/)",
                     "$ref": "#/definitions/selectorExpression"
                 },
+                "level": {
+                    "type": "string",
+                    "title": "Level",
+                    "description": "If the rule fails, how serious is the result. By default this is set to Error.",
+                    "markdownDescription": "If the rule fails, how serious is the result. By default this is set to `Error`. [See help](https://microsoft.github.io/PSRule/v2/authoring/writing-rules/)",
+                    "enum": [
+                        "Error",
+                        "Warning",
+                        "Information"
+                    ],
+                    "default": "Error"
+                },
                 "type": {
                     "type": "array",
                     "title": "Type pre-condition",

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Management.Automation;
 using System.Threading;
 using PSRule.Definitions;
+using PSRule.Definitions.Rules;
 using PSRule.Pipeline;
 using PSRule.Resources;
 using PSRule.Rules;
@@ -32,6 +33,12 @@ namespace PSRule.Commands
         [ValidateNotNullOrEmpty()]
         [ValidateLength(3, 128)]
         public string Name { get; set; }
+
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SeverityLevel? Level { get; set; }
 
         /// <summary>
         /// The definition of the deployment.
@@ -94,6 +101,7 @@ namespace PSRule.Commands
             var context = RunspaceContext.CurrentThread;
             var errorPreference = GetErrorActionPreference();
             var metadata = GetCommentMetadata(MyInvocation.ScriptName, MyInvocation.ScriptLineNumber, MyInvocation.OffsetInLine);
+            var level = ResourceHelper.GetLevel(Level);
             var tag = GetTag(Tag);
             var source = context.Source.File;
             var extent = new RuleExtent(
@@ -119,6 +127,7 @@ namespace PSRule.Commands
                 source: source,
                 id: id,
                 @ref: ResourceHelper.GetIdNullable(source.ModuleName, Ref, ResourceIdKind.Ref),
+                level: level,
                 info: info,
                 condition: ps,
                 tag: tag,

--- a/src/PSRule/Common/SeverityLevelExtensions.cs
+++ b/src/PSRule/Common/SeverityLevelExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Definitions.Rules;
+
+namespace PSRule
+{
+    internal static class SeverityLevelExtensions
+    {
+        public static SeverityLevel GetWorstCase(this SeverityLevel o1, SeverityLevel o2)
+        {
+            if (o2 == SeverityLevel.Error || o1 == SeverityLevel.Error)
+                return SeverityLevel.Error;
+            else if (o2 == SeverityLevel.Warning || o1 == SeverityLevel.Warning)
+                return SeverityLevel.Warning;
+
+            return o2 == SeverityLevel.Information || o1 == SeverityLevel.Information ? SeverityLevel.Information : SeverityLevel.None;
+        }
+    }
+}

--- a/src/PSRule/Definitions/IResultRecord.cs
+++ b/src/PSRule/Definitions/IResultRecord.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Definitions
+{
+    public interface IResultRecord
+    {
+    }
+}

--- a/src/PSRule/Definitions/IRuleResult.cs
+++ b/src/PSRule/Definitions/IRuleResult.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Definitions.Rules;
+using PSRule.Rules;
+
+namespace PSRule.Definitions
+{
+    public interface IRuleResult : IResultRecord
+    {
+        string RunId { get; }
+
+        RuleOutcome Outcome { get; }
+
+        SeverityLevel Level { get; }
+
+        long Time { get; }
+    }
+}

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using PSRule.Definitions.Rules;
 using PSRule.Pipeline;
 using PSRule.Runtime;
 using YamlDotNet.Core;
@@ -495,6 +496,11 @@ namespace PSRule.Definitions
                 metadata.Annotations != null &&
                 metadata.Annotations.TryGetBool(ANNOTATION_OBSOLETE, out var obsolete)
                 && obsolete.GetValueOrDefault(false);
+        }
+
+        internal static SeverityLevel GetLevel(SeverityLevel? level)
+        {
+            return !level.HasValue || level.Value == SeverityLevel.None ? RuleV1.DEFAULT_LEVEL : level.Value;
         }
     }
 }

--- a/src/PSRule/Definitions/Rules/Rule.cs
+++ b/src/PSRule/Definitions/Rules/Rule.cs
@@ -9,10 +9,29 @@ using YamlDotNet.Serialization;
 
 namespace PSRule.Definitions.Rules
 {
+    /// <summary>
+    /// If the rule fails, how serious is the result.
+    /// </summary>
+    public enum SeverityLevel
+    {
+        None = 0,
+
+        Error = 1,
+
+        Warning = 2,
+
+        Information = 3
+    }
+
     public interface IRuleV1 : IResource, IDependencyTarget
     {
         [Obsolete("Use Name instead.")]
         string RuleName { get; }
+
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        SeverityLevel Level { get; }
 
         string Synopsis { get; }
 
@@ -28,6 +47,11 @@ namespace PSRule.Definitions.Rules
     {
         LanguageIf Condition { get; }
 
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        SeverityLevel? Level { get; }
+
         string[] Type { get; }
 
         string[] With { get; }
@@ -36,11 +60,14 @@ namespace PSRule.Definitions.Rules
     [Spec(Specs.V1, Specs.Rule)]
     internal sealed class RuleV1 : InternalResource<RuleV1Spec>, IResource, IRuleV1
     {
+        internal const SeverityLevel DEFAULT_LEVEL = SeverityLevel.Error;
+
         public RuleV1(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, RuleV1Spec spec)
             : base(ResourceKind.Rule, apiVersion, source, metadata, info, spec)
         {
             Ref = ResourceHelper.GetIdNullable(source.ModuleName, metadata.Ref, ResourceIdKind.Ref);
             Alias = ResourceHelper.GetRuleId(source.ModuleName, metadata.Alias, ResourceIdKind.Alias);
+            Level = ResourceHelper.GetLevel(spec.Level);
         }
 
         [JsonIgnore]
@@ -50,6 +77,13 @@ namespace PSRule.Definitions.Rules
         [JsonIgnore]
         [YamlIgnore]
         public ResourceId[] Alias { get; }
+
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        [JsonIgnore]
+        [YamlIgnore]
+        public SeverityLevel Level { get; }
 
         /// <summary>
         /// A human readable block of text, used to identify the purpose of the rule.
@@ -83,6 +117,11 @@ namespace PSRule.Definitions.Rules
     internal sealed class RuleV1Spec : Spec, IRuleSpec
     {
         public LanguageIf Condition { get; set; }
+
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        public SeverityLevel? Level { get; set; }
 
         /// <summary>
         /// An optional type precondition before the rule is evaluated.

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -404,6 +404,7 @@ namespace PSRule.Host
                         Alias = block.Alias,
                         Source = block.Source,
                         Tag = block.Tag,
+                        Level = block.Level,
                         Info = block.Info,
                         DependsOn = block.DependsOn,
                         Flags = block.Flags,
@@ -422,6 +423,7 @@ namespace PSRule.Host
                         Alias = block.Alias,
                         Source = block.Source,
                         Tag = block.Metadata.Tags,
+                        Level = block.Level,
                         Info = info,
                         DependsOn = null, // TODO: No support for DependsOn yet
                         Flags = block.Flags,
@@ -439,7 +441,6 @@ namespace PSRule.Host
         private static DependencyTargetCollection<RuleBlock> ToRuleBlockV1(ILanguageBlock[] blocks, RunspaceContext context)
         {
             // Index rules by RuleId
-            //var results = new Dictionary<string, RuleBlock>(StringComparer.OrdinalIgnoreCase);
             var results = new DependencyTargetCollection<RuleBlock>();
 
             // Keep track of rule names and ids that have been added
@@ -488,10 +489,11 @@ namespace PSRule.Host
                         var block = new RuleBlock
                         (
                             source: yaml.Source,
-                            id: ruleId,
+                            id: yaml.Id,
                             @ref: yaml.Ref,
+                            level: yaml.Level,
                             info: info,
-                            condition: new RuleVisitor(yaml.Source.ModuleName, ruleId.Value, yaml.Spec),
+                            condition: new RuleVisitor(yaml.Source.ModuleName, yaml.Id.Value, yaml.Spec),
                             alias: yaml.Alias,
                             tag: yaml.Metadata.Tags,
                             dependsOn: null,  // TODO: No support for DependsOn yet

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1662,6 +1662,10 @@ function Rule {
         [Parameter(Mandatory = $False)]
         [String[]]$Alias,
 
+        # If the rule fails, how serious is the result.
+        [Parameter(Mandatory = $False)]
+        [PSRule.Definitions.Rules.SeverityLevel]$Level,
+
         # The body of the rule
         [Parameter(Position = 1, Mandatory = $True)]
         [ScriptBlock]$Body,

--- a/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
@@ -1,0 +1,711 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Management.Automation;
+using System.Reflection;
+using System.Threading;
+using PSRule.Configuration;
+using PSRule.Resources;
+using PSRule.Rules;
+
+namespace PSRule.Pipeline.Formatters
+{
+    internal interface IAssertFormatter : IPipelineWriter
+    {
+        void Result(InvokeResult result);
+
+        void Error(ErrorRecord errorRecord);
+
+        void Warning(WarningRecord warningRecord);
+
+        void End(int total, int fail, int error);
+    }
+
+    /// <summary>
+    /// Configures formatted output.
+    /// </summary>
+    internal sealed class TerminalSupport
+    {
+        public TerminalSupport(int indent)
+        {
+            BodyIndent = new string(' ', indent);
+            MessageIdent = BodyIndent;
+            StartResultIndent = FormatterStrings.StartObjectPrefix;
+            SourceLocationPrefix = "| ";
+            SynopsisPrefix = FormatterStrings.SynopsisPrefix;
+            PassStatus = FormatterStrings.Result_Pass;
+            FailStatus = FormatterStrings.Result_Fail;
+            InformationStatus = FormatterStrings.Result_Information;
+            WarningStatus = FormatterStrings.Result_Warning;
+            ErrorStatus = FormatterStrings.Result_Error;
+            RecommendationHeading = FormatterStrings.Recommend;
+            RecommendationPrefix = "| ";
+            ReasonHeading = FormatterStrings.Reason;
+            ReasonItemPrefix = "| - ";
+            HelpHeading = FormatterStrings.Help;
+            HelpLinkPrefix = "| - ";
+        }
+
+        public string BodyIndent { get; }
+
+        public string MessageIdent { get; internal set; }
+
+        public string StartResultIndent { get; internal set; }
+
+        public ConsoleColor? StartResultForegroundColor { get; internal set; }
+
+        public string SourceLocationPrefix { get; internal set; }
+
+        public ConsoleColor? SourceLocationForegroundColor { get; internal set; }
+
+        public string SynopsisPrefix { get; internal set; }
+
+        public ConsoleColor? SynopsisForegroundColor { get; internal set; }
+
+        public string PassStatus { get; internal set; }
+
+        public ConsoleColor? PassForegroundColor { get; internal set; }
+
+        public ConsoleColor? PassBackgroundColor { get; internal set; }
+
+        public ConsoleColor? PassStatusBackgroundColor { get; internal set; }
+
+        public ConsoleColor? PassStatusForegroundColor { get; internal set; }
+
+        public string FailStatus { get; internal set; }
+
+        public ConsoleColor? FailForegroundColor { get; internal set; }
+
+        public ConsoleColor? FailBackgroundColor { get; internal set; }
+
+        public ConsoleColor? FailStatusBackgroundColor { get; internal set; }
+
+        public ConsoleColor? FailStatusForegroundColor { get; internal set; }
+
+        public string InformationStatus { get; internal set; }
+
+        public string WarningStatus { get; internal set; }
+
+        public ConsoleColor? WarningForegroundColor { get; internal set; }
+
+        public ConsoleColor? WarningBackgroundColor { get; internal set; }
+
+        public ConsoleColor? WarningStatusBackgroundColor { get; internal set; }
+
+        public ConsoleColor? WarningStatusForegroundColor { get; internal set; }
+
+        public string ErrorStatus { get; internal set; }
+
+        public ConsoleColor? ErrorForegroundColor { get; internal set; }
+
+        public ConsoleColor? ErrorBackgroundColor { get; internal set; }
+
+        public ConsoleColor? ErrorStatusBackgroundColor { get; internal set; }
+
+        public ConsoleColor? ErrorStatusForegroundColor { get; internal set; }
+
+        public ConsoleColor? BodyForegroundColor { get; internal set; }
+
+        public string RecommendationHeading { get; internal set; }
+
+        public string RecommendationPrefix { get; internal set; }
+
+        public string ReasonHeading { get; internal set; }
+
+        public string ReasonItemPrefix { get; internal set; }
+
+        public string HelpHeading { get; internal set; }
+
+        public string HelpLinkPrefix { get; internal set; }
+    }
+
+    /// <summary>
+    /// A base class for a formatter.
+    /// </summary>
+    internal abstract class AssertFormatterBase : PipelineLoggerBase, IAssertFormatter
+    {
+        private const string OUTPUT_SEPARATOR_BAR = "----------------------------";
+
+        protected readonly IPipelineWriter Writer;
+        protected readonly PSRuleOption Option;
+
+        private bool _UnbrokenContent;
+        private bool _UnbrokenInfo;
+        private bool _UnbrokenObject;
+
+        private static readonly TerminalSupport DefaultTerminalSupport = new TerminalSupport(4);
+
+        protected AssertFormatterBase(Source[] source, IPipelineWriter writer, PSRuleOption option)
+        {
+            Writer = writer;
+            Option = option;
+            Banner();
+            Source(source);
+            SupportLinks(source);
+        }
+
+        #region IAssertFormatter
+
+        public void Error(ErrorRecord errorRecord)
+        {
+            Error(errorRecord.Exception.Message);
+        }
+
+        public void Warning(WarningRecord warningRecord)
+        {
+            Warning(warningRecord.Message);
+        }
+
+        public void Result(InvokeResult result)
+        {
+            if ((Option.Output.Outcome.Value & result.Outcome) != result.Outcome)
+                return;
+
+            StartResult(result, out var records);
+            for (var i = 0; i < records.Length; i++)
+            {
+                if (records[i].IsSuccess())
+                    Pass(records[i]);
+                else if (records[i].Outcome == RuleOutcome.Error)
+                    FailWithError(records[i]);
+                else
+                    Fail(records[i]);
+            }
+        }
+
+        public void End(int total, int fail, int error)
+        {
+            if (Option.Output.Footer.GetValueOrDefault(FooterFormat.Default) != FooterFormat.None)
+                LineBreak();
+
+            FooterRuleCount(total, fail, error);
+            FooterRunInfo();
+        }
+
+        #endregion IAssertFormatter
+
+        #region PipelineLoggerBase
+
+        protected sealed override void DoWriteError(ErrorRecord errorRecord)
+        {
+            Error(errorRecord);
+        }
+
+        protected sealed override void DoWriteWarning(string message)
+        {
+            Warning(message);
+        }
+
+        protected sealed override void DoWriteVerbose(string message)
+        {
+            Writer.WriteVerbose(message);
+        }
+
+        protected sealed override void DoWriteInformation(InformationRecord informationRecord)
+        {
+            Writer.WriteInformation(informationRecord);
+        }
+
+        protected sealed override void DoWriteDebug(DebugRecord debugRecord)
+        {
+            Writer.WriteDebug(debugRecord);
+        }
+
+        protected sealed override void DoWriteObject(object sendToPipeline, bool enumerateCollection)
+        {
+            Writer.WriteObject(sendToPipeline, enumerateCollection);
+        }
+
+        #endregion PipelineLoggerBase
+
+        /// <summary>
+        /// Occurs when a rule passes.
+        /// </summary>
+        private void Pass(RuleRecord record)
+        {
+            if (Option.Output.As != ResultFormat.Detail || !Option.Output.Outcome.Value.HasFlag(RuleOutcome.Pass))
+                return;
+
+            BreakIfUnbrokenObject();
+            BreakIfUnbrokenInfo();
+            WriteStatus(
+                status: GetTerminalSupport().PassStatus,
+                statusIndent: GetTerminalSupport().BodyIndent,
+                statusForeground: GetTerminalSupport().PassStatusForegroundColor,
+                statusBackground: GetTerminalSupport().PassStatusBackgroundColor,
+                messageForeground: GetTerminalSupport().PassForegroundColor,
+                messageBackground: GetTerminalSupport().PassBackgroundColor,
+                message: record.RuleName,
+                suffix: record.Ref
+            );
+            UnbrokenContent();
+        }
+
+        /// <summary>
+        /// Occurs when a rule fails.
+        /// </summary>
+        private void Fail(RuleRecord record)
+        {
+            if (!Option.Output.Outcome.Value.HasFlag(RuleOutcome.Fail))
+                return;
+
+            BreakIfUnbrokenObject();
+            BreakIfUnbrokenInfo();
+            WriteStatus(
+                status: GetTerminalSupport().FailStatus,
+                statusIndent: GetTerminalSupport().BodyIndent,
+                statusForeground: GetTerminalSupport().FailStatusForegroundColor,
+                statusBackground: GetTerminalSupport().FailStatusBackgroundColor,
+                messageForeground: GetTerminalSupport().FailForegroundColor,
+                messageBackground: GetTerminalSupport().FailBackgroundColor,
+                message: record.RuleName,
+                suffix: record.Ref
+            );
+            FailDetail(record);
+        }
+
+        /// <summary>
+        /// Occurs when a rule raises an error.
+        /// </summary>
+        private void FailWithError(RuleRecord record)
+        {
+            if (!Option.Output.Outcome.Value.HasFlag(RuleOutcome.Error))
+                return;
+
+            BreakIfUnbrokenObject();
+            BreakIfUnbrokenInfo();
+            WriteStatus(
+                status: GetTerminalSupport().ErrorStatus,
+                statusIndent: GetTerminalSupport().BodyIndent,
+                statusForeground: GetTerminalSupport().ErrorStatusForegroundColor,
+                statusBackground: GetTerminalSupport().ErrorStatusBackgroundColor,
+                messageForeground: GetTerminalSupport().ErrorForegroundColor,
+                messageBackground: GetTerminalSupport().ErrorBackgroundColor,
+                message: record.RuleName,
+                suffix: record.Ref
+            );
+            ErrorDetail(record);
+            UnbrokenContent();
+        }
+
+        protected virtual void FailDetail(RuleRecord record)
+        {
+            WriteSourceLocation(record, shouldBreak: false);
+            WriteRecommendation(record);
+            WriteReason(record);
+            WriteHelp(record);
+            LineBreak();
+        }
+
+        protected virtual void ErrorDetail(RuleRecord record)
+        {
+
+        }
+
+        protected void Error(string message)
+        {
+            WriteErrorMessage(GetTerminalSupport().MessageIdent, message);
+        }
+
+        protected void Warning(string message)
+        {
+            WriteWarningMessage(GetTerminalSupport().MessageIdent, message);
+        }
+
+        protected void Information(string message)
+        {
+            WriteInformationMessage(GetTerminalSupport().MessageIdent, message);
+        }
+
+        private void Banner()
+        {
+            if (!Option.Output.Banner.GetValueOrDefault(BannerFormat.Default).HasFlag(BannerFormat.Title))
+                return;
+
+            WriteLine(FormatterStrings.Banner.Replace("\\n", Environment.NewLine));
+            LineBreak();
+        }
+
+        private void StartResult(InvokeResult result, out RuleRecord[] records)
+        {
+            records = result.AsRecord();
+            if (records == null || records.Length == 0)
+                return;
+
+            BreakIfUnbrokenContent();
+            BreakIfUnbrokenInfo();
+            WriteStartResult(result);
+            UnbrokenObject();
+        }
+
+        private void WriteStartResult(InvokeResult result)
+        {
+            WriteLine(
+                message: string.Concat(
+                    GetTerminalSupport().StartResultIndent,
+                    result.TargetName,
+                    " : ",
+                    result.TargetType,
+                    " [",
+                    result.Pass,
+                    "/",
+                    result.Total,
+                    "]"),
+                forgroundColor: GetTerminalSupport().StartResultForegroundColor);
+        }
+
+        protected virtual TerminalSupport GetTerminalSupport()
+        {
+            return DefaultTerminalSupport;
+        }
+
+        private void Source(Source[] source)
+        {
+            if (!Option.Output.Banner.GetValueOrDefault(BannerFormat.Default).HasFlag(BannerFormat.Source))
+                return;
+
+            var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion;
+            WriteLineFormat(FormatterStrings.PSRuleVersion, version);
+            var list = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; source != null && i < source.Length; i++)
+            {
+                if (source[i].Module != null && !list.Contains(source[i].Module.Name))
+                {
+                    WriteLineFormat(FormatterStrings.ModuleVersion, source[i].Module.Name, source[i].Module.Version);
+                    list.Add(source[i].Module.Name);
+                }
+            }
+            LineBreak();
+        }
+
+        private void SupportLinks(Source[] source)
+        {
+            if (!Option.Output.Banner.GetValueOrDefault(BannerFormat.Default).HasFlag(BannerFormat.SupportLinks))
+                return;
+
+            WriteLine(OUTPUT_SEPARATOR_BAR);
+            WriteLine(FormatterStrings.HelpDocs);
+            WriteLine(FormatterStrings.HelpContribute);
+            WriteLine(FormatterStrings.HelpIssues);
+            var list = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; source != null && i < source.Length; i++)
+            {
+                if (source[i].Module != null && !list.Contains(source[i].Module.Name) && !string.IsNullOrEmpty(source[i].Module.ProjectUri))
+                {
+                    WriteLineFormat(FormatterStrings.HelpModule, source[i].Module.Name, source[i].Module.ProjectUri);
+                    list.Add(source[i].Module.Name);
+                }
+            }
+            WriteLine(OUTPUT_SEPARATOR_BAR);
+            LineBreak();
+        }
+
+        protected static string GetErrorMessage(RuleRecord record)
+        {
+            return string.IsNullOrEmpty(record.Ref) ?
+                string.Format(
+                    Thread.CurrentThread.CurrentCulture,
+                    FormatterStrings.Result_ErrorDetail,
+                    record.TargetName,
+                    record.RuleName,
+                    record.Error.Message
+                ) :
+                string.Format(
+                    Thread.CurrentThread.CurrentCulture,
+                    FormatterStrings.Result_ErrorDetailWithRef,
+                    record.TargetName,
+                    record.RuleName,
+                    record.Error.Message,
+                    record.Ref
+                );
+        }
+
+        protected static string GetFailMessage(RuleRecord record)
+        {
+            return string.IsNullOrEmpty(record.Ref) ?
+                string.Format(
+                    Thread.CurrentThread.CurrentCulture,
+                    FormatterStrings.Result_FailDetail,
+                    record.TargetName,
+                    record.RuleName,
+                    record.Info.Synopsis
+                ) :
+                string.Format(
+                    Thread.CurrentThread.CurrentCulture,
+                    FormatterStrings.Result_FailDetailWithRef,
+                    record.TargetName,
+                    record.RuleName,
+                    record.Info.Synopsis,
+                    record.Ref
+                );
+        }
+
+        private void FooterRuleCount(int total, int fail, int error)
+        {
+            if (!Option.Output.Footer.GetValueOrDefault(FooterFormat.Default).HasFlag(FooterFormat.RuleCount))
+                return;
+
+            WriteLineFormat(FormatterStrings.FooterRuleCount, total, fail, error);
+        }
+
+        private void FooterRunInfo()
+        {
+            if (!Option.Output.Footer.GetValueOrDefault(FooterFormat.Default).HasFlag(FooterFormat.RunInfo))
+                return;
+
+            var elapsed = PipelineContext.CurrentThread.RunTime.Elapsed;
+            WriteLineFormat(FormatterStrings.FooterRunInfo, PipelineContext.CurrentThread.RunId, elapsed.ToString("c", Thread.CurrentThread.CurrentCulture));
+        }
+
+        protected void WriteStatus(string status, string statusIndent, ConsoleColor? statusForeground, ConsoleColor? statusBackground, ConsoleColor? messageForeground, ConsoleColor? messageBackground, string message, string suffix = null)
+        {
+            var output = message;
+            if (statusForeground != null || statusBackground != null)
+            {
+                Writer.WriteHost(new HostInformationMessage { Message = statusIndent, NoNewLine = true });
+                Writer.WriteHost(new HostInformationMessage
+                {
+                    Message = status,
+                    ForegroundColor = statusForeground,
+                    BackgroundColor = statusBackground,
+                    NoNewLine = true
+                });
+                Writer.WriteHost(new HostInformationMessage { Message = " ", NoNewLine = true });
+                output = string.IsNullOrEmpty(suffix) ? output : string.Concat(output, " (", suffix, ")");
+            }
+            else
+            {
+                output = string.IsNullOrEmpty(suffix) ? string.Concat(status, output) : string.Concat(status, output, " (", suffix, ")"); ;
+            }
+            Writer.WriteHost(new HostInformationMessage
+            {
+                Message = output,
+                ForegroundColor = messageForeground,
+                BackgroundColor = messageBackground
+            });
+        }
+
+        protected void WriteLine(string prefix, ConsoleColor? forgroundColor, string message, params object[] args)
+        {
+            var output = args == null || args.Length == 0 ? message : string.Format(Thread.CurrentThread.CurrentCulture, message, args);
+            Writer.WriteHost(new HostInformationMessage { Message = string.Concat(prefix, output), ForegroundColor = forgroundColor });
+        }
+
+        protected void WriteLine(string message, string prefix = null, ConsoleColor? forgroundColor = null)
+        {
+            var output = string.IsNullOrEmpty(prefix) ? message : string.Concat(prefix, message);
+            Writer.WriteHost(new HostInformationMessage { Message = output, ForegroundColor = forgroundColor });
+        }
+
+        protected void WriteIndentedLine(string message, string indent, string prefix = null, ConsoleColor? forgroundColor = null)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            var output = string.Concat(indent, prefix, message);
+            Writer.WriteHost(new HostInformationMessage { Message = output, ForegroundColor = forgroundColor });
+        }
+
+        protected void WriteIndentedLines(string message, string indent, string prefix = null, ConsoleColor? forgroundColor = null)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            var lines = message.SplitSemantic();
+            for (var i = 0; i < lines.Length; i++)
+                WriteIndentedLine(lines[i], indent, prefix, forgroundColor);
+        }
+
+        protected void WriteLineFormat(string message, params object[] args)
+        {
+            WriteLine(string.Format(Thread.CurrentThread.CurrentCulture, message, args));
+        }
+
+        protected void WriteLines(string message, string prefix = null, ConsoleColor? forgroundColor = null)
+        {
+            if (string.IsNullOrEmpty(message))
+                return;
+
+            var lines = message.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+            for (var i = 0; i < lines.Length; i++)
+                WriteLine(lines[i], prefix, forgroundColor);
+        }
+
+        protected void LineBreak()
+        {
+            Writer.WriteHost(new HostInformationMessage() { Message = string.Empty });
+            _UnbrokenContent = _UnbrokenInfo = _UnbrokenObject = false;
+        }
+
+        protected void BreakIfUnbrokenInfo()
+        {
+            if (!_UnbrokenInfo)
+                return;
+
+            LineBreak();
+        }
+
+        protected void BreakIfUnbrokenContent()
+        {
+            if (!_UnbrokenContent)
+                return;
+
+            LineBreak();
+        }
+
+        protected void BreakIfUnbrokenObject()
+        {
+            if (!_UnbrokenObject)
+                return;
+
+            LineBreak();
+        }
+
+        protected void UnbrokenInfo()
+        {
+            _UnbrokenInfo = true;
+        }
+
+        protected void UnbrokenContent()
+        {
+            _UnbrokenContent = true;
+        }
+
+        protected void UnbrokenObject()
+        {
+            _UnbrokenObject = true;
+        }
+
+        protected void WriteSourceLocation(RuleRecord record, bool shouldBreak = true)
+        {
+            if (record.Source != null && record.Source.Length > 0)
+            {
+                if (shouldBreak)
+                    LineBreak();
+
+                for (var i = 0; i < record.Source.Length; i++)
+                    WriteIndentedLine(
+                        message: record.Source[i].ToString(FormatterStrings.SourceAt, useRelativePath: true),
+                        indent: GetTerminalSupport().BodyIndent,
+                        prefix: GetTerminalSupport().SourceLocationPrefix,
+                        forgroundColor: GetTerminalSupport().SourceLocationForegroundColor
+                    );
+            }
+        }
+
+        protected void WriteSynopsis(RuleRecord record, bool shouldBreak = true)
+        {
+            if (!string.IsNullOrEmpty(record.Info.Synopsis))
+            {
+                if (shouldBreak)
+                    LineBreak();
+
+                WriteIndentedLine(
+                    message: record.Info.Synopsis,
+                    indent: GetTerminalSupport().BodyIndent,
+                    prefix: GetTerminalSupport().SynopsisPrefix,
+                    forgroundColor: GetTerminalSupport().SynopsisForegroundColor
+                );
+            }
+        }
+
+        protected void WriteRecommendation(RuleRecord record)
+        {
+            if (!string.IsNullOrEmpty(record.Recommendation))
+            {
+                LineBreak();
+                WriteLine(GetTerminalSupport().RecommendationHeading, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+                WriteIndentedLines(
+                    message: record.Recommendation,
+                    indent: GetTerminalSupport().BodyIndent,
+                    prefix: GetTerminalSupport().RecommendationPrefix,
+                    forgroundColor: GetTerminalSupport().BodyForegroundColor
+                );
+            }
+        }
+
+        protected void WriteReason(RuleRecord record)
+        {
+            if (record.Reason != null && record.Reason.Length > 0)
+            {
+                LineBreak();
+                WriteLine(GetTerminalSupport().ReasonHeading, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+                for (var i = 0; i < record.Reason.Length; i++)
+                {
+                    WriteIndentedLine(
+                        message: record.Reason[i],
+                        indent: GetTerminalSupport().BodyIndent,
+                        prefix: GetTerminalSupport().ReasonItemPrefix,
+                        forgroundColor: GetTerminalSupport().BodyForegroundColor
+                    );
+                }
+            }
+        }
+
+        protected void WriteHelp(RuleRecord record)
+        {
+            var link = record.Info?.GetOnlineHelpUri()?.ToString();
+            if (!string.IsNullOrEmpty(link))
+            {
+                LineBreak();
+                WriteLine(GetTerminalSupport().HelpHeading, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+                WriteIndentedLine(
+                    message: link,
+                    indent: GetTerminalSupport().BodyIndent,
+                    prefix: GetTerminalSupport().HelpLinkPrefix,
+                    forgroundColor: GetTerminalSupport().BodyForegroundColor
+                );
+            }
+        }
+
+        protected void WriteErrorMessage(string indent, string message)
+        {
+            BreakIfUnbrokenObject();
+            BreakIfUnbrokenContent();
+            WriteStatus(
+                status: GetTerminalSupport().ErrorStatus,
+                statusIndent: indent,
+                statusForeground: GetTerminalSupport().ErrorStatusForegroundColor,
+                statusBackground: GetTerminalSupport().ErrorStatusBackgroundColor,
+                messageForeground: GetTerminalSupport().ErrorForegroundColor,
+                messageBackground: GetTerminalSupport().ErrorBackgroundColor,
+                message: message);
+            UnbrokenInfo();
+        }
+
+        protected void WriteWarningMessage(string indent, string message)
+        {
+            BreakIfUnbrokenObject();
+            BreakIfUnbrokenContent();
+            WriteStatus(
+                status: GetTerminalSupport().WarningStatus,
+                statusIndent: indent,
+                statusForeground: GetTerminalSupport().WarningStatusForegroundColor,
+                statusBackground: GetTerminalSupport().WarningStatusBackgroundColor,
+                messageForeground: GetTerminalSupport().WarningForegroundColor,
+                messageBackground: GetTerminalSupport().WarningBackgroundColor,
+                message: message
+            );
+            UnbrokenInfo();
+        }
+
+        protected void WriteInformationMessage(string indent, string message)
+        {
+            BreakIfUnbrokenObject();
+            BreakIfUnbrokenContent();
+            WriteStatus(
+                status: GetTerminalSupport().InformationStatus,
+                statusIndent: indent,
+                statusForeground: GetTerminalSupport().WarningStatusForegroundColor,
+                statusBackground: GetTerminalSupport().WarningStatusBackgroundColor,
+                messageForeground: GetTerminalSupport().WarningForegroundColor,
+                messageBackground: GetTerminalSupport().WarningBackgroundColor,
+                message: message
+            );
+            UnbrokenInfo();
+        }
+    }
+}

--- a/src/PSRule/Pipeline/Formatters/AzurePipelinesFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/AzurePipelinesFormatter.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Configuration;
+using PSRule.Rules;
+
+namespace PSRule.Pipeline.Formatters
+{
+    /// <summary>
+    /// Formatter for Azure Pipelines.
+    /// </summary>
+    internal sealed class AzurePipelinesFormatter : AssertFormatterBase, IAssertFormatter
+    {
+        // Available commands are defined here: https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands
+        private const string MESSAGE_PREFIX_ERROR = "##vso[task.logissue type=error]";
+        private const string MESSAGE_PREFIX_WARNING = "##vso[task.logissue type=warning]";
+
+        private readonly TerminalSupport _TerminalSupport;
+
+        internal AzurePipelinesFormatter(Source[] source, IPipelineWriter logger, PSRuleOption option)
+            : base(source, logger, option)
+        {
+            _TerminalSupport = new TerminalSupport(4)
+            {
+                MessageIdent = string.Empty,
+                ErrorStatus = MESSAGE_PREFIX_ERROR,
+                WarningStatus = MESSAGE_PREFIX_WARNING,
+            };
+        }
+
+        protected override TerminalSupport GetTerminalSupport()
+        {
+            return _TerminalSupport;
+        }
+
+        protected override void ErrorDetail(RuleRecord record)
+        {
+            if (record.Error == null)
+                return;
+
+            LineBreak();
+            Error(GetErrorMessage(record));
+            LineBreak();
+            WriteLine(record.Error.PositionMessage);
+            LineBreak();
+            WriteLine(record.Error.ScriptStackTrace);
+        }
+
+        protected override void FailDetail(RuleRecord record)
+        {
+            base.FailDetail(record);
+            var message = GetFailMessage(record);
+            if (record.Level == Definitions.Rules.SeverityLevel.Error)
+                Error(message);
+
+            if (record.Level == Definitions.Rules.SeverityLevel.Warning)
+                Warning(message);
+
+            if (record.Level != Definitions.Rules.SeverityLevel.Information)
+                LineBreak();
+        }
+    }
+}

--- a/src/PSRule/Pipeline/Formatters/ClientFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/ClientFormatter.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using PSRule.Configuration;
+using PSRule.Resources;
+using PSRule.Rules;
+
+namespace PSRule.Pipeline.Formatters
+{
+    /// <summary>
+    /// Client assert formatter.
+    /// </summary>
+    internal sealed class ClientFormatter : AssertFormatterBase, IAssertFormatter
+    {
+        private readonly TerminalSupport _TerminalSupport;
+
+        internal ClientFormatter(Source[] source, IPipelineWriter logger, PSRuleOption option)
+            : base(source, logger, option)
+        {
+            _TerminalSupport = new TerminalSupport(4)
+            {
+                StartResultForegroundColor = ConsoleColor.Green,
+                SourceLocationForegroundColor = ConsoleColor.Red,
+                SynopsisForegroundColor = ConsoleColor.Red,
+                ErrorForegroundColor = ConsoleColor.Red,
+                FailForegroundColor = ConsoleColor.Red,
+                PassForegroundColor = ConsoleColor.Green,
+                WarningForegroundColor = ConsoleColor.Yellow,
+                BodyForegroundColor = ConsoleColor.Cyan,
+            };
+        }
+
+        protected override TerminalSupport GetTerminalSupport()
+        {
+            return _TerminalSupport;
+        }
+
+        protected override void ErrorDetail(RuleRecord record)
+        {
+            if (record.Error == null)
+                return;
+
+            LineBreak();
+            WriteLine(FormatterStrings.Message, forgroundColor: GetTerminalSupport().ErrorForegroundColor);
+            WriteIndentedLine(record.Error.Message, GetTerminalSupport().BodyIndent, forgroundColor: GetTerminalSupport().ErrorForegroundColor);
+            LineBreak();
+            WriteLine(FormatterStrings.Position, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+            WriteIndentedLine(record.Error.PositionMessage, GetTerminalSupport().BodyIndent, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+            LineBreak();
+            WriteLine(FormatterStrings.StackTrace, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+            WriteIndentedLine(record.Error.ScriptStackTrace, GetTerminalSupport().BodyIndent, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+        }
+    }
+}

--- a/src/PSRule/Pipeline/Formatters/GitHubActionsFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/GitHubActionsFormatter.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Configuration;
+using PSRule.Rules;
+
+namespace PSRule.Pipeline.Formatters
+{
+    /// <summary>
+    /// Formatter for GitHub Actions.
+    /// </summary>
+    internal sealed class GitHubActionsFormatter : AssertFormatterBase, IAssertFormatter
+    {
+        // Available commands are defined here: https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions
+        private const string ERROR_COMMAND_NO_SOURCE = "::error::";
+        private const string WARNING_COMMAND_NO_SOURCE = "::warning::";
+        private const string NOTICE_COMMAND_NO_SOURCE = "::notice::";
+
+        private readonly TerminalSupport _TerminalSupport;
+
+        internal GitHubActionsFormatter(Source[] source, IPipelineWriter logger, PSRuleOption option)
+            : base(source, logger, option)
+        {
+            _TerminalSupport = new TerminalSupport(4)
+            {
+                MessageIdent = string.Empty,
+                ErrorStatus = ERROR_COMMAND_NO_SOURCE,
+                WarningStatus = WARNING_COMMAND_NO_SOURCE,
+                InformationStatus = NOTICE_COMMAND_NO_SOURCE,
+            };
+        }
+
+        protected override TerminalSupport GetTerminalSupport()
+        {
+            return _TerminalSupport;
+        }
+
+        protected override void ErrorDetail(RuleRecord record)
+        {
+            if (record.Error == null)
+                return;
+
+            LineBreak();
+            Error(GetErrorMessage(record));
+            LineBreak();
+            WriteLine(record.Error.PositionMessage);
+            LineBreak();
+            WriteLine(record.Error.ScriptStackTrace);
+        }
+
+        protected override void FailDetail(RuleRecord record)
+        {
+            base.FailDetail(record);
+            var message = GetFailMessage(record);
+            if (record.Level == Definitions.Rules.SeverityLevel.Error)
+                Error(message);
+
+            if (record.Level == Definitions.Rules.SeverityLevel.Warning)
+                Warning(message);
+
+            if (record.Level == Definitions.Rules.SeverityLevel.Information)
+                Information(message);
+
+            LineBreak();
+        }
+    }
+}

--- a/src/PSRule/Pipeline/Formatters/PlainFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/PlainFormatter.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Configuration;
+using PSRule.Resources;
+using PSRule.Rules;
+
+namespace PSRule.Pipeline.Formatters
+{
+    /// <summary>
+    /// Plain text assert formatter.
+    /// </summary>
+    internal sealed class PlainFormatter : AssertFormatterBase, IAssertFormatter
+    {
+        internal PlainFormatter(Source[] source, IPipelineWriter logger, PSRuleOption option)
+            : base(source, logger, option) { }
+
+        protected override void ErrorDetail(RuleRecord record)
+        {
+            if (record.Error == null)
+                return;
+
+            LineBreak();
+            WriteLine(FormatterStrings.Message, forgroundColor: GetTerminalSupport().ErrorForegroundColor);
+            WriteIndentedLine(record.Error.Message, GetTerminalSupport().BodyIndent, forgroundColor: GetTerminalSupport().ErrorForegroundColor);
+            LineBreak();
+            WriteLine(FormatterStrings.Position, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+            WriteIndentedLine(record.Error.PositionMessage, GetTerminalSupport().BodyIndent, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+            LineBreak();
+            WriteLine(FormatterStrings.StackTrace, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+            WriteIndentedLine(record.Error.ScriptStackTrace, GetTerminalSupport().BodyIndent, forgroundColor: GetTerminalSupport().BodyForegroundColor);
+        }
+    }
+}

--- a/src/PSRule/Pipeline/Formatters/VisualStudioCodeFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/VisualStudioCodeFormatter.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using PSRule.Configuration;
+using PSRule.Resources;
+using PSRule.Rules;
+
+namespace PSRule.Pipeline.Formatters
+{
+    /// <summary>
+    /// Visual Studio Code assert formatter.
+    /// </summary>
+    internal sealed class VisualStudioCodeFormatter : AssertFormatterBase, IAssertFormatter
+    {
+        private readonly TerminalSupport _TerminalSupport;
+
+        internal VisualStudioCodeFormatter(Source[] source, IPipelineWriter logger, PSRuleOption option)
+            : base(source, logger, option)
+        {
+            _TerminalSupport = new TerminalSupport(2)
+            {
+                StartResultIndent = FormatterStrings.VSCode_StartObjectPrefix,
+                StartResultForegroundColor = ConsoleColor.Green,
+                SourceLocationForegroundColor = ConsoleColor.Cyan,
+                SourceLocationPrefix = null,
+                SynopsisPrefix = null,
+                SynopsisForegroundColor = ConsoleColor.Cyan,
+                ErrorStatus = FormatterStrings.VSCode_Error,
+                ErrorForegroundColor = ConsoleColor.Red,
+                ErrorStatusForegroundColor = ConsoleColor.Black,
+                ErrorStatusBackgroundColor = ConsoleColor.Red,
+                FailStatus = FormatterStrings.VSCode_Fail,
+                FailForegroundColor = ConsoleColor.Red,
+                FailStatusForegroundColor = ConsoleColor.Black,
+                FailStatusBackgroundColor = ConsoleColor.Red,
+                PassStatus = FormatterStrings.VSCode_Pass,
+                PassForegroundColor = ConsoleColor.Green,
+                PassStatusForegroundColor = ConsoleColor.Black,
+                PassStatusBackgroundColor = ConsoleColor.Green,
+                WarningStatus = FormatterStrings.VSCode_Warning,
+                WarningForegroundColor = ConsoleColor.Yellow,
+                WarningStatusForegroundColor = ConsoleColor.Black,
+                WarningStatusBackgroundColor = ConsoleColor.Yellow,
+                BodyForegroundColor = ConsoleColor.White,
+                RecommendationHeading = FormatterStrings.VSCode_Recommend,
+                RecommendationPrefix = null,
+                ReasonHeading = FormatterStrings.VSCode_Reason,
+                ReasonItemPrefix = "- ",
+                HelpHeading = FormatterStrings.VSCode_Help,
+                HelpLinkPrefix = "- ",
+            };
+        }
+
+        protected override TerminalSupport GetTerminalSupport()
+        {
+            return _TerminalSupport;
+        }
+
+        protected override void FailDetail(RuleRecord record)
+        {
+            WriteSynopsis(record, shouldBreak: true);
+            WriteSourceLocation(record, shouldBreak: true);
+            WriteRecommendation(record);
+            WriteReason(record);
+            WriteHelp(record);
+            LineBreak();
+        }
+    }
+}

--- a/src/PSRule/Pipeline/InvokeResult.cs
+++ b/src/PSRule/Pipeline/InvokeResult.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using PSRule.Definitions.Rules;
 using PSRule.Rules;
 
 namespace PSRule.Pipeline
@@ -13,6 +14,7 @@ namespace PSRule.Pipeline
     {
         private readonly List<RuleRecord> _Record;
         private RuleOutcome _Outcome;
+        private SeverityLevel _Level;
         private long _Time;
         private int _Total;
         private int _Error;
@@ -41,6 +43,8 @@ namespace PSRule.Pipeline
         internal int Pass => _Total - _Error - _Fail;
 
         public RuleOutcome Outcome => _Outcome;
+
+        public SeverityLevel Level => _Level;
 
         internal string TargetName
         {
@@ -100,8 +104,10 @@ namespace PSRule.Pipeline
                 _Error++;
 
             if (ruleRecord.Outcome == RuleOutcome.Fail)
+            {
                 _Fail++;
-
+                _Level = _Level.GetWorstCase(ruleRecord.Level);
+            }
             _Record.Add(ruleRecord);
         }
     }

--- a/src/PSRule/Resources/FormatterStrings.Designer.cs
+++ b/src/PSRule/Resources/FormatterStrings.Designer.cs
@@ -241,6 +241,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to     [INFO] .
+        /// </summary>
+        internal static string Result_Information {
+            get {
+                return ResourceManager.GetString("Result_Information", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to     [PASS] .
         /// </summary>
         internal static string Result_Pass {

--- a/src/PSRule/Resources/FormatterStrings.resx
+++ b/src/PSRule/Resources/FormatterStrings.resx
@@ -179,6 +179,9 @@
   <data name="Result_FailDetailWithRef" xml:space="preserve">
     <value>{3}: {0} failed {1}. {2}</value>
   </data>
+  <data name="Result_Information" xml:space="preserve">
+    <value>    [INFO] </value>
+  </data>
   <data name="Result_Pass" xml:space="preserve">
     <value>    [PASS] </value>
   </data>

--- a/src/PSRule/Rules/Rule.cs
+++ b/src/PSRule/Rules/Rule.cs
@@ -31,6 +31,12 @@ namespace PSRule.Rules
         public string Name => Id.Name;
 
         /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        [JsonProperty(PropertyName = "level")]
+        public SeverityLevel Level { get; set; }
+
+        /// <summary>
         /// Legacy. A unique identifier for the rule.
         /// </summary>
         [JsonProperty(PropertyName = "ruleId", Required = Required.Always)]

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -23,7 +23,7 @@ namespace PSRule.Rules
     [DebuggerDisplay("{Id} @{Source.Path}")]
     internal sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable, IResource, IRuleV1
     {
-        internal RuleBlock(SourceFile source, ResourceId id, ResourceId? @ref, RuleHelpInfo info, ICondition condition, ResourceTags tag, ResourceId[] alias, ResourceId[] dependsOn, Hashtable configuration, RuleExtent extent, ResourceFlags flags)
+        internal RuleBlock(SourceFile source, ResourceId id, ResourceId? @ref, SeverityLevel level, RuleHelpInfo info, ICondition condition, ResourceTags tag, ResourceId[] alias, ResourceId[] dependsOn, Hashtable configuration, RuleExtent extent, ResourceFlags flags)
         {
             Source = source;
             Name = id.Name;
@@ -33,6 +33,7 @@ namespace PSRule.Rules
             Ref = @ref;
             Alias = alias;
 
+            Level = level;
             Info = info;
             Condition = condition;
             Tag = tag;
@@ -50,6 +51,11 @@ namespace PSRule.Rules
         public ResourceId? Ref { get; }
 
         public ResourceId[] Alias { get; }
+
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        public SeverityLevel Level { get; }
 
         /// <summary>
         /// The name of the rule.

--- a/src/PSRule/Rules/RuleRecord.cs
+++ b/src/PSRule/Rules/RuleRecord.cs
@@ -9,6 +9,7 @@ using System.Text;
 using Newtonsoft.Json;
 using PSRule.Data;
 using PSRule.Definitions;
+using PSRule.Definitions.Rules;
 using YamlDotNet.Serialization;
 
 namespace PSRule.Rules
@@ -18,13 +19,13 @@ namespace PSRule.Rules
     /// </summary>
     [DebuggerDisplay("{RuleId}, Outcome = {Outcome}")]
     [JsonObject]
-    public sealed class RuleRecord
+    public sealed class RuleRecord : IRuleResult
     {
-        internal RuleRecord(string runId, string ruleId, string ruleName, string @ref, PSObject targetObject, string targetName, string targetType, ResourceTags tag, RuleHelpInfo info, Hashtable field, Hashtable data, TargetSourceInfo[] source, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
+        internal RuleRecord(string runId, ResourceId ruleId, string @ref, PSObject targetObject, string targetName, string targetType, ResourceTags tag, RuleHelpInfo info, Hashtable field, Hashtable data, TargetSourceInfo[] source, SeverityLevel level, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
         {
             RunId = runId;
-            RuleId = ruleId;
-            RuleName = ruleName;
+            RuleId = ruleId.Value;
+            RuleName = ruleId.Name;
             Ref = @ref;
             TargetObject = targetObject;
             TargetName = targetName;
@@ -33,6 +34,7 @@ namespace PSRule.Rules
             OutcomeReason = reason;
             Info = info;
             Source = source;
+            Level = level;
             if (tag != null)
                 Tag = tag.ToHashtable();
 
@@ -63,6 +65,12 @@ namespace PSRule.Rules
         public readonly string RuleName;
 
         public string Ref { get; }
+
+        /// <summary>
+        /// If the rule fails, how serious is the result.
+        /// </summary>
+        [JsonProperty(PropertyName = "level")]
+        public SeverityLevel Level { get; }
 
         /// <summary>
         /// The outcome after the rule processes an object.
@@ -166,6 +174,11 @@ namespace PSRule.Rules
                 sb.AppendLine(Reason[i]);
 
             return sb.ToString();
+        }
+
+        internal bool HasSource()
+        {
+            return Source != null && Source.Length > 0;
         }
     }
 }

--- a/src/PSRule/Rules/SuppressionFilter.cs
+++ b/src/PSRule/Rules/SuppressionFilter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using PSRule.Configuration;
 using PSRule.Definitions;

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -647,8 +647,7 @@ namespace PSRule.Runtime
             RuleBlock = ruleBlock;
             RuleRecord = new RuleRecord(
                 runId: Pipeline.RunId,
-                ruleId: ruleBlock.Id.Value,
-                ruleName: ruleBlock.Name,
+                ruleId: ruleBlock.Id,
                 @ref: ruleBlock.Ref.GetValueOrDefault().Name,
                 targetObject: TargetObject.Value,
                 targetName: Binding.TargetName,
@@ -657,7 +656,8 @@ namespace PSRule.Runtime
                 info: ruleBlock.Info,
                 field: Binding.Field,
                 data: Data,
-                source: TargetObject.Source.GetSourceInfo()
+                source: TargetObject.Source.GetSourceInfo(),
+                level: ruleBlock.Level
             );
 
             if (Writer != null)

--- a/tests/PSRule.Tests/AssertFormatterTests.cs
+++ b/tests/PSRule.Tests/AssertFormatterTests.cs
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+using PSRule.Configuration;
+using PSRule.Definitions;
+using PSRule.Definitions.Rules;
+using PSRule.Pipeline;
+using PSRule.Pipeline.Formatters;
+using PSRule.Rules;
+using Xunit;
+
+namespace PSRule
+{
+    /// <summary>
+    /// Tests for formatters used by assert pipeline.
+    /// </summary>
+    public sealed class AssertFormatterTests
+    {
+        [Fact]
+        public void Plain()
+        {
+            var option = GetOption();
+            option.Output.Banner = BannerFormat.None;
+            var writer = GetWriter();
+
+            // Check output is empty
+            var formatter = new PlainFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.End();
+            Assert.Equal("", writer.Output);
+
+            // Check pass output
+            writer.Clear();
+            formatter = new PlainFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetPassResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [1/1]
+
+    [PASS] Test
+", writer.Output);
+
+            // Check fail output
+            writer.Clear();
+            formatter = new PlainFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+
+            // Check fail output as warning
+            writer.Clear();
+            formatter = new PlainFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Warning));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+
+            // Check fail output as information
+            writer.Clear();
+            formatter = new PlainFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Information));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+        }
+
+        [Fact]
+        public void Client()
+        {
+            var option = GetOption();
+            option.Output.Banner = BannerFormat.None;
+            var writer = GetWriter();
+
+            // Check output is empty
+            var formatter = new ClientFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.End();
+            Assert.Equal("", writer.Output);
+
+            // Check pass output
+            writer.Clear();
+            formatter = new ClientFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetPassResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [1/1]
+
+    [PASS] Test
+", writer.Output);
+
+            // Check fail output
+            writer.Clear();
+            formatter = new ClientFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+
+            // Check fail output as warning
+            writer.Clear();
+            formatter = new ClientFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Warning));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+
+            // Check fail output as information
+            writer.Clear();
+            formatter = new ClientFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Information));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+        }
+
+        [Fact]
+        public void AzurePipelines()
+        {
+            var option = GetOption();
+            option.Output.Banner = BannerFormat.None;
+            var writer = GetWriter();
+
+            // Check output is empty
+            var formatter = new AzurePipelinesFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.End();
+            Assert.Equal("", writer.Output);
+
+            // Check pass output
+            writer.Clear();
+            formatter = new AzurePipelinesFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetPassResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [1/1]
+
+    [PASS] Test
+", writer.Output);
+
+            // Check fail output
+            writer.Clear();
+            formatter = new AzurePipelinesFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+##vso[task.logissue type=error]TestObject failed Test1. 
+
+    [FAIL] Test2
+
+##vso[task.logissue type=error]TestObject failed Test2. 
+
+", writer.Output);
+
+            // Check fail output as warning
+            writer.Clear();
+            formatter = new AzurePipelinesFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Warning));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+##vso[task.logissue type=warning]TestObject failed Test1. 
+
+    [FAIL] Test2
+
+##vso[task.logissue type=warning]TestObject failed Test2. 
+
+", writer.Output);
+
+            // Check fail output as information
+            writer.Clear();
+            formatter = new AzurePipelinesFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Information));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+    [FAIL] Test2
+
+", writer.Output);
+        }
+
+        [Fact]
+        public void GitHubActions()
+        {
+            var option = GetOption();
+            option.Output.Banner = BannerFormat.None;
+            var writer = GetWriter();
+
+            // Check output is empty
+            var formatter = new GitHubActionsFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.End();
+            Assert.Equal("", writer.Output);
+
+            // Check pass output
+            writer.Clear();
+            formatter = new GitHubActionsFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetPassResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [1/1]
+
+    [PASS] Test
+", writer.Output);
+
+            // Check fail output
+            writer.Clear();
+            formatter = new GitHubActionsFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult());
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+::error::TestObject failed Test1. 
+
+    [FAIL] Test2
+
+::error::TestObject failed Test2. 
+
+", writer.Output);
+
+            // Check fail output as warning
+            writer.Clear();
+            formatter = new GitHubActionsFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Warning));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+::warning::TestObject failed Test1. 
+
+    [FAIL] Test2
+
+::warning::TestObject failed Test2. 
+
+", writer.Output);
+
+            // Check fail output as information
+            writer.Clear();
+            formatter = new GitHubActionsFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Information));
+            formatter.End();
+            Assert.Equal(@" -> TestObject : TestType [0/2]
+
+    [FAIL] Test1
+
+::notice::TestObject failed Test1. 
+
+    [FAIL] Test2
+
+::notice::TestObject failed Test2. 
+
+", writer.Output);
+        }
+
+        [Fact]
+        public void VisualStudioCode()
+        {
+            var option = GetOption();
+            option.Output.Banner = BannerFormat.None;
+            var writer = GetWriter();
+
+            // Check output is empty
+            var formatter = new VisualStudioCodeFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.End();
+            Assert.Equal("", writer.Output);
+
+            // Check pass output
+            writer.Clear();
+            formatter = new VisualStudioCodeFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetPassResult());
+            formatter.End();
+            Assert.Equal(@"> TestObject : TestType [1/1]
+
+   PASS  Test
+", writer.Output);
+
+            // Check fail output
+            writer.Clear();
+            formatter = new VisualStudioCodeFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult());
+            formatter.End();
+            Assert.Equal(@"> TestObject : TestType [0/2]
+
+   FAIL  Test1
+
+   FAIL  Test2
+
+", writer.Output);
+
+            // Check fail output as warning
+            writer.Clear();
+            formatter = new VisualStudioCodeFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Warning));
+            formatter.End();
+            Assert.Equal(@"> TestObject : TestType [0/2]
+
+   FAIL  Test1
+
+   FAIL  Test2
+
+", writer.Output);
+
+            // Check fail output as information
+            writer.Clear();
+            formatter = new VisualStudioCodeFormatter(null, writer, option);
+            formatter.Begin();
+            formatter.Result(GetFailResult(SeverityLevel.Information));
+            formatter.End();
+            Assert.Equal(@"> TestObject : TestType [0/2]
+
+   FAIL  Test1
+
+   FAIL  Test2
+
+", writer.Output);
+        }
+
+        #region Helper methods
+
+        private static InvokeResult GetPassResult()
+        {
+            var result = new InvokeResult();
+            result.Add(new RuleRecord
+            (
+                runId: "run-001",
+                ruleId: ResourceId.Parse(".\\Test"),
+                @ref: "",
+                targetObject: new PSObject(),
+                targetName: "TestObject",
+                targetType: "TestType",
+                tag: new ResourceTags(),
+                info: new RuleHelpInfo("Test", "Test rule", null),
+                field: null,
+                data: null,
+                source: null,
+                level: SeverityLevel.Error,
+                outcome: RuleOutcome.Pass,
+                reason: RuleOutcomeReason.Processed
+            ));
+            return result;
+        }
+
+        private static InvokeResult GetFailResult(SeverityLevel level = SeverityLevel.Error)
+        {
+            var result = new InvokeResult();
+            result.Add(new RuleRecord
+            (
+                runId: "run-001",
+                ruleId: ResourceId.Parse(".\\Test1"),
+                @ref: "",
+                targetObject: new PSObject(),
+                targetName: "TestObject",
+                targetType: "TestType",
+                tag: new ResourceTags(),
+                info: new RuleHelpInfo("Test1", "Test rule", null),
+                field: null,
+                data: null,
+                source: null,
+                level: level,
+                outcome: RuleOutcome.Fail,
+                reason: RuleOutcomeReason.Processed
+            ));
+            result.Add(new RuleRecord
+            (
+                runId: "run-001",
+                ruleId: ResourceId.Parse(".\\Test2"),
+                @ref: "",
+                targetObject: new PSObject(),
+                targetName: "TestObject",
+                targetType: "TestType",
+                tag: new ResourceTags(),
+                info: new RuleHelpInfo("Test2", "Test rule", null),
+                field: null,
+                data: null,
+                source: null,
+                level: level,
+                outcome: RuleOutcome.Fail,
+                reason: RuleOutcomeReason.Processed
+            ));
+            return result;
+        }
+
+        private static PSRuleOption GetOption()
+        {
+            return PSRuleOption.FromDefault();
+        }
+
+        private static TestAssertWriter GetWriter()
+        {
+            return new TestAssertWriter(GetOption());
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Tests/FromFile.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFile.Rule.jsonc
@@ -4,14 +4,13 @@
 //
 // YAML-based rules for unit testing
 //
-
 [
     {
         // Synopsis: A YAML rule for testing.
         "apiVersion": "github.com/microsoft/PSRule/v1",
         "kind": "Rule",
         "metadata": {
-            "name": "BasicRule",
+            "name": "JsonBasicRule",
             "tags": {
                 "feature": "tag"
             }
@@ -73,7 +72,7 @@
         "apiVersion": "github.com/microsoft/PSRule/v1",
         "kind": "Rule",
         "metadata": {
-            "name": "RuleWithCustomType",
+            "name": "RuleJsonWithCustomType",
             "tags": {
                 "release": "GA"
             }
@@ -93,7 +92,7 @@
         "apiVersion": "github.com/microsoft/PSRule/v1",
         "kind": "Rule",
         "metadata": {
-            "name": "RuleWithSelector",
+            "name": "RuleJsonWithSelector",
             "tags": {
                 "release": "GA"
             }
@@ -136,6 +135,60 @@
             "condition": {
                 "field": "Name",
                 "equals": "TestValue"
+            }
+        }
+    },
+    {
+        // Synopsis: Rule for unit testing of rule error level.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRuleErrorLevel",
+            "tags": {
+                "test": "Level"
+            }
+        },
+        "spec": {
+            "level": "Error",
+            "condition": {
+                "field": "name",
+                "equals": "TestObject1"
+            }
+        }
+    },
+    {
+        // Synopsis: Rule for unit testing of rule warning level.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRuleWarningLevel",
+            "tags": {
+                "test": "Level"
+            }
+        },
+        "spec": {
+            "level": "Warning",
+            "condition": {
+                "field": "name",
+                "equals": "TestObject1"
+            }
+        }
+    },
+    {
+        // Synopsis: Rule for unit testing of rule information level.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRuleInfoLevel",
+            "tags": {
+                "test": "Level"
+            }
+        },
+        "spec": {
+            "level": "Information",
+            "condition": {
+                "field": "name",
+                "equals": "TestObject1"
             }
         }
     }

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -457,3 +457,18 @@ Rule 'IssueGetTest' {
 Rule 'IssueReportTest' {
     $Assert.Create($PSRule.Issue.Get('Downstream.Issue'));
 }
+
+# Synopsis: Rule for unit testing of rule error level.
+Rule 'PS1RuleErrorLevel' -Level 'Error' -Tag @{ test = 'Level' } {
+    $Assert.HasFieldValue($TargetObject, 'name', 'TestObject1');
+}
+
+# Synopsis: Rule for unit testing of rule warning level.
+Rule 'PS1RuleWarningLevel' -Level 'Warning' -Tag @{ test = 'Level' } {
+    $Assert.HasFieldValue($TargetObject, 'name', 'TestObject1');
+}
+
+# Synopsis: Rule for unit testing of rule information level.
+Rule 'PS1RuleInfoLevel' -Level 'Information' -Tag @{ test = 'Level' } {
+    $Assert.HasFieldValue($TargetObject, 'name', 'TestObject1');
+}

--- a/tests/PSRule.Tests/FromFile.Rule.yaml
+++ b/tests/PSRule.Tests/FromFile.Rule.yaml
@@ -10,7 +10,7 @@
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
-  name: BasicRule
+  name: YamlBasicRule
   tags:
     feature: tag
 spec:
@@ -54,7 +54,7 @@ spec:
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
-  name: RuleWithCustomType
+  name: RuleYamlWithCustomType
   tags:
     release: GA
 spec:
@@ -69,7 +69,7 @@ spec:
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Rule
 metadata:
-  name: RuleWithSelector
+  name: RuleYamlWithSelector
   tags:
     release: GA
 spec:
@@ -115,3 +115,45 @@ spec:
     subset:
     - 'audit'
     - 'firewall'
+
+---
+# Synopsis: Rule for unit testing of rule error level.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: YamlRuleErrorLevel
+  tags:
+    test: Level
+spec:
+  level: Error
+  condition:
+    field: name
+    equals: TestObject1
+
+---
+# Synopsis: Rule for unit testing of rule warning level.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: YamlRuleWarningLevel
+  tags:
+    test: Level
+spec:
+  level: Warning
+  condition:
+    field: name
+    equals: TestObject1
+
+---
+# Synopsis: Rule for unit testing of rule information level.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: YamlRuleInfoLevel
+  tags:
+    test: Level
+spec:
+  level: Information
+  condition:
+    field: name
+    equals: TestObject1

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -327,7 +327,42 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result[1].Reason | Should -BeExactly 'Field Name: Is set to ''TestObject1''.';
             $result[2].Reason | Should -BeExactly 'The field ''Name'' is set to ''TestObject2''.';
             $result[3].Reason | Should -BeExactly 'Field Name: Is set to ''TestObject2''.';
+        }
 
+        It 'Returns severity level' {
+            $testObject = @(
+                [PSCustomObject]@{
+                    Name = "TestObject1"
+                }
+                [PSCustomObject]@{
+                    Name = "TestObject2"
+                }
+            )
+
+            $result = $testObject | Invoke-PSRule -Path $ruleFilePath, $yamlFilePath, $jsonFilePath -Tag @{ test = 'Level' } -Outcome Fail;
+            $result | Should -Not -BeNullOrEmpty;
+            $result.Count | Should -Be 9;
+
+            # Error
+            $filteredResult = @($result | Where-Object {
+                $_.Level -eq 'Error'
+            })
+            $filteredResult.Count | Should -Be 3;
+            $filteredResult.RuleName | Should -BeIn 'PS1RuleErrorLevel', 'YamlRuleErrorLevel', 'JsonRuleErrorLevel'
+
+            # Warning
+            $filteredResult = @($result | Where-Object {
+                $_.Level -eq 'Warning'
+            })
+            $filteredResult.Count | Should -Be 3;
+            $filteredResult.RuleName | Should -BeIn 'PS1RuleWarningLevel', 'YamlRuleWarningLevel', 'JsonRuleWarningLevel'
+
+            # Information
+            $filteredResult = @($result | Where-Object {
+                $_.Level -eq 'Information'
+            })
+            $filteredResult.Count | Should -Be 3;
+            $filteredResult.RuleName | Should -BeIn 'PS1RuleInfoLevel', 'YamlRuleInfoLevel', 'JsonRuleInfoLevel'
         }
     }
 
@@ -1258,7 +1293,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
                 $warningMessages = $outwarnings.ToArray();
-                $warningMessages.Length | Should -Be 146;
+                $warningMessages.Length | Should -Be 152;
 
                 $warningMessages | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages.Message | Should -MatchExactly "Rule '.\\[a-zA-Z0-9]+' was suppressed by suppression group '.\\SuppressWithTargetNameAnd(Null|Empty)Rule' for 'TestObject[1-2]'."
@@ -1302,9 +1337,9 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 2;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[0].Message | Should -BeExactly "73 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'."
+                $warningMessages[0].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'."
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[1].Message | Should -BeExactly "73 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'."
+                $warningMessages[1].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'."
             }
 
             It 'No warnings' {

--- a/tests/PSRule.Tests/RulesTests.cs
+++ b/tests/PSRule.Tests/RulesTests.cs
@@ -30,13 +30,13 @@ namespace PSRule
             // From current path
             var rule = HostHelper.GetRule(GetSource(), context, includeDependencies: false);
             Assert.NotNull(rule);
-            Assert.Equal("BasicRule", rule[0].Name);
+            Assert.Equal("YamlBasicRule", rule[0].Name);
             Assert.Equal(PSRuleOption.GetRootedPath(""), rule[0].Source.HelpPath);
 
             // From relative path
             rule = HostHelper.GetRule(GetSource("../../../FromFile.Rule.yaml"), context, includeDependencies: false);
             Assert.NotNull(rule);
-            Assert.Equal("BasicRule", rule[0].Name);
+            Assert.Equal("YamlBasicRule", rule[0].Name);
             Assert.Equal(PSRuleOption.GetRootedPath("../../.."), rule[0].Source.HelpPath);
 
             var hashtable = rule[0].Tag.ToHashtable();
@@ -52,8 +52,8 @@ namespace PSRule
             ImportSelectors(context);
             var yamlTrue = GetRuleVisitor(context, "RuleYamlTrue");
             var yamlFalse = GetRuleVisitor(context, "RuleYamlFalse");
-            var customType = GetRuleVisitor(context, "RuleWithCustomType");
-            var withSelector = GetRuleVisitor(context, "RuleWithSelector");
+            var customType = GetRuleVisitor(context, "RuleYamlWithCustomType");
+            var withSelector = GetRuleVisitor(context, "RuleYamlWithSelector");
             context.EnterSourceScope(yamlTrue.Source);
 
             var actual1 = GetObject((name: "value", value: 3));
@@ -145,13 +145,13 @@ namespace PSRule
             // From current path
             var rule = HostHelper.GetRule(GetSource("FromFile.Rule.jsonc"), context, includeDependencies: false);
             Assert.NotNull(rule);
-            Assert.Equal("BasicRule", rule[0].Name);
+            Assert.Equal("JsonBasicRule", rule[0].Name);
             Assert.Equal(PSRuleOption.GetRootedPath(""), rule[0].Source.HelpPath);
 
             // From relative path
             rule = HostHelper.GetRule(GetSource("../../../FromFile.Rule.jsonc"), context, includeDependencies: false);
             Assert.NotNull(rule);
-            Assert.Equal("BasicRule", rule[0].Name);
+            Assert.Equal("JsonBasicRule", rule[0].Name);
             Assert.Equal(PSRuleOption.GetRootedPath("../../.."), rule[0].Source.HelpPath);
 
             var hashtable = rule[0].Tag.ToHashtable();

--- a/tests/PSRule.Tests/TestAssertWriter.cs
+++ b/tests/PSRule.Tests/TestAssertWriter.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+using System.Text;
+using PSRule.Configuration;
+using PSRule.Pipeline;
+
+namespace PSRule
+{
+    internal sealed class TestAssertWriter : PipelineWriter
+    {
+        private readonly StringBuilder _Output;
+
+        public TestAssertWriter(PSRuleOption option)
+            : base(null, option)
+        {
+            _Output = new StringBuilder();
+        }
+
+        public string Output => _Output.ToString();
+
+        public void Clear()
+        {
+            _Output.Clear();
+        }
+
+        public override void WriteHost(HostInformationMessage info)
+        {
+            if (info.NoNewLine.GetValueOrDefault(false))
+                _Output.Append(info.Message);
+            else
+                _Output.AppendLine(info.Message);
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added support for rule severity level. #880
  - Rules can be configured to be `Error`, `Warning`, or `Information`.
  - Failing rules with the `Error` severity level will cause the pipeline to fail.
  - Rules with the `Warning` severity level will be reported as warnings.
  - Rules with the `Information` severity level will be reported as informational messages.
  - By default, the severity level for a rule is `Error`.

Fixes #880

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
