### PR TITLE
Fixed Invoke-PSRule hanging if JSON rule file is empty

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -14,6 +14,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2202024:
+
+- Bug fixes:
+  - Fixed Invoke-PSRule hanging if JSON rule file is empty. [#969](https://github.com/microsoft/PSRule/issues/969)
+
 ## v2.0.0-B2202024 (pre-release)
 
 What's changed since pre-release v2.0.0-B2202017:

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -309,9 +309,12 @@ namespace PSRule.Host
 
                             using var reader = new JsonTextReader(new StreamReader(file.Path));
 
-                            // Consume lines until start of array is found
-                            while (reader.TokenType != JsonToken.StartArray)
-                                reader.Read();
+                            // Consume lines until start of array
+                            while (reader.TokenType == JsonToken.None || reader.TokenType == JsonToken.Comment)
+                            {
+                                if (!reader.Read())
+                                    break;
+                            }
 
                             if (reader.TokenType == JsonToken.StartArray && reader.Read())
                             {

--- a/tests/PSRule.Tests/FromFile.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFile.Rule.jsonc
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 //
-// YAML-based rules for unit testing
+// JSON-based rules for unit testing
 //
 [
     {

--- a/tests/PSRule.Tests/FromFileEmpty.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFileEmpty.Rule.jsonc
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+//
+// Empty JSON-based rules for unit testing
+//

--- a/tests/PSRule.Tests/FromFileEmpty.Rule.yaml
+++ b/tests/PSRule.Tests/FromFileEmpty.Rule.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Empty YAML-based rules for unit testing
+#

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1425,6 +1425,18 @@ Describe 'Test-PSRuleTarget' -Tag 'Test-PSRuleTarget','Common' {
             $result = $testObject | Test-PSRuleTarget -Path $ruleFilePath -Name 'NotARule' -WarningVariable outWarnings -WarningAction SilentlyContinue;
             $result | Should -BeNullOrEmpty;
             $outWarnings | Should -Be 'Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.';
+
+            # Json
+            $jsonRuleFilePath = Join-Path -Path $here -ChildPath 'FromFileEmpty.Rule.jsonc'
+            $result = $testObject | Invoke-PSRule -Path $jsonRuleFilePath -WarningVariable outWarning -WarningAction SilentlyContinue
+            $result | Should -BeNullOrEmpty;
+            $outWarnings | Should -Be 'Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.';
+
+            # Yaml
+            $yamlRuleFilePath = Join-Path -Path $here -ChildPath 'FromFileEmpty.Rule.yaml'
+            $result = $testObject | Invoke-PSRule -Path $yamlRuleFilePath -WarningVariable outWarning -WarningAction SilentlyContinue
+            $result | Should -BeNullOrEmpty;
+            $outWarnings | Should -Be 'Could not find a matching rule. Please check that Path, Name and Tag parameters are correct.';
         }
 
         It 'Returns warning with empty path' {


### PR DESCRIPTION
## PR Summary

Fixes #969

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
