### PR TITLE
Added repository info in output #978 #964

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -14,6 +14,17 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2202065:
+
+- General improvements:
+  - Capture and output repository info in Assert-PSRule runs. [#978](https://github.com/microsoft/PSRule/issues/978)
+    - Added `Repository.Url` option set repository URL reported in output.
+    - Repository URL is detected automatically for GitHub Actions and Azure Pipelines.
+    - Added `RepositoryInfo` to `Output.Banner` option.
+    - Repository info is shown by default.
+- Bug fixes:
+  - Fixed SARIF should report base branch. [#964](https://github.com/microsoft/PSRule/issues/964)
+
 ## v2.0.0-B2202065 (pre-release)
 
 What's changed since pre-release v2.0.0-B2202056:

--- a/docs/commands/PSRule/en-US/Export-PSRuleBaseline.md
+++ b/docs/commands/PSRule/en-US/Export-PSRuleBaseline.md
@@ -14,8 +14,8 @@ Exports a list of baselines.
 ## SYNTAX
 
 ```text
-Export-PSRuleBaseline [[-Path] <string[]>] -OutputPath <string> [-Module <string[]>] [-Name <string[]>]
- [-Option <PSRuleOption>] [-Culture <string>] [-OutputFormat <OutputFormat>] [-OutputEncoding <OutputEncoding>]
+Export-PSRuleBaseline [-Module <String[]>] [[-Path] <String[]>] [-Name <String[]>] [-Option <PSRuleOption>]
+ [-Culture <String>] [-OutputFormat <OutputFormat>] -OutputPath <String> [-OutputEncoding <OutputEncoding>]
  [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -216,6 +216,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -22,14 +22,15 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-AliasReferenceWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
  [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
  [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
  [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
  [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
  [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int>]
- [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -40,15 +41,16 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>] [-IncludeModule <String[]>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
+ [-AliasReferenceWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-IncludeModule <String[]>]
  [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
  [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
  [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
  [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
  [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
  [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int>]
- [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -58,15 +60,16 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-BindTargetName <BindTargetName[]>] [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>]
  [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>]
  [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
- [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
+ [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
+ [-SuppressedRuleWarning <Boolean>] [-AliasReferenceWarning <Boolean>] [-InvariantCultureWarning <Boolean>]
  [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
  [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
  [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
  [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
  [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
  [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int>]
- [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -762,6 +765,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutputJsonIndent
+
+Sets the option `Output.JsonIndent`.
+The `Output.JsonIndent` option configures indentation for JSON output.
+
+This option only applies to `Get-PSRule`, `Invoke-PSRule` and `Assert-PSRule` cmdlets.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: JsonIndent
+Accepted values: 0, 1, 2, 3, 4
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutputOutcome
 
 Sets the `Output.Outcome` option.
@@ -797,6 +820,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutputSarifProblemsOnly
+
+Sets the option `Option.SarifProblemsOnly`.
+The `Output.SarifProblemsOnly` option determines if SARIF output only includes fail and error outcomes.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutputStyle
 
 Sets the option `Option.Style`.
@@ -817,22 +857,19 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -OutputJsonIndent
+### -RepositoryUrl
 
-Sets the option `Output.JsonIndent`.
-The `Output.JsonIndent` option configures indentation for JSON output.
-
-This option only applies to `Get-PSRule`, `Invoke-PSRule` and `Assert-PSRule` cmdlets.
+Sets the option `Repository.Url`.
+The `Repository.Url` option sets the repository URL reported in output.
 
 ```yaml
-Type: Int
+Type: String
 Parameter Sets: (All)
-Aliases: JsonIndent
-Accepted values: 0, 1, 2, 3, 4
+Aliases:
 
 Required: False
 Position: Named
-Default value: 0
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -851,6 +888,40 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AliasReferenceWarning
+
+Sets the option `Execution.AliasReferenceWarning`.
+The `Execution.AliasReferenceWarning` option determines if a warning is logged when alises are referenced.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases: ExecutionAliasReferenceWarning
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InvariantCultureWarning
+
+Sets the option `Execution.InvariantCultureWarning`.
+The `Execution.InvariantCultureWarning` option set if a warning is logged when invarient culture is detected.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases: ExecutionInvariantCultureWarning
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -18,15 +18,16 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>] [-BindingNameSeparator <String>]
  [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-InconclusiveWarning <Boolean>]
- [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>]
- [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>]
- [-InputPathIgnore <String[]>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
- [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputStyle <OutputStyle>]
- [-OutputJsonIndent <Int>] [-RuleIncludeLocal <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>] [-AliasReferenceWarning <Boolean>]
+ [-InvariantCultureWarning <Boolean>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
+ [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
+ [-ObjectPath <String>] [-InputPathIgnore <String[]>] [-InputTargetType <String[]>]
+ [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
+ [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>]
+ [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>]
+ [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int32>]
+ [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -655,6 +656,26 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutputJsonIndent
+
+Sets the option `Output.JsonIndent`.
+The `Output.JsonIndent` option configures indentation for JSON output.
+
+This option only applies to `Get-PSRule`, `Invoke-PSRule` and `Assert-PSRule` cmdlets.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases: JsonIndent
+Accepted values: 0, 1, 2, 3, 4
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutputOutcome
 
 Sets the `Output.Outcome` option.
@@ -690,6 +711,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -OutputSarifProblemsOnly
+
+Sets the option `Option.SarifProblemsOnly`.
+The `Output.SarifProblemsOnly` option determines if SARIF output only includes fail and error outcomes.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -OutputStyle
 
 Sets the option `Option.Style`.
@@ -706,26 +744,6 @@ Accepted values: Client, Plain, AzurePipelines, GitHubActions
 Required: False
 Position: Named
 Default value: Client
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -OutputJsonIndent
-
-Sets the option `Output.JsonIndent`.
-The `Output.JsonIndent` option configures indentation for JSON output.
-
-This option only applies to `Get-PSRule`, `Invoke-PSRule` and `Assert-PSRule` cmdlets.
-
-```yaml
-Type: Int
-Parameter Sets: (All)
-Aliases: JsonIndent
-Accepted values: 0, 1, 2, 3, 4
-
-Required: False
-Position: Named
-Default value: 0
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -762,6 +780,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -RepositoryUrl
+
+Sets the option `Repository.Url`.
+The `Repository.Url` option sets the repository URL reported in output.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -RuleIncludeLocal
 
 Sets the option `Rule.IncludeLocal`.
@@ -776,6 +811,40 @@ Aliases:
 Required: False
 Position: Named
 Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AliasReferenceWarning
+
+Sets the option `Execution.AliasReferenceWarning`.
+The `Execution.AliasReferenceWarning` option determines if a warning is logged when alises are referenced.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases: ExecutionAliasReferenceWarning
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InvariantCultureWarning
+
+Sets the option `Execution.InvariantCultureWarning`.
+The `Execution.InvariantCultureWarning` option set if a warning is logged when invarient culture is detected.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases: ExecutionInvariantCultureWarning
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -43,6 +43,7 @@ The following workspace options are available for use:
 - [Output.Path](#outputpath)
 - [Output.SarifProblemsOnly](#outputsarifproblemsonly)
 - [Output.Style](#outputstyle)
+- [Repository.Url](#repositoryurl)
 - [Requires](#requires)
 - [Suppression](#suppression)
 
@@ -1650,10 +1651,11 @@ The following information can be shown or hidden by configuring this option.
 - `Title` (1) - Shows the PSRule title ASCII text.
 - `Source` (2) - Shows rules module versions used in this run.
 - `SupportLinks` (4) - Shows supporting links for PSRule and rules modules.
+- `RepositoryInfo` (8) - Show information about the repository where PSRule is being run from.
 
 Additionally the following rollup options exist:
 
-- `Default` - Shows `Title`, `Source`, and `SupportLinks`.
+- `Default` - Shows `Title`, `Source`, `SupportLinks`, `RepositoryInfo`.
 This is the default option.
 - `Minimal` - Shows `Source`.
 
@@ -2208,7 +2210,7 @@ The default number of spaces is 0.
 This option applies to output generated from `-OutputFormat Json` for `Get-PSRule` and `Invoke-PSRule`.
 This option also applies to output generated from `-OutputPath` for `Assert-PSRule`.
 
-The range of indentation accepts a minimum of 0(machine first) spaces and a maximum of 4 spaces.
+The range of indentation accepts a minimum of 0 (machine first) spaces and a maximum of 4 spaces.
 
 This option can be specified using:
 
@@ -2254,6 +2256,47 @@ env:
 variables:
 - name: PSRULE_OUTPUT_JSONINDENT
   value: 2
+```
+
+### Repository.Url
+
+This option can be configured to set the repository URL reported in output.
+By default, the repository URL is detected from environment variables set by the build system.
+
+- In GitHub Actions, the repository URL is detected from the `GITHUB_REPOSITORY` environment variable.
+- In Azure Pipelines, the repository URL is detected from the `BUILD_REPOSITORY_URI` environment variable.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the RepositoryUrl parameter
+$option = New-PSRuleOption -RepositoryUrl 'https://github.com/microsoft/PSRule';
+```
+
+```powershell
+# PowerShell: Using the Repository.Url hashtable key
+$option = New-PSRuleOption -Option @{ 'Repository.Url' = 'https://github.com/microsoft/PSRule' };
+```
+
+```powershell
+# PowerShell: Using the RepositoryUrl parameter to set YAML
+Set-PSRuleOption -RepositoryUrl 'https://github.com/microsoft/PSRule';
+```
+
+```yaml
+# YAML: Using the repository/url property
+repository:
+  url: 'https://github.com/microsoft/PSRule'
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_REPOSITORY_URL='https://github.com/microsoft/PSRule'
+```
+
+```powershell
+# PowerShell: Using environment variable
+$env:PSRULE_REPOSITORY_URL = 'https://github.com/microsoft/PSRule';
 ```
 
 ### Requires

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -376,8 +376,8 @@
                 },
                 "banner": {
                     "title": "Banner format",
-                    "description": "The information displayed for Assert-PSRule banner. The default is Default which includes Title, Source, and SupportLinks.",
-                    "markdownDescription": "The information displayed for Assert-PSRule banner. The default is `Default` which includes `Title`, `Source`, and `SupportLinks`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#outputbanner)",
+                    "description": "The information displayed for Assert-PSRule banner. The default is Default which includes Title, Source, SupportLinks, and RepositoryInfo.",
+                    "markdownDescription": "The information displayed for Assert-PSRule banner. The default is `Default` which includes `Title`, `Source`, `SupportLinks`, and `RepositoryInfo`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#outputbanner)",
                     "oneOf": [
                         {
                             "type": "string",
@@ -386,6 +386,7 @@
                                 "Title",
                                 "Source",
                                 "SupportLinks",
+                                "RepositoryInfo",
                                 "Default",
                                 "Minimal"
                             ]
@@ -581,6 +582,10 @@
                     "type": "object",
                     "$ref": "#/definitions/output-option"
                 },
+                "repository": {
+                    "type": "object",
+                    "$ref": "#/definitions/repository-option"
+                },
                 "requires": {
                     "type": "object",
                     "$ref": "#/definitions/requires"
@@ -600,6 +605,21 @@
                             "$ref": "#/definitions/suppression-option"
                         }
                     ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "repository-option": {
+            "type": "object",
+            "title": "Repository",
+            "description": "Configures repository options.",
+            "markdownDescription": "Configures repository options.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "title": "Repository URL",
+                    "description": "The URL to the repository.",
+                    "markdownDescription": "The URL to the repository."
                 }
             },
             "additionalProperties": false

--- a/src/PSRule/Common/GitHelper.cs
+++ b/src/PSRule/Common/GitHelper.cs
@@ -1,43 +1,174 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.IO;
+using PSRule.Configuration;
 
 namespace PSRule
 {
+    /// <summary>
+    /// Helper for working with Git and CI tools.
+    /// </summary>
+    /// <remarks>
+    /// Azure Pipelines: https://docs.microsoft.com/azure/devops/pipelines/build/variables
+    /// GitHub Actions: https://docs.github.com/actions/learn-github-actions/environment-variables#default-environment-variables
+    /// </remarks>
     internal static class GitHelper
     {
-        public static string GetHeadRef(string path)
+        private const string GIT_HEAD = "HEAD";
+        private const string GIT_REF_PREFIX = "ref: ";
+        private const string GIT_DEFAULT_PATH = ".git/";
+        private const string GIT_REF_HEAD = "refs/heads/";
+
+        private const string GITHUB_BASE_URL = "https://github.com/";
+
+        // Environment variables for PSRule
+        private const string ENV_PSRULE_REPO_REF = "PSRULE_REPOSITORY_REF";
+        private const string ENV_PSRULE_REPO_HEADREF = "PSRULE_REPOSITORY_HEADREF";
+        private const string ENV_PSRULE_REPO_BASEREF = "PSRULE_REPOSITORY_BASEREF";
+        private const string ENV_PSRULE_REPO_REVISION = "PSRULE_REPOSITORY_REVISION";
+        private const string ENV_PSRULE_REPO_URL = "PSRULE_REPOSITORY_URL";
+
+        // Environment variables for Azure Pipelines
+        private const string ENV_ADO_REPO_REF = "BUILD_SOURCEBRANCH";
+        private const string ENV_ADO_REPO_BASEREF = "SYSTEM_PULLREQUEST_TARGETBRANCH";
+        private const string ENV_ADO_REPO_REVISION = "BUILD_SOURCEVERSION";
+        private const string ENV_ADO_REPO_URL = "BUILD_REPOSITORY_URI";
+
+        // Environment variables for GitHub Actions
+        private const string ENV_GITHUB_REPO_REF = "GITHUB_REF";
+        private const string ENV_GITHUB_REPO_HEADREF = "GITHUB_HEAD_REF";
+        private const string ENV_GITHUB_REPO_BASEREF = "GITHUB_BASE_REF";
+        private const string ENV_GITHUB_REPO_REVISION = "GITHUB_SHA";
+        private const string ENV_GITHUB_REPO_URL = "GITHUB_REPOSITORY";
+
+        /// <summary>
+        /// The get HEAD ref.
+        /// </summary>
+        public static bool TryHeadRef(out string value, string path = null)
         {
             // Try PSRule
-            if (EnvironmentHelper.Default.TryString("PSRULE_GITREF", out var value))
-                return value;
+            if (EnvironmentHelper.Default.TryString(ENV_PSRULE_REPO_REF, out value) ||
+                EnvironmentHelper.Default.TryString(ENV_PSRULE_REPO_HEADREF, out value))
+                return true;
 
             // Try Azure Pipelines
-            if (EnvironmentHelper.Default.TryString("BUILD_SOURCEBRANCH", out value))
-                return value;
+            if (EnvironmentHelper.Default.TryString(ENV_ADO_REPO_REF, out value))
+                return true;
 
             // Try GitHub Actions
-            if (EnvironmentHelper.Default.TryString("GITHUB_REF", out value))
-                return value;
+            if (EnvironmentHelper.Default.TryString(ENV_GITHUB_REPO_REF, out value) ||
+                EnvironmentHelper.Default.TryString(ENV_GITHUB_REPO_HEADREF, out value))
+                return true;
 
-            // Try .git/HEAD
-            return TryReadHead(path, out value) ? value : null;
+            // Try .git/
+            return TryReadHead(path, out value);
+        }
+
+        /// <summary>
+        /// Get the HEAD branch name.
+        /// </summary>
+        public static bool TryHeadBranch(out string value, string path = null)
+        {
+            value = TryHeadRef(out value, path) && value.StartsWith(GIT_REF_HEAD) ? value.Substring(11) : value;
+            return !string.IsNullOrEmpty(value);
+        }
+
+        /// <summary>
+        /// Get the target ref.
+        /// </summary
+        public static bool TryBaseRef(out string value, string path = null)
+        {
+            // Try PSRule
+            if (EnvironmentHelper.Default.TryString(ENV_PSRULE_REPO_BASEREF, out value))
+                return true;
+
+            // Try Azure Pipelines
+            if (EnvironmentHelper.Default.TryString(ENV_ADO_REPO_BASEREF, out value))
+                return true;
+
+            // Try GitHub Actions
+            if (EnvironmentHelper.Default.TryString(ENV_GITHUB_REPO_BASEREF, out value))
+                return true;
+
+            // Try .git/
+            return TryReadHead(path, out value);
+        }
+
+        public static bool TryRevision(out string value, string path = null)
+        {
+            // Try PSRule
+            if (EnvironmentHelper.Default.TryString(ENV_PSRULE_REPO_REVISION, out value))
+                return true;
+
+            // Try Azure Pipelines
+            if (EnvironmentHelper.Default.TryString(ENV_ADO_REPO_REVISION, out value))
+                return true;
+
+            // Try GitHub Actions
+            if (EnvironmentHelper.Default.TryString(ENV_GITHUB_REPO_REVISION, out value))
+                return true;
+
+            // Try .git/
+            return TryReadCommit(path, out value);
+        }
+
+        public static bool TryRepository(out string value, string path = null)
+        {
+            // Try PSRule
+            if (EnvironmentHelper.Default.TryString(ENV_PSRULE_REPO_URL, out value))
+                return true;
+
+            // Try Azure Pipelines
+            if (EnvironmentHelper.Default.TryString(ENV_ADO_REPO_URL, out value))
+                return true;
+
+            // Try GitHub Actions
+            if (EnvironmentHelper.Default.TryString(ENV_GITHUB_REPO_URL, out value))
+            {
+                value = string.Concat(GITHUB_BASE_URL, value);
+                return true;
+            }
+
+            // Try .git/
+            return false;
         }
 
         private static bool TryReadHead(string path, out string value)
         {
             value = null;
-            var headFilePath = Path.Combine(path, "HEAD");
-            if (!File.Exists(headFilePath))
+            return TryGitFile(path, GIT_HEAD, out var filePath) && TryCommit(filePath, out value, out _);
+        }
+
+        private static bool TryReadCommit(string path, out string value)
+        {
+            value = null;
+            if (!TryGitFile(path, GIT_HEAD, out var filePath))
                 return false;
 
-            var lines = File.ReadAllLines(headFilePath);
+            while (TryCommit(filePath, out value, out var isRef) && isRef)
+                TryGitFile(path, value, out filePath);
+
+            return value != null;
+        }
+
+        private static bool TryGitFile(string path, string file, out string filePath)
+        {
+            path ??= PSRuleOption.GetRootedBasePath(GIT_DEFAULT_PATH);
+            filePath = Path.Combine(path, file);
+            return File.Exists(filePath);
+        }
+
+        private static bool TryCommit(string path, out string value, out bool isRef)
+        {
+            value = null;
+            isRef = false;
+            var lines = File.ReadAllLines(path);
             if (lines == null || lines.Length == 0)
                 return false;
 
-            value = lines[0].StartsWith("ref: ", System.StringComparison.OrdinalIgnoreCase) ? lines[0].Substring(5) : lines[0];
-
+            isRef = lines[0].StartsWith(GIT_REF_PREFIX, System.StringComparison.OrdinalIgnoreCase);
+            value = isRef ? lines[0].Substring(5) : lines[0];
             return true;
         }
     }

--- a/src/PSRule/Configuration/BannerFormat.cs
+++ b/src/PSRule/Configuration/BannerFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -34,7 +34,12 @@ namespace PSRule.Configuration
         /// </summary>
         SupportLinks = 4,
 
-        Default = Title | Source | SupportLinks,
+        /// <summary>
+        /// Information about the repository where PSRule is being run from.
+        /// </summary>
+        RepositoryInfo = 8,
+
+        Default = Title | Source | SupportLinks | RepositoryInfo,
         Minimal = Source
     }
 }

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -65,6 +65,7 @@ namespace PSRule.Configuration
             Logging = new LoggingOption();
             Output = new OutputOption();
             Pipeline = new PipelineHook();
+            Repository = new RepositoryOption();
             Requires = new RequiresOption();
             Rule = new RuleOption();
             Suppression = new SuppressionOption();
@@ -84,6 +85,7 @@ namespace PSRule.Configuration
             Logging = new LoggingOption(option?.Logging);
             Output = new OutputOption(option?.Output);
             Pipeline = new PipelineHook(option?.Pipeline);
+            Repository = new RepositoryOption(option?.Repository);
             Requires = new RequiresOption(option?.Requires);
             Rule = new RuleOption(option?.Rule);
             Suppression = new SuppressionOption(option?.Suppression);
@@ -129,6 +131,8 @@ namespace PSRule.Configuration
         [YamlIgnore]
         [JsonIgnore]
         public PipelineHook Pipeline { get; set; }
+
+        public RepositoryOption Repository { get; set; }
 
         /// <summary>
         /// Specifies the required version of a module to use.
@@ -177,6 +181,7 @@ namespace PSRule.Configuration
             result.Include = IncludeOption.Combine(result.Include, o2?.Include);
             result.Input = InputOption.Combine(result.Input, o2?.Input);
             result.Logging = LoggingOption.Combine(result.Logging, o2?.Logging);
+            result.Repository = RepositoryOption.Combine(result.Repository, o2?.Repository);
             result.Output = OutputOption.Combine(result.Output, o2?.Output);
             return result;
         }
@@ -280,6 +285,7 @@ namespace PSRule.Configuration
             option.Input.Load(env);
             option.Logging.Load(env);
             option.Output.Load(env);
+            option.Repository.Load(env);
             option.Requires.Load(env);
             BaselineOption.Load(option, env);
             return option;
@@ -299,6 +305,7 @@ namespace PSRule.Configuration
             option.Input.Load(index);
             option.Logging.Load(index);
             option.Output.Load(index);
+            option.Repository.Load(index);
             option.Requires.Load(index);
             BaselineOption.Load(option, index);
             return option;
@@ -384,6 +391,7 @@ namespace PSRule.Configuration
                 Output == other.Output &&
                 Suppression == other.Suppression &&
                 Pipeline == other.Pipeline &&
+                Repository == other.Repository &&
                 Rule == other.Rule;
         }
 
@@ -402,6 +410,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (Output != null ? Output.GetHashCode() : 0);
                 hash = hash * 23 + (Suppression != null ? Suppression.GetHashCode() : 0);
                 hash = hash * 23 + (Pipeline != null ? Pipeline.GetHashCode() : 0);
+                hash = hash * 23 + (Repository != null ? Repository.GetHashCode() : 0);
                 hash = hash * 23 + (Rule != null ? Rule.GetHashCode() : 0);
                 return hash;
             }

--- a/src/PSRule/Configuration/RepositoryOption.cs
+++ b/src/PSRule/Configuration/RepositoryOption.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// Options that configure the execution sandbox.
+    /// </summary>
+    public sealed class RepositoryOption : IEquatable<RepositoryOption>
+    {
+        internal static readonly RepositoryOption Default = new RepositoryOption
+        {
+
+        };
+
+        public RepositoryOption()
+        {
+            Url = null;
+        }
+
+        public RepositoryOption(RepositoryOption option)
+        {
+            if (option == null)
+                return;
+
+            Url = option.Url;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is RepositoryOption option && Equals(option);
+        }
+
+        public bool Equals(RepositoryOption other)
+        {
+            return other != null &&
+                Url == other.Url;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked // Overflow is fine
+            {
+                var hash = 17;
+                hash = hash * 23 + (Url != null ? Url.GetHashCode() : 0);
+                return hash;
+            }
+        }
+
+        internal static RepositoryOption Combine(RepositoryOption o1, RepositoryOption o2)
+        {
+            var result = new RepositoryOption(o1)
+            {
+                Url = o1.Url ?? o2.Url,
+            };
+            return result;
+        }
+
+        /// <summary>
+        /// Determines if a warning is raised when an alias to a resource is used.
+        /// </summary>
+        [DefaultValue(null)]
+        public string Url { get; set; }
+
+        internal void Load(EnvironmentHelper env)
+        {
+            if (env.TryString("PSRULE_REPOSITORY_URL", out var url))
+                Url = url;
+        }
+
+        internal void Load(Dictionary<string, object> index)
+        {
+            if (index.TryPopString("Repository.Url", out var url))
+                Url = url;
+        }
+    }
+}

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1239,7 +1239,7 @@ function New-PSRuleOption {
 
         # Sets the Output.Banner option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Default', 'Minimal', 'None', 'Title', 'Source', 'SupportLinks')]
+        [ValidateSet('Default', 'Minimal', 'None', 'Title', 'Source', 'SupportLinks', 'RepositoryInfo')]
         [PSRule.Configuration.BannerFormat]$OutputBanner = 'Default',
 
         # Sets the Output.Culture option
@@ -1285,6 +1285,10 @@ function New-PSRuleOption {
         [ValidateRange(0, 4)]
         [Alias('JsonIndent')]
         [int]$OutputJsonIndent = 0,
+
+        # Sets the Repository.Url option
+        [Parameter(Mandatory = $False)]
+        [String]$RepositoryUrl,
 
         # Sets the Rule.IncludeLocal option
         [Parameter(Mandatory = $False)]
@@ -1505,7 +1509,7 @@ function Set-PSRuleOption {
 
         # Sets the Output.Banner option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Default', 'Minimal', 'None', 'Title', 'Source', 'SupportLinks')]
+        [ValidateSet('Default', 'Minimal', 'None', 'Title', 'Source', 'SupportLinks', 'RepositoryInfo')]
         [PSRule.Configuration.BannerFormat]$OutputBanner = 'Default',
 
         # Sets the Output.Culture option
@@ -1551,6 +1555,10 @@ function Set-PSRuleOption {
         [ValidateRange(0, 4)]
         [Alias('JsonIndent')]
         [Int]$OutputJsonIndent = 0,
+
+        # Sets the Repository.Url option
+        [Parameter(Mandatory = $False)]
+        [String]$RepositoryUrl,
 
         # Sets the Rule.IncludeLocal option
         [Parameter(Mandatory = $False)]
@@ -2211,7 +2219,7 @@ function SetOptions {
 
         # Sets the Output.Banner option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('Default', 'Minimal', 'None', 'Title', 'Source', 'SupportLinks')]
+        [ValidateSet('Default', 'Minimal', 'None', 'Title', 'Source', 'SupportLinks', 'RepositoryInfo')]
         [PSRule.Configuration.BannerFormat]$OutputBanner = 'Default',
 
         # Sets the Output.Culture option
@@ -2257,6 +2265,10 @@ function SetOptions {
         [ValidateRange(0, 4)]
         [Alias('JsonIndent')]
         [Int]$OutputJsonIndent = 0,
+
+        # Sets the Repository.Url option
+        [Parameter(Mandatory = $False)]
+        [String]$RepositoryUrl,
 
         # Sets the Rule.IncludeLocal option
         [Parameter(Mandatory = $False)]
@@ -2443,6 +2455,11 @@ function SetOptions {
         # Sets option Output.Style
         if ($PSBoundParameters.ContainsKey('OutputStyle')) {
             $Option.Output.Style = $OutputStyle;
+        }
+
+        # Sets option Repository.Url
+        if ($PSBoundParameters.ContainsKey('RepositoryUrl')) {
+            $Option.Repository.Url = $RepositoryUrl;
         }
 
         # Sets option Rule.IncludeLocal

--- a/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
@@ -145,6 +145,7 @@ namespace PSRule.Pipeline.Formatters
             Banner();
             Source(source);
             SupportLinks(source);
+            RepositoryInfo();
         }
 
         #region IAssertFormatter
@@ -401,6 +402,25 @@ namespace PSRule.Pipeline.Formatters
             }
             WriteLine(OUTPUT_SEPARATOR_BAR);
             LineBreak();
+        }
+
+        private void RepositoryInfo()
+        {
+            if (!Option.Output.Banner.GetValueOrDefault(BannerFormat.Default).HasFlag(BannerFormat.RepositoryInfo))
+                return;
+
+            if (!GitHelper.TryRepository(out var repository))
+                return;
+
+            WriteLineFormat(FormatterStrings.Repository_Url, repository);
+            if (GitHelper.TryHeadBranch(out var branch))
+                WriteLineFormat(FormatterStrings.Repository_Branch, branch);
+
+            if (GitHelper.TryRevision(out var revision))
+                WriteLineFormat(FormatterStrings.Repository_Revision, revision);
+
+            if (!string.IsNullOrEmpty(repository) || !string.IsNullOrEmpty(branch) || !string.IsNullOrEmpty(revision))
+                LineBreak();
         }
 
         protected static string GetErrorMessage(RuleRecord record)

--- a/src/PSRule/Pipeline/PipelineReciever.cs
+++ b/src/PSRule/Pipeline/PipelineReciever.cs
@@ -247,7 +247,7 @@ namespace PSRule.Pipeline
                 return null;
 
             sourceInfo = new TargetSourceInfo(inputFileInfo);
-            var headRef = GitHelper.GetHeadRef(inputFileInfo.DirectoryName);
+            GitHelper.TryHeadRef(out var headRef, inputFileInfo.DirectoryName);
             return new RepositoryInfo(inputFileInfo.BasePath, headRef);
         }
 

--- a/src/PSRule/Resources/FormatterStrings.Designer.cs
+++ b/src/PSRule/Resources/FormatterStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace PSRule.Resources {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class FormatterStrings {
@@ -183,6 +183,33 @@ namespace PSRule.Resources {
         internal static string Recommend {
             get {
                 return ResourceManager.GetString("Recommend", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   on : {0}.
+        /// </summary>
+        internal static string Repository_Branch {
+            get {
+                return ResourceManager.GetString("Repository_Branch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to   at : {0}.
+        /// </summary>
+        internal static string Repository_Revision {
+            get {
+                return ResourceManager.GetString("Repository_Revision", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to From repository: {0}.
+        /// </summary>
+        internal static string Repository_Url {
+            get {
+                return ResourceManager.GetString("Repository_Url", resourceCulture);
             }
         }
         

--- a/src/PSRule/Resources/FormatterStrings.resx
+++ b/src/PSRule/Resources/FormatterStrings.resx
@@ -161,6 +161,15 @@
     <value>    | RECOMMEND:</value>
     <comment>Recommendation output header</comment>
   </data>
+  <data name="Repository_Branch" xml:space="preserve">
+    <value>  on : {0}</value>
+  </data>
+  <data name="Repository_Revision" xml:space="preserve">
+    <value>  at : {0}</value>
+  </data>
+  <data name="Repository_Url" xml:space="preserve">
+    <value>From repository: {0}</value>
+  </data>
   <data name="Result_Error" xml:space="preserve">
     <value>    [ERROR] </value>
   </data>

--- a/tests/PSRule.Tests/OutputWriterTests.cs
+++ b/tests/PSRule.Tests/OutputWriterTests.cs
@@ -23,6 +23,7 @@ namespace PSRule
         {
             var option = GetOption();
             option.Output.SarifProblemsOnly = false;
+            option.Repository.Url = "https://github.com/microsoft/PSRule.UnitTest";
             var output = new TestWriter(option);
             var result = new InvokeResult();
             result.Add(GetPass());
@@ -38,6 +39,7 @@ namespace PSRule
             Assert.NotNull(actual);
             Assert.Equal("PSRule", actual["runs"][0]["tool"]["driver"]["name"]);
             Assert.Equal("0.0.1", actual["runs"][0]["tool"]["driver"]["semanticVersion"].Value<string>().Split('+')[0]);
+            Assert.Equal("https://github.com/microsoft/PSRule.UnitTest", actual["runs"][0]["versionControlProvenance"][0]["repositoryUri"].Value<string>());
 
             // Pass
             Assert.Equal("TestModule\\rule-001", actual["runs"][0]["results"][0]["ruleId"]);

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -6,9 +6,7 @@
 #
 
 [CmdletBinding()]
-param (
-
-)
+param ()
 
 BeforeAll {
     # Setup error handling
@@ -1629,6 +1627,34 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Repository.Url' {
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Repository.Url' = 'https://github.com/microsoft/PSRule.UnitTest' };
+            $option.Repository.Url | Should -Be 'https://github.com/microsoft/PSRule.UnitTest';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Repository.Url | Should -Be 'https://github.com/microsoft/PSRule.UnitTest';
+        }
+
+        It 'from Environment' {
+            try {
+                $Env:PSRULE_REPOSITORY_URL = 'https://github.com/microsoft/PSRule.UnitTest';
+                $option = New-PSRuleOption;
+                $option.Repository.Url | Should -Be 'https://github.com/microsoft/PSRule.UnitTest';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_REPOSITORY_URL' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -RepositoryUrl 'https://github.com/microsoft/PSRule.UnitTest' -Path $emptyOptionsFilePath;
+            $option.Repository.Url | Should -Be 'https://github.com/microsoft/PSRule.UnitTest';
+        }
+    }
+
     Context 'Read Requires' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
@@ -1976,6 +2002,13 @@ Describe 'Set-PSRuleOption' -Tag 'Option','Set-PSRuleOption' {
         It 'from parameter' {
             $option = Set-PSRuleOption -OutputStyle 'AzurePipelines' @optionParams;
             $option.Output.Style | Should -Be 'AzurePipelines';
+        }
+    }
+
+    Context 'Read Repository.Url' {
+        It 'from parameter' {
+            $option = Set-PSRuleOption -RepositoryUrl 'https://github.com/microsoft/PSRule.UnitTest' @optionParams;
+            $option.Repository.Url | Should -Be 'https://github.com/microsoft/PSRule.UnitTest';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -1,5 +1,8 @@
 # These are options for unit tests
 
+repository:
+  url: 'https://github.com/microsoft/PSRule.UnitTest'
+
 # Configure baseline
 rule:
   include:


### PR DESCRIPTION
## PR Summary

- Capture and output repository info in Assert-PSRule runs. #978
  - Added `Repository.Url` option set repository URL reported in output.
  - Repository URL is detected automatically for GitHub Actions and Azure Pipelines.
  - Added `RepositoryInfo` to `Output.Banner` option.
  - Repository info is shown by default.
- Fixed SARIF should report base branch. #964

Fixes #978
Fixes #964

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
