### PR TITLE
Added convert to numeric expressions #943

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -14,6 +14,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.0.0-B2203033:
+
+- General improvements:
+  - Added `convert` to numeric comparison expressions. [#943](https://github.com/microsoft/PSRule/issues/943)
+    - Type conversion is now supported for `less`, `lessOrEquals`, `greater`, and `greaterOrEquals`.
+
 ## v2.0.0-B2203033 (pre-release)
 
 What's changed since pre-release v2.0.0-B2203019:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -416,17 +416,23 @@ spec:
 
 The `greater` condition determines if the operand is greater than a supplied value.
 The field value can either be an integer, float, array, or string.
+
+- `convert` - Optionally, perform type conversion on operand type.
+  By default `convert` is `false`.
+
 When the field value is:
 
 - An integer or float, a numerical comparison is used.
 - An array, the number of elements is compared.
 - A string, the length of the string is compared.
+  If `convert` is `true`, the string is converted a number instead.
 - A DateTime, the number of days from the current time is compared.
 
 Syntax:
 
 ```yaml
 greater: <int>
+convert: <boolean>
 ```
 
 For example:
@@ -457,17 +463,23 @@ spec:
 
 The `greaterOrEquals` condition determines if the operand is greater or equal to the supplied value.
 The field value can either be an integer, float, array, or string.
+
+- `convert` - Optionally, perform type conversion on operand type.
+  By default `convert` is `false`.
+
 When the field value is:
 
 - An integer or float, a numerical comparison is used.
 - An array, the number of elements is compared.
 - A string, the length of the string is compared.
+  If `convert` is `true`, the string is converted a number instead.
 - A DateTime, the number of days from the current time is compared.
 
 Syntax:
 
 ```yaml
 greaterOrEquals: <int>
+convert: <boolean>
 ```
 
 For example:
@@ -999,17 +1011,23 @@ spec:
 
 The `less` condition determines if the operand is less than a supplied value.
 The field value can either be an integer, float, array, or string.
+
+- `convert` - Optionally, perform type conversion on operand type.
+  By default `convert` is `false`.
+
 When the field value is:
 
 - An integer or float, a numerical comparison is used.
 - An array, the number of elements is compared.
 - A string, the length of the string is compared.
+  If `convert` is `true`, the string is converted a number instead.
 - A DateTime, the number of days from the current time is compared.
 
 Syntax:
 
 ```yaml
 less: <int>
+convert: <boolean>
 ```
 
 For example:
@@ -1040,17 +1058,23 @@ spec:
 
 The `lessOrEquals` condition determines if the operand is less or equal to the supplied value.
 The field value can either be an integer, float, array, or string.
+
+- `convert` - Optionally, perform type conversion on operand type.
+  By default `convert` is `false`.
+
 When the field value is:
 
 - An integer or float, a numerical comparison is used.
 - An array, the number of elements is compared.
 - A string, the length of the string is compared.
+  If `convert` is `true`, the string is converted a number instead.
 - A DateTime, the number of days from the current time is compared.
 
 Syntax:
 
 ```yaml
 lessOrEquals: <int>
+convert: <boolean>
 ```
 
 For example:

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -1177,6 +1177,13 @@
                     "title": "Less",
                     "description": "Must be less then the specified value.",
                     "markdownDescription": "Must be less then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type of compared operand.",
+                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                    "default": false
                 }
             },
             "required": [
@@ -1196,6 +1203,13 @@
                     "title": "Less or Equal to",
                     "description": "Must be less or equal to the specified value.",
                     "markdownDescription": "Must be less or equal to the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#lessorequals)"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type of compared operand.",
+                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                    "default": false
                 }
             },
             "required": [
@@ -1215,6 +1229,13 @@
                     "title": "Greater",
                     "description": "Must be greater then the specified value.",
                     "markdownDescription": "Must be greater then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greater)"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type of compared operand.",
+                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                    "default": false
                 }
             },
             "required": [
@@ -1234,6 +1255,13 @@
                     "title": "Greater or Equal to",
                     "description": "Must be greater or equal to the specified value.",
                     "markdownDescription": "Must be greater or equal to the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greaterorequals)"
+                },
+                "convert": {
+                    "type": "boolean",
+                    "title": "Type conversion",
+                    "description": "Convert type of compared operand.",
+                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                    "default": false
                 }
             },
             "required": [

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -684,7 +684,8 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (!TryPropertyLong(properties, LESS, out var propertyValue) ||
-                !TryOperand(context, LESS, o, properties, out var operand))
+                !TryOperand(context, LESS, o, properties, out var operand) ||
+                !GetConvert(properties, out var convert))
                 return Invalid(context, LESS);
 
             if (operand.Value == null)
@@ -698,7 +699,7 @@ namespace PSRule.Definitions.Expressions
             if (!ExpressionHelpers.CompareNumeric(
                 operand.Value,
                 propertyValue,
-                convert: false,
+                convert,
                 compare: out var compare,
                 value: out _))
                 return Invalid(context, LESS);
@@ -719,7 +720,8 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (!TryPropertyLong(properties, LESSOREQUALS, out var propertyValue) ||
-                !TryOperand(context, LESSOREQUALS, o, properties, out var operand))
+                !TryOperand(context, LESSOREQUALS, o, properties, out var operand) ||
+                !GetConvert(properties, out var convert))
                 return Invalid(context, LESSOREQUALS);
 
             if (operand.Value == null)
@@ -733,7 +735,7 @@ namespace PSRule.Definitions.Expressions
             if (!ExpressionHelpers.CompareNumeric(
                 operand.Value,
                 propertyValue,
-                convert: false,
+                convert,
                 compare: out var compare,
                 value: out _))
                 return Invalid(context, LESSOREQUALS);
@@ -754,7 +756,8 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (!TryPropertyLong(properties, GREATER, out var propertyValue) ||
-                !TryOperand(context, GREATER, o, properties, out var operand))
+                !TryOperand(context, GREATER, o, properties, out var operand) ||
+                !GetConvert(properties, out var convert))
                 return Invalid(context, GREATER);
 
             if (operand.Value == null)
@@ -768,7 +771,7 @@ namespace PSRule.Definitions.Expressions
             if (!ExpressionHelpers.CompareNumeric(
                 operand.Value,
                 propertyValue,
-                convert: false,
+                convert,
                 compare: out var compare,
                 value: out _))
                 return Invalid(context, GREATER);
@@ -789,7 +792,8 @@ namespace PSRule.Definitions.Expressions
         {
             var properties = GetProperties(args);
             if (!TryPropertyLong(properties, GREATEROREQUALS, out var propertyValue) ||
-                !TryOperand(context, GREATEROREQUALS, o, properties, out var operand))
+                !TryOperand(context, GREATEROREQUALS, o, properties, out var operand) ||
+                !GetConvert(properties, out var convert))
                 return Invalid(context, GREATEROREQUALS);
 
             if (operand.Value == null)
@@ -803,7 +807,7 @@ namespace PSRule.Definitions.Expressions
             if (!ExpressionHelpers.CompareNumeric(
                 operand.Value,
                 propertyValue,
-                convert: false,
+                convert,
                 compare: out var compare,
                 value: out _))
                 return Invalid(context, GREATEROREQUALS);

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -560,6 +560,8 @@ namespace PSRule
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject((name: "value", value: 2));
             var actual7 = GetObject((name: "value", value: -1));
+            var actual8 = GetObject((name: "valueStr", value: "0"));
+            var actual9 = GetObject((name: "valueStr", value: "-1"));
 
             Assert.False(less.Match(actual1));
             Assert.False(less.Match(actual2));
@@ -568,21 +570,23 @@ namespace PSRule
             Assert.True(less.Match(actual5));
             Assert.True(less.Match(actual6));
             Assert.True(less.Match(actual7));
+            Assert.False(less.Match(actual8));
+            Assert.True(less.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameLess", GetSource(path), out var context);
-            var actual8 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "ItemTwo")
             );
-            var actual9 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "ItemThree")
             );
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.True(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual9));
-            Assert.False(withName.Match(actual9));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
         }
 
         [Theory]
@@ -598,6 +602,8 @@ namespace PSRule
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject((name: "value", value: 2));
             var actual7 = GetObject((name: "value", value: -1));
+            var actual8 = GetObject((name: "valueStr", value: "0"));
+            var actual9 = GetObject((name: "valueStr", value: "-1"));
 
             Assert.True(lessOrEquals.Match(actual1));
             Assert.False(lessOrEquals.Match(actual2));
@@ -606,21 +612,23 @@ namespace PSRule
             Assert.True(lessOrEquals.Match(actual5));
             Assert.True(lessOrEquals.Match(actual6));
             Assert.True(lessOrEquals.Match(actual7));
+            Assert.True(lessOrEquals.Match(actual8));
+            Assert.True(lessOrEquals.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameLessOrEquals", GetSource(path), out var context);
-            var actual8 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "ItemTwo")
             );
-            var actual9 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "ItemThree")
             );
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.True(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual9));
-            Assert.False(withName.Match(actual9));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
         }
 
         [Theory]
@@ -636,6 +644,8 @@ namespace PSRule
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject((name: "value", value: 2));
             var actual7 = GetObject((name: "value", value: -1));
+            var actual8 = GetObject((name: "valueStr", value: "0"));
+            var actual9 = GetObject((name: "valueStr", value: "-1"));
 
             Assert.False(greater.Match(actual1));
             Assert.True(greater.Match(actual2));
@@ -644,21 +654,23 @@ namespace PSRule
             Assert.False(greater.Match(actual5));
             Assert.False(greater.Match(actual6));
             Assert.False(greater.Match(actual7));
+            Assert.True(greater.Match(actual8));
+            Assert.False(greater.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameGreater", GetSource(path), out var context);
-            var actual8 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "ItemTwo")
             );
-            var actual9 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "ItemThree")
             );
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.False(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.False(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual9));
-            Assert.True(withName.Match(actual9));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.True(withName.Match(actual2));
         }
 
         [Theory]
@@ -674,6 +686,8 @@ namespace PSRule
             var actual5 = GetObject((name: "value", value: null));
             var actual6 = GetObject((name: "value", value: 2));
             var actual7 = GetObject((name: "value", value: -1));
+            var actual8 = GetObject((name: "valueStr", value: "0"));
+            var actual9 = GetObject((name: "valueStr", value: "-1"));
 
             Assert.True(greaterOrEquals.Match(actual1));
             Assert.True(greaterOrEquals.Match(actual2));
@@ -682,21 +696,23 @@ namespace PSRule
             Assert.False(greaterOrEquals.Match(actual5));
             Assert.False(greaterOrEquals.Match(actual6));
             Assert.False(greaterOrEquals.Match(actual7));
+            Assert.True(greaterOrEquals.Match(actual8));
+            Assert.True(greaterOrEquals.Match(actual9));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameGreaterOrEquals", GetSource(path), out var context);
-            var actual8 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "ItemTwo")
             );
-            var actual9 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "ItemThree")
             );
 
-            context.EnterTargetObject(new TargetObject(actual8));
-            Assert.False(withName.Match(actual8));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.False(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual9));
-            Assert.True(withName.Match(actual9));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.True(withName.Match(actual2));
         }
 
         [Theory]

--- a/tests/PSRule.Tests/Selectors.Rule.jsonc
+++ b/tests/PSRule.Tests/Selectors.Rule.jsonc
@@ -344,8 +344,17 @@
         },
         "spec": {
             "if": {
-                "field": "Value",
-                "less": 3
+                "anyOf": [
+                    {
+                        "field": "Value",
+                        "less": 3
+                    },
+                    {
+                        "field": "ValueStr",
+                        "less": 0,
+                        "convert": true
+                    }
+                ]
             }
         }
     },
@@ -358,8 +367,17 @@
         },
         "spec": {
             "if": {
-                "field": "Value",
-                "lessOrEquals": 3
+                "anyOf": [
+                    {
+                        "field": "Value",
+                        "lessOrEquals": 3
+                    },
+                    {
+                        "field": "ValueStr",
+                        "lessOrEquals": 0,
+                        "convert": true
+                    }
+                ]
             }
         }
     },
@@ -372,8 +390,17 @@
         },
         "spec": {
             "if": {
-                "field": "Value",
-                "greater": 3
+                "anyOf": [
+                    {
+                        "field": "Value",
+                        "greater": 3
+                    },
+                    {
+                        "field": "ValueStr",
+                        "greater": -1,
+                        "convert": true
+                    }
+                ]
             }
         }
     },
@@ -386,8 +413,17 @@
         },
         "spec": {
             "if": {
-                "field": "Value",
-                "greaterOrEquals": 3
+                "anyOf": [
+                    {
+                        "field": "Value",
+                        "greaterOrEquals": 3
+                    },
+                    {
+                        "field": "ValueStr",
+                        "greaterOrEquals": -1,
+                        "convert": true
+                    }
+                ]
             }
         }
     },

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -241,8 +241,12 @@ metadata:
   name: YamlLess
 spec:
   if:
-    field: 'Value'
-    less: 3
+    anyOf:
+    - field: 'Value'
+      less: 3
+    - field: 'ValueStr'
+      less: 0
+      convert: true
 
 ---
 # Synopsis: Test lessOrEquals
@@ -252,8 +256,12 @@ metadata:
   name: YamlLessOrEquals
 spec:
   if:
-    field: 'Value'
-    lessOrEquals: 3
+    anyOf:
+    - field: 'Value'
+      lessOrEquals: 3
+    - field: 'ValueStr'
+      lessOrEquals: 0
+      convert: true
 
 ---
 # Synopsis: Test greater
@@ -263,8 +271,12 @@ metadata:
   name: YamlGreater
 spec:
   if:
-    field: 'Value'
-    greater: 3
+    anyOf:
+    - field: 'Value'
+      greater: 3
+    - field: 'ValueStr'
+      greater: -1
+      convert: true
 
 ---
 # Synopsis: Test greaterOrEquals
@@ -274,8 +286,12 @@ metadata:
   name: YamlGreaterOrEquals
 spec:
   if:
-    field: 'Value'
-    greaterOrEquals: 3
+    anyOf:
+    - field: 'Value'
+      greaterOrEquals: 3
+    - field: 'ValueStr'
+      greaterOrEquals: -1
+      convert: true
 
 ---
 # Synopsis: Test startsWith


### PR DESCRIPTION
## PR Summary

- Added `convert` to numeric comparison expressions. #943
  - Type conversion is now supported for `less`, `lessOrEquals`, `greater`, and `greaterOrEquals`.

Fixes #943 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
