### PR TITLE
Add type conversion and case-sensitivity #1001

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -14,6 +14,14 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2202072:
+
+- General improvements:
+  - Added `convert` and `caseSensitive` to string comparison expressions. [#1001](https://github.com/microsoft/PSRule/issues/1001)
+    - The following expressions support type convertion and case-sensitive comparison.
+      - `startsWith`, `contains`, and `endsWith`.
+      - `equals` and `notEquals`.
+
 ## v2.0.0-B2202072 (pre-release)
 
 What's changed since pre-release v2.0.0-B2202065:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -151,10 +151,17 @@ spec:
 The `contains` condition can be used to determine if the operand contains a specified sub-string.
 One or more strings to compare can be specified.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  By default, case-insensitive comparison is performed.
+- `convert` - Optionally, types can be converted to string type.
+  By default `convert` is `false`.
+
 Syntax:
 
 ```yaml
 contains: <string | array>
+caseSensitive: <boolean>
+convert: <boolean>
 ```
 
 - If the operand is a field, and the field does not exist, _contains_ always returns `false`.
@@ -231,10 +238,18 @@ spec:
 
 The `equals` condition can be used to compare if the operand is equal to a supplied value.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  This only applies to string comparisons.
+  By default, case-insensitive comparison is performed.
+- `convert` - Optionally, perform type conversion on operand type.
+  By default `convert` is `false`.
+
 Syntax:
 
 ```yaml
 equals: <string | int | bool>
+caseSensitive: <boolean>
+convert: <boolean>
 ```
 
 For example:
@@ -266,10 +281,17 @@ spec:
 The `endsWith` condition can be used to determine if the operand ends with a specified string.
 One or more strings to compare can be specified.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  By default, case-insensitive comparison is performed.
+- `convert` - Optionally, types can be converted to string type.
+  By default `convert` is `false`.
+
 Syntax:
 
 ```yaml
 endsWith: <string | array>
+caseSensitive: <boolean>
+convert: <boolean>
 ```
 
 - If the operand is a field, and the field does not exist, _endsWith_ always returns `false`.
@@ -1166,10 +1188,18 @@ spec:
 
 The `notEquals` condition can be used to compare if a field is equal to a supplied value.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  This only applies to string comparisons.
+  By default, case-insensitive comparison is performed.
+- `convert` - Optionally, perform type conversion on operand type.
+  By default `convert` is `false`.
+
 Syntax:
 
 ```yaml
 notEquals: <string | int | bool>
+caseSensitive: <boolean>
+convert: <boolean>
 ```
 
 For example:
@@ -1387,10 +1417,17 @@ spec:
 The `startsWith` condition can be used to determine if the operand starts with a specified string.
 One or more strings to compare can be specified.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  By default, case-insensitive comparison is performed.
+- `convert` - Optionally, types can be converted to string type.
+  By default `convert` is `false`.
+
 Syntax:
 
 ```yaml
 startsWith: <string | array>
+caseSensitive: <boolean>
+convert: <boolean>
 ```
 
 - If the operand is a field, and the field does not exist, _startsWith_ always returns `false`.

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -937,6 +937,20 @@
                     "description": "Must have the specified value.",
                     "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
                     "$ref": "#/definitions/selectorExpressionValue"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type of compared operand.",
+                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
+                    "default": false
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines if comparing values is case-sensitive. Only applies to string values.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. Only applies to string values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
+                    "default": false
                 }
             },
             "required": [
@@ -956,6 +970,20 @@
                     "description": "Must not have the specified value.",
                     "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
                     "$ref": "#/definitions/selectorExpressionValue"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type of compared operand.",
+                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
+                    "default": false
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines if comparing values is case-sensitive. Only applies to string values.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. Only applies to string values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
+                    "default": false
                 }
             },
             "required": [
@@ -1225,6 +1253,20 @@
                     "description": "Must start with one of the specified values.",
                     "markdownDescription": "Must start with one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
                     "$ref": "#/definitions/selectorExpressionValueMultiString"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type to string.",
+                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
+                    "default": false
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines if comparing values is case-sensitive.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
+                    "default": false
                 }
             },
             "required": [
@@ -1244,6 +1286,20 @@
                     "description": "Must end with one of the specified values.",
                     "markdownDescription": "Must end with one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
                     "$ref": "#/definitions/selectorExpressionValueMultiString"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type to string.",
+                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
+                    "default": false
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines if comparing values is case-sensitive.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
+                    "default": false
                 }
             },
             "required": [
@@ -1263,6 +1319,20 @@
                     "description": "Must contain one of the specified values.",
                     "markdownDescription": "Must contain one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
                     "$ref": "#/definitions/selectorExpressionValueMultiString"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type to string.",
+                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
+                    "default": false
+                },
+                "caseSensitive": {
+                    "type": "boolean",
+                    "title": "Case sensitive",
+                    "description": "Determines if comparing values is case-sensitive.",
+                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
+                    "default": false
                 }
             },
             "required": [

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -440,13 +440,16 @@ namespace PSRule.Definitions.Expressions
         internal static bool Equals(ExpressionContext context, ExpressionInfo info, object[] args, object o)
         {
             var properties = GetProperties(args);
-            if (!TryPropertyAny(properties, EQUALS, out var propertyValue) || !TryOperand(context, EQUALS, o, properties, out var operand))
+            if (!TryPropertyAny(properties, EQUALS, out var propertyValue) ||
+                !TryOperand(context, EQUALS, o, properties, out var operand) ||
+                !GetConvert(properties, out var convert) ||
+                !GetCaseSensitive(properties, out var caseSensitive))
                 return Invalid(context, EQUALS);
 
             // int, string, bool
             return Condition(
                 context,
-                ExpressionHelpers.Equal(propertyValue, operand.Value, caseSensitive: false, convertExpected: true),
+                ExpressionHelpers.Equal(propertyValue, operand.Value, caseSensitive, convertExpected: true, convertActual: convert),
                 operand,
                 ReasonStrings.Assert_IsSetTo,
                 operand.Value
@@ -462,13 +465,15 @@ namespace PSRule.Definitions.Expressions
             if (TryFieldNotExists(context, o, properties))
                 return Pass();
 
-            if (!TryOperand(context, NOTEQUALS, o, properties, out var operand))
+            if (!TryOperand(context, NOTEQUALS, o, properties, out var operand) ||
+                !GetConvert(properties, out var convert) ||
+                !GetCaseSensitive(properties, out var caseSensitive))
                 return Invalid(context, NOTEQUALS);
 
             // int, string, bool
             return Condition(
                 context,
-                !ExpressionHelpers.Equal(propertyValue, operand.Value, caseSensitive: false, convertExpected: true),
+                !ExpressionHelpers.Equal(propertyValue, operand.Value, caseSensitive, convertExpected: true, convertActual: convert),
                 operand,
                 ReasonStrings.Assert_IsSetTo,
                 operand.Value
@@ -819,14 +824,16 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (TryPropertyStringArray(properties, STARTSWITH, out var propertyValue) &&
-                TryOperand(context, STARTSWITH, o, properties, out var operand))
+                TryOperand(context, STARTSWITH, o, properties, out var operand) &&
+                GetConvert(properties, out var convert) &&
+                GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(STARTSWITH, operand.Value, propertyValue);
-                if (!ExpressionHelpers.TryString(operand.Value, out var value))
+                if (!ExpressionHelpers.TryString(operand.Value, convert, out var value))
                     return NotString(context, operand);
 
                 for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
-                    if (ExpressionHelpers.StartsWith(value, propertyValue[i], caseSensitive: false))
+                    if (ExpressionHelpers.StartsWith(value, propertyValue[i], caseSensitive))
                         return Pass();
 
                 return Fail(
@@ -844,14 +851,16 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (TryPropertyStringArray(properties, ENDSWITH, out var propertyValue) &&
-                TryOperand(context, ENDSWITH, o, properties, out var operand))
+                TryOperand(context, ENDSWITH, o, properties, out var operand) &&
+                GetConvert(properties, out var convert) &&
+                GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(ENDSWITH, operand.Value, propertyValue);
-                if (!ExpressionHelpers.TryString(operand.Value, out var value))
+                if (!ExpressionHelpers.TryString(operand.Value, convert, out var value))
                     return NotString(context, operand);
 
                 for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
-                    if (ExpressionHelpers.EndsWith(value, propertyValue[i], caseSensitive: false))
+                    if (ExpressionHelpers.EndsWith(value, propertyValue[i], caseSensitive))
                         return Pass();
 
                 return Fail(
@@ -869,14 +878,16 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (TryPropertyStringArray(properties, CONTAINS, out var propertyValue) &&
-                TryOperand(context, CONTAINS, o, properties, out var operand))
+                TryOperand(context, CONTAINS, o, properties, out var operand) &&
+                GetConvert(properties, out var convert) &&
+                GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(CONTAINS, operand.Value, propertyValue);
-                if (!ExpressionHelpers.TryString(operand.Value, out var value))
+                if (!ExpressionHelpers.TryString(operand.Value, convert, out var value))
                     return NotString(context, operand);
 
                 for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
-                    if (ExpressionHelpers.Contains(value, propertyValue[i], caseSensitive: false))
+                    if (ExpressionHelpers.Contains(value, propertyValue[i], caseSensitive))
                         return Pass();
 
                 return Fail(

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -16,6 +16,13 @@ using Assert = Xunit.Assert;
 
 namespace PSRule
 {
+    internal enum TestEnumValue
+    {
+        None = 0,
+
+        All = 1
+    }
+
     public sealed class SelectorTests
     {
         private const string SelectorYamlFileName = "Selectors.Rule.yaml";
@@ -68,7 +75,8 @@ namespace PSRule
             var actual1 = GetObject(
                 (name: "ValueString", value: "abc"),
                 (name: "ValueInt", value: 123),
-                (name: "ValueBool", value: true)
+                (name: "ValueBool", value: true),
+                (name: "ValueEnum", value: TestEnumValue.All)
             );
             var actual2 = GetObject(
                 (name: "ValueString", value: "efg"),
@@ -85,26 +93,39 @@ namespace PSRule
                 (name: "ValueInt", value: 123),
                 (name: "ValueBool", value: false)
             );
+            var actual5 = GetObject(
+                (name: "ValueString", value: "abc"),
+                (name: "ValueInt", value: 123),
+                (name: "ValueBool", value: true),
+                (name: "ValueEnum", value: TestEnumValue.None)
+            );
+            var actual6 = GetObject(
+                (name: "ValueString", value: "ABC"),
+                (name: "ValueInt", value: 123),
+                (name: "ValueBool", value: true)
+            );
 
             Assert.True(equals.Match(actual1));
             Assert.False(equals.Match(actual2));
             Assert.False(equals.Match(actual3));
             Assert.False(equals.Match(actual4));
+            Assert.False(equals.Match(actual5));
+            Assert.False(equals.Match(actual6));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameEquals", GetSource(path), out var context);
-            var actual5 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "TargetObject1")
             );
-            var actual6 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "TargetObject2")
             );
 
-            context.EnterTargetObject(new TargetObject(actual5));
-            Assert.True(withName.Match(actual5));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual6));
-            Assert.False(withName.Match(actual6));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
 
             // With type
             var withType = GetSelectorVisitor($"{type}TypeEquals", GetSource(path), out context);
@@ -129,7 +150,8 @@ namespace PSRule
             var actual1 = GetObject(
                 (name: "ValueString", value: "efg"),
                 (name: "ValueInt", value: 456),
-                (name: "ValueBool", value: false)
+                (name: "ValueBool", value: false),
+                (name: "ValueEnum", value: TestEnumValue.None)
             );
             var actual2 = GetObject(
                 (name: "ValueString", value: "abc"),
@@ -146,26 +168,39 @@ namespace PSRule
                 (name: "ValueInt", value: 456),
                 (name: "ValueBool", value: true)
             );
+            var actual5 = GetObject(
+                (name: "ValueString", value: "efg"),
+                (name: "ValueInt", value: 456),
+                (name: "ValueBool", value: false),
+                (name: "ValueEnum", value: TestEnumValue.All)
+            );
+            var actual6 = GetObject(
+                (name: "ValueString", value: "ABC"),
+                (name: "ValueInt", value: 456),
+                (name: "ValueBool", value: false)
+            );
 
             Assert.True(notEquals.Match(actual1));
             Assert.False(notEquals.Match(actual2));
             Assert.False(notEquals.Match(actual3));
             Assert.False(notEquals.Match(actual4));
+            Assert.False(notEquals.Match(actual5));
+            Assert.True(notEquals.Match(actual6));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameNotEquals", GetSource(path), out var context);
-            var actual5 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "TargetObject1")
             );
-            var actual6 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "TargetObject2")
             );
 
-            context.EnterTargetObject(new TargetObject(actual5));
-            Assert.False(withName.Match(actual5));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.False(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual6));
-            Assert.True(withName.Match(actual6));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.True(withName.Match(actual2));
         }
 
         [Theory]
@@ -676,6 +711,9 @@ namespace PSRule
             var actual4 = GetObject((name: "value", value: new string[] { }));
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject();
+            var actual7 = GetObject((name: "value", value: "EFG"));
+            var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
+            var actual9 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.None));
 
             Assert.True(startsWith.Match(actual1));
             Assert.True(startsWith.Match(actual2));
@@ -683,21 +721,24 @@ namespace PSRule
             Assert.False(startsWith.Match(actual4));
             Assert.False(startsWith.Match(actual5));
             Assert.False(startsWith.Match(actual6));
+            Assert.False(startsWith.Match(actual7));
+            Assert.True(startsWith.Match(actual8));
+            Assert.False(startsWith.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameStartsWith", GetSource(path), out var context);
-            var actual7 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "1TargetObject")
             );
-            var actual8 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "2TargetObject")
             );
 
-            context.EnterTargetObject(new TargetObject(actual7));
-            Assert.True(withName.Match(actual7));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.False(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
         }
 
         [Theory]
@@ -712,6 +753,9 @@ namespace PSRule
             var actual4 = GetObject((name: "value", value: new string[] { }));
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject();
+            var actual7 = GetObject((name: "value", value: "EFG"));
+            var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
+            var actual9 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.None));
 
             Assert.True(endsWith.Match(actual1));
             Assert.True(endsWith.Match(actual2));
@@ -719,21 +763,24 @@ namespace PSRule
             Assert.False(endsWith.Match(actual4));
             Assert.False(endsWith.Match(actual5));
             Assert.False(endsWith.Match(actual6));
+            Assert.False(endsWith.Match(actual7));
+            Assert.True(endsWith.Match(actual8));
+            Assert.False(endsWith.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameEndsWith", GetSource(path), out var context);
-            var actual7 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "TargetObject1")
             );
-            var actual8 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "TargetObject2")
             );
 
-            context.EnterTargetObject(new TargetObject(actual7));
-            Assert.True(withName.Match(actual7));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.False(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
         }
 
         [Theory]
@@ -748,6 +795,9 @@ namespace PSRule
             var actual4 = GetObject((name: "value", value: new string[] { }));
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject();
+            var actual7 = GetObject((name: "value", value: "BCD"));
+            var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
+            var actual9 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.None));
 
             Assert.True(contains.Match(actual1));
             Assert.True(contains.Match(actual2));
@@ -755,21 +805,24 @@ namespace PSRule
             Assert.False(contains.Match(actual4));
             Assert.False(contains.Match(actual5));
             Assert.False(contains.Match(actual6));
+            Assert.False(contains.Match(actual7));
+            Assert.True(contains.Match(actual8));
+            Assert.False(contains.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameContains", GetSource(path), out var context);
-            var actual7 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "Target.1.Object")
             );
-            var actual8 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "Target.2.Object")
             );
 
-            context.EnterTargetObject(new TargetObject(actual7));
-            Assert.True(withName.Match(actual7));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.False(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
         }
 
         [Theory]

--- a/tests/PSRule.Tests/Selectors.Rule.jsonc
+++ b/tests/PSRule.Tests/Selectors.Rule.jsonc
@@ -177,7 +177,8 @@
                 "allOf": [
                     {
                         "field": "ValueString",
-                        "equals": "abc"
+                        "equals": "abc",
+                        "caseSensitive": true
                     },
                     {
                         "field": "ValueInt",
@@ -186,6 +187,19 @@
                     {
                         "field": "ValueBool",
                         "equals": true
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "field": "ValueEnum",
+                                "exists": false
+                            },
+                            {
+                                "field": "ValueEnum",
+                                "equals": "All",
+                                "convert": true
+                            }
+                        ]
                     }
                 ]
             }
@@ -203,7 +217,8 @@
                 "allOf": [
                     {
                         "field": "ValueString",
-                        "notEquals": "abc"
+                        "notEquals": "abc",
+                        "caseSensitive": true
                     },
                     {
                         "field": "ValueInt",
@@ -212,6 +227,19 @@
                     {
                         "field": "ValueBool",
                         "notEquals": true
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "field": "ValueEnum",
+                                "exists": false
+                            },
+                            {
+                                "field": "ValueEnum",
+                                "notEquals": "All",
+                                "convert": true
+                            }
+                        ]
                     }
                 ]
             }
@@ -381,7 +409,8 @@
                             },
                             {
                                 "field": "Value",
-                                "startsWith": "e"
+                                "startsWith": "e",
+                                "caseSensitive": true
                             }
                         ]
                     },
@@ -390,6 +419,19 @@
                         "startsWith": [
                             "a",
                             "e"
+                        ]
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "field": "OtherValue",
+                                "exists": false
+                            },
+                            {
+                                "field": "OtherValue",
+                                "startsWith": "a",
+                                "convert": true
+                            }
                         ]
                     }
                 ]
@@ -414,7 +456,8 @@
                             },
                             {
                                 "field": "Value",
-                                "endsWith": "g"
+                                "endsWith": "g",
+                                "caseSensitive": true
                             }
                         ]
                     },
@@ -423,6 +466,19 @@
                         "endsWith": [
                             "c",
                             "g"
+                        ]
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "field": "OtherValue",
+                                "exists": false
+                            },
+                            {
+                                "field": "OtherValue",
+                                "endsWith": "l",
+                                "convert": true
+                            }
                         ]
                     }
                 ]
@@ -447,7 +503,8 @@
                             },
                             {
                                 "field": "Value",
-                                "contains": "bc"
+                                "contains": "bc",
+                                "caseSensitive": true
                             }
                         ]
                     },
@@ -456,6 +513,19 @@
                         "contains": [
                             "ab",
                             "bc"
+                        ]
+                    },
+                    {
+                        "anyOf": [
+                            {
+                                "field": "OtherValue",
+                                "exists": false
+                            },
+                            {
+                                "field": "OtherValue",
+                                "contains": "l",
+                                "convert": true
+                            }
                         ]
                     }
                 ]

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -128,10 +128,17 @@ spec:
     allOf:
     - field: 'ValueString'
       equals: 'abc'
+      caseSensitive: true
     - field: 'ValueInt'
       equals: 123
     - field: 'ValueBool'
       equals: true
+    - anyOf:
+      - field: 'ValueEnum'
+        exists: false
+      - field: 'ValueEnum'
+        equals: 'All'
+        convert: true
 
 ---
 # Synopsis: Test notEquals
@@ -144,10 +151,17 @@ spec:
     allOf:
     - field: 'ValueString'
       notEquals: 'abc'
+      caseSensitive: true
     - field: 'ValueInt'
       notEquals: 123
     - field: 'ValueBool'
       notEquals: true
+    - anyOf:
+      - field: 'ValueEnum'
+        exists: false
+      - field: 'ValueEnum'
+        notEquals: 'All'
+        convert: true
 
 ---
 # Synopsis: Test hasValue true
@@ -277,10 +291,17 @@ spec:
         startsWith: 'a'
       - field: 'Value'
         startsWith: 'e'
+        caseSensitive: true
     - field: 'Value'
       startsWith:
       - 'a'
       - 'e'
+    - anyOf:
+      - field: 'OtherValue'
+        exists: false
+      - field: 'OtherValue'
+        startsWith: 'a'
+        convert: true
 
 ---
 # Synopsis: Test endsWith
@@ -296,10 +317,17 @@ spec:
         endsWith: 'c'
       - field: 'Value'
         endsWith: 'g'
+        caseSensitive: true
     - field: 'Value'
       endsWith:
       - 'c'
       - 'g'
+    - anyOf:
+      - field: 'OtherValue'
+        exists: false
+      - field: 'OtherValue'
+        endsWith: 'l'
+        convert: true
 
 ---
 # Synopsis: Test contains
@@ -315,10 +343,17 @@ spec:
         contains: 'ab'
       - field: 'Value'
         contains: 'bc'
+        caseSensitive: true
     - field: 'Value'
       contains:
       - 'ab'
       - 'bc'
+    - anyOf:
+      - field: 'OtherValue'
+        exists: false
+      - field: 'OtherValue'
+        contains: 'l'
+        convert: true
 
 ---
 # Synopsis: Test isString


### PR DESCRIPTION
## PR Summary

- Added `convert` and `caseSensitive` to string comparison expressions.
  - The following expressions support type convertion and case-sensitive comparison.
    - `startsWith`, `contains`, and `endsWith`.
    - `equals` and `notEquals`.

Fixes #1001 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
