### PR TITLE
Fixes unclear error on invalid rule name #1012

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -8,6 +8,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 - YAML resources will require an `apiVersion` from PSRule v2. [#648](https://github.com/microsoft/PSRule/issues/648)
 - Setting the default module baseline requires a module configuration from PSRule v2. [#809](https://github.com/microsoft/PSRule/issues/809)
+- Resource names have naming restrictions introduced from PSRule v2. [#1012](https://github.com/microsoft/PSRule/issues/1012)
 
 !!! Info
     The next release of PSRule is currently in preview.

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -8,6 +8,7 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 - YAML resources will require an `apiVersion` from PSRule v2. [#648](https://github.com/microsoft/PSRule/issues/648)
 - Setting the default module baseline requires a module configuration from PSRule v2. [#809](https://github.com/microsoft/PSRule/issues/809)
+- Resource names have naming restrictions introduced from PSRule v2. [#1012](https://github.com/microsoft/PSRule/issues/1012)
 
 !!! Info
     You can discuss v2 pre-releases on the [GitHub discussions page](https://github.com/microsoft/PSRule/discussions/966).
@@ -19,6 +20,11 @@ What's changed since pre-release v2.0.0-B2203033:
 - General improvements:
   - Added `convert` to numeric comparison expressions. [#943](https://github.com/microsoft/PSRule/issues/943)
     - Type conversion is now supported for `less`, `lessOrEquals`, `greater`, and `greaterOrEquals`.
+  - **Breaking change:** Added validation of resource names. [#1012](https://github.com/microsoft/PSRule/issues/1012)
+    - Resource names must now match `^[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$` to be valid.
+    - Invalid rules names will now produce a specific error.
+- Bug fixes:
+  - Fixed unclear error message on invalid rule names. [#1012](https://github.com/microsoft/PSRule/issues/1012)
 
 ## v2.0.0-B2203033 (pre-release)
 

--- a/docs/authoring/storing-rules.md
+++ b/docs/authoring/storing-rules.md
@@ -47,7 +47,17 @@ For example, [PSRule for Azure][1] uses the name prefix of `Azure.` for rules in
     - `Azure.AKS.AuthorizedIPs`
     - `Azure.SQL.MinTLS`
 
-When naming custom rules we recommend that you:
+In addition, names for rules and other resources must meet the following requirements:
+
+- **Use between 3 and 128 characters** &mdash; This is the minimum and maximum length of a resource name.
+- **Use only letters, numbers, hyphens, dots, and underscores** &mdash; These are the only allowed characters.
+  However, only letters and numbers are allows at the beginning and end of the name.
+
+```text title="Regular expression for valid resource names"
+^[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$
+```
+
+When naming rules we recommend that you:
 
 - **Use a standard prefix** &mdash; You can use the `Local.` or `Org.` prefix for standalone rules.
   - Alternatively choose a short prefix that identifies your organization.

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -7,6 +7,24 @@ This document contains notes to help upgrade from previous versions of PSRule.
 PSRule v2.0.0 is a planned future release.
 It's not yet available, but you can take these steps to proactively prepare for the release.
 
+### Resources naming restrictions
+
+When naming resources such as rules or selectors, the following restrictions apply:
+
+- **Use between 3 and 128 characters** &mdash; This is the minimum and maximum length of a resource name.
+- **Use only letters, numbers, hyphens, dots, and underscores** &mdash; These are the only allowed characters.
+  However, only letters and numbers are allows at the beginning and end of the name.
+
+Prior to _v2.0.0_, there was no specific naming restriction for resources.
+However functionally PSRule and downstream components could not support all resource names.
+To avoid confusion, we have decided to restrict resource names to a specific set of characters.
+
+From _v2.0.0_, resource names that do not meet the naming restrictions will generate an error.
+
+```text title="Regular expression for valid resource names"
+^[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$
+```
+
 ### Setting default module baseline
 
 When packaging rules in a module, you can set the default baseline.

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -123,7 +123,7 @@
                             "markdownDescription": "Rules to include by name in the baseline. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#ruleinclude)",
                             "items": {
                                 "type": "string",
-                                "$ref": "#/definitions/resourceName"
+                                "$ref": "#/definitions/resourceNameReference"
                             },
                             "uniqueItems": true
                         },
@@ -134,7 +134,7 @@
                             "markdownDescription": "Rules to exclude by name from the baseline. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#ruleexclude)",
                             "items": {
                                 "type": "string",
-                                "$ref": "#/definitions/resourceName"
+                                "$ref": "#/definitions/resourceNameReference"
                             },
                             "uniqueItems": true
                         },
@@ -268,7 +268,7 @@
                             "title": "Baseline",
                             "description": "The name of a baseline to use.",
                             "markdownDescription": "The name of a baseline to use. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#rulebaseline)",
-                            "$ref": "#/definitions/resourceName"
+                            "$ref": "#/definitions/resourceNameReference"
                         }
                     },
                     "additionalProperties": false
@@ -278,7 +278,14 @@
         },
         "resourceName": {
             "type": "string",
-            "minLength": 3
+            "minLength": 3,
+            "maxLength": 128,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$"
+        },
+        "resourceNameReference": {
+            "type": "string",
+            "minLength": 3,
+            "pattern": "^.*\\[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$"
         },
         "resourceTags": {
             "type": "object",

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -104,6 +104,11 @@ namespace PSRule.Definitions
         ISourceExtent Extent { get; }
     }
 
+    internal interface IResourceVisitor
+    {
+        bool Visit(IResource resource);
+    }
+
     internal abstract class ResourceRef
     {
         public readonly string Id;
@@ -140,6 +145,11 @@ namespace PSRule.Definitions
         }
 
         internal IResource Block { get; }
+
+        internal bool Visit(IResourceVisitor visitor)
+        {
+            return Block != null && visitor != null && visitor.Visit(Block);
+        }
     }
 
     internal sealed class ResourceBuilder

--- a/src/PSRule/Definitions/ResourceValidator.cs
+++ b/src/PSRule/Definitions/ResourceValidator.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+using System.Text.RegularExpressions;
+using System.Threading;
+using PSRule.Resources;
+using PSRule.Runtime;
+
+namespace PSRule.Definitions
+{
+    internal interface IResourceValidator : IResourceVisitor
+    {
+
+    }
+
+    /// <summary>
+    /// A helper class to help validate a resource object.
+    /// </summary>
+    internal sealed class ResourceValidator : IResourceValidator
+    {
+        private const string ERRORID_INVALIDRESOURCENAME = "PSRule.Parse.InvalidResourceName";
+
+        private static readonly Regex ValidName = new Regex("^[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$", RegexOptions.Compiled);
+
+        private readonly RunspaceContext _Context;
+
+        public ResourceValidator(RunspaceContext context)
+        {
+            _Context = context;
+        }
+
+        internal static bool IsNameValid(string name)
+        {
+            return !string.IsNullOrEmpty(name) && ValidName.Match(name).Success;
+        }
+
+        public bool Visit(IResource resource)
+        {
+            return VisitName(resource);
+        }
+
+        private bool VisitName(IResource resource)
+        {
+            if (IsNameValid(resource.Name))
+                return true;
+
+            ReportError(ERRORID_INVALIDRESOURCENAME, PSRuleResources.InvalidResourceName, resource.Name, ReportExtent(resource.Extent));
+            return false;
+        }
+
+        private static string ReportExtent(ISourceExtent extent)
+        {
+            return string.Concat(extent.File, " line ", extent.Line);
+        }
+
+        private void ReportError(string errorId, string message, params object[] args)
+        {
+            if (_Context == null)
+                return;
+
+            ReportError(new Pipeline.ParseException(
+                message: string.Format(Thread.CurrentThread.CurrentCulture, message, args),
+                errorId: errorId
+            ));
+        }
+
+        private void ReportError(Pipeline.ParseException exception)
+        {
+            if (_Context == null)
+                return;
+
+            _Context.WriteError(new ErrorRecord(
+                exception: exception,
+                errorId: exception.ErrorId,
+                errorCategory: ErrorCategory.InvalidOperation,
+                targetObject: null
+            ));
+        }
+    }
+}

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources
-{
+namespace PSRule.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,776 +19,646 @@ namespace PSRule.Resources
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class PSRuleResources
-    {
-
+    internal class PSRuleResources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal PSRuleResources()
-        {
+        internal PSRuleResources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.PSRuleResources", typeof(PSRuleResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The {0} resource &apos;{1}&apos; is currently referencing &apos;{2}&apos; using the alias &apos;{3}&apos;. Consider updating the reference to use name or id directly..
         /// </summary>
-        internal static string AliasReference
-        {
-            get
-            {
+        internal static string AliasReference {
+            get {
                 return ResourceManager.GetString("AliasReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Suppression for the rule &apos;{0}&apos; was configured using the alias &apos;{1}&apos;. Consider updating the suppression to use the name or id directly..
         /// </summary>
-        internal static string AliasSuppression
-        {
-            get
-            {
+        internal static string AliasSuppression {
+            get {
                 return ResourceManager.GetString("AliasSuppression", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Binding functions are not supported in this language mode..
         /// </summary>
-        internal static string ConstrainedTargetBinding
-        {
-            get
-            {
+        internal static string ConstrainedTargetBinding {
+            get {
                 return ResourceManager.GetString("ConstrainedTargetBinding", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}: The property &apos;${1}.{2}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string DebugPropertyObsolete
-        {
-            get
-            {
+        internal static string DebugPropertyObsolete {
+            get {
                 return ResourceManager.GetString("DebugPropertyObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target failed If precondition.
         /// </summary>
-        internal static string DebugTargetIfMismatch
-        {
-            get
-            {
+        internal static string DebugTargetIfMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetIfMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to Target failed Type precondition.
+        ///   Looks up a localized string similar to Target failed Rule precondition.
         /// </summary>
-        internal static string DebugTargetTypeMismatch
-        {
-            get
-            {
-                return ResourceManager.GetString("DebugTargetTypeMismatch", resourceCulture);
-            }
-        }
-
-        internal static string DebugTargetRuleMismatch
-        {
-            get
-            {
+        internal static string DebugTargetRuleMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetRuleMismatch", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target failed Type precondition.
+        /// </summary>
+        internal static string DebugTargetTypeMismatch {
+            get {
+                return ResourceManager.GetString("DebugTargetTypeMismatch", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to A circular rule dependency was detected. The rule &apos;{0}&apos; depends on &apos;{1}&apos; which also depend on &apos;{0}&apos;..
         /// </summary>
-        internal static string DependencyCircularReference
-        {
-            get
-            {
+        internal static string DependencyCircularReference {
+            get {
                 return ResourceManager.GetString("DependencyCircularReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The dependency &apos;{0}&apos; for &apos;{1}&apos; could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path..
         /// </summary>
-        internal static string DependencyNotFound
-        {
-            get
-            {
+        internal static string DependencyNotFound {
+            get {
                 return ResourceManager.GetString("DependencyNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A rule with the same id &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleId
-        {
-            get
-            {
+        internal static string DuplicateRuleId {
+            get {
                 return ResourceManager.GetString("DuplicateRuleId", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        /// Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
+        ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleName
-        {
-            get
-            {
+        internal static string DuplicateRuleName {
+            get {
                 return ResourceManager.GetString("DuplicateRuleName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} : Reported &apos;{1}&apos;. At {2}:{3} char:{4}.
         /// </summary>
-        internal static string ErrorDetailMessage
-        {
-            get
-            {
+        internal static string ErrorDetailMessage {
+            get {
                 return ResourceManager.GetString("ErrorDetailMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more errors occured..
         /// </summary>
-        internal static string ErrorPipelineException
-        {
-            get
-            {
+        internal static string ErrorPipelineException {
+            get {
                 return ResourceManager.GetString("ErrorPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exists: {0}.
         /// </summary>
-        internal static string ExistsTrue
-        {
-            get
-            {
+        internal static string ExistsTrue {
+            get {
                 return ResourceManager.GetString("ExistsTrue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to File.
         /// </summary>
-        internal static string FileSourceType
-        {
-            get
-            {
+        internal static string FileSourceType {
+            get {
                 return ResourceManager.GetString("FileSourceType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
         /// </summary>
-        internal static string FoundModules
-        {
-            get
-            {
+        internal static string FoundModules {
+            get {
                 return ResourceManager.GetString("FoundModules", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported..
         /// </summary>
-        internal static string InvalidErrorAction
-        {
-            get
-            {
+        internal static string InvalidErrorAction {
+            get {
                 return ResourceManager.GetString("InvalidErrorAction", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The resource name &apos;{0}&apos; is not valid at {1}. Each resource name must be between 3-128 characters in length, must start and end with a letter or number, and only contain letters, numbers, hyphens, dots, or underscores. See https://aka.ms/ps-rule/naming for more information..
+        /// </summary>
+        internal static string InvalidResourceName {
+            get {
+                return ResourceManager.GetString("InvalidResourceName", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule nesting was detected for rule at {0}. Rules must not be nested..
         /// </summary>
-        internal static string InvalidRuleNesting
-        {
-            get
-            {
+        internal static string InvalidRuleNesting {
+            get {
                 return ResourceManager.GetString("InvalidRuleNesting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An invalid rule result was returned for {0}. Conditions must return boolean $True or $False..
         /// </summary>
-        internal static string InvalidRuleResult
-        {
-            get
-            {
+        internal static string InvalidRuleResult {
+            get {
                 return ResourceManager.GetString("InvalidRuleResult", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string KeywordConditionScope
-        {
-            get
-            {
+        internal static string KeywordConditionScope {
+            get {
                 return ResourceManager.GetString("KeywordConditionScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block or script precondition..
         /// </summary>
-        internal static string KeywordRuleScope
-        {
-            get
-            {
+        internal static string KeywordRuleScope {
+            get {
                 return ResourceManager.GetString("KeywordRuleScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can not be nested in a Rule block..
         /// </summary>
-        internal static string KeywordSourceScope
-        {
-            get
-            {
+        internal static string KeywordSourceScope {
+            get {
                 return ResourceManager.GetString("KeywordSourceScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1} {0} {2}.
         /// </summary>
-        internal static string LanguageExpressionTrace
-        {
-            get
-            {
+        internal static string LanguageExpressionTrace {
+            get {
                 return ResourceManager.GetString("LanguageExpressionTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please open your browser to the following location: {0}.
         /// </summary>
-        internal static string LaunchBrowser
-        {
-            get
-            {
+        internal static string LaunchBrowser {
+            get {
                 return ResourceManager.GetString("LaunchBrowser", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Wildcard match requires exactly one name..
         /// </summary>
-        internal static string MatchSingleName
-        {
-            get
-            {
+        internal static string MatchSingleName {
+            get {
                 return ResourceManager.GetString("MatchSingleName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Matches: {0}.
         /// </summary>
-        internal static string MatchTrue
-        {
-            get
-            {
+        internal static string MatchTrue {
+            get {
                 return ResourceManager.GetString("MatchTrue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Update module &apos;{0}&apos; to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config..
         /// </summary>
-        internal static string ModuleManifestBaseline
-        {
-            get
-            {
+        internal static string ModuleManifestBaseline {
+            get {
                 return ResourceManager.GetString("ModuleManifestBaseline", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target object &apos;{0}&apos; has not been processed because no matching rules were found..
         /// </summary>
-        internal static string ObjectNotProcessed
-        {
-            get
-            {
+        internal static string ObjectNotProcessed {
+            get {
                 return ResourceManager.GetString("ObjectNotProcessed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Options file does not exist..
         /// </summary>
-        internal static string OptionsNotFound
-        {
-            get
-            {
+        internal static string OptionsNotFound {
+            get {
                 return ResourceManager.GetString("OptionsNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to # Source: {0}.
         /// </summary>
-        internal static string OptionsSourceComment
-        {
-            get
-            {
+        internal static string OptionsSourceComment {
+            get {
                 return ResourceManager.GetString("OptionsSourceComment", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
-        internal static string OutcomeError
-        {
-            get
-            {
+        internal static string OutcomeError {
+            get {
                 return ResourceManager.GetString("OutcomeError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Fail.
         /// </summary>
-        internal static string OutcomeFail
-        {
-            get
-            {
+        internal static string OutcomeFail {
+            get {
                 return ResourceManager.GetString("OutcomeFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Pass.
         /// </summary>
-        internal static string OutcomePass
-        {
-            get
-            {
+        internal static string OutcomePass {
+            get {
                 return ResourceManager.GetString("OutcomePass", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRuleFail
-        {
-            get
-            {
+        internal static string OutcomeRuleFail {
+            get {
                 return ResourceManager.GetString("OutcomeRuleFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PASS] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRulePass
-        {
-            get
-            {
+        internal static string OutcomeRulePass {
+            get {
                 return ResourceManager.GetString("OutcomeRulePass", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
-        internal static string OutcomeUnknown
-        {
-            get
-            {
+        internal static string OutcomeUnknown {
+            get {
                 return ResourceManager.GetString("OutcomeUnknown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The property &apos;${0}.{1}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string PropertyObsolete
-        {
-            get
-            {
+        internal static string PropertyObsolete {
+            get {
                 return ResourceManager.GetString("PropertyObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize the file &apos;{0}&apos;: {1}.
         /// </summary>
-        internal static string ReadFileFailed
-        {
-            get
-            {
+        internal static string ReadFileFailed {
+            get {
                 return ResourceManager.GetString("ReadFileFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
-        internal static string ReadJsonFailed
-        {
-            get
-            {
+        internal static string ReadJsonFailed {
+            get {
                 return ResourceManager.GetString("ReadJsonFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The module version &apos;{1}&apos; for &apos;{0}&apos; does not match the required version &apos;{2}&apos;. To continue, first update the module to match the version requirement..
         /// </summary>
-        internal static string RequiredVersionMismatch
-        {
-            get
-            {
+        internal static string RequiredVersionMismatch {
+            get {
                 return ResourceManager.GetString("RequiredVersionMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The {0} &apos;{1}&apos; is obsolete. Consider switching to an alternative {0}..
         /// </summary>
-        internal static string ResourceObsolete
-        {
-            get
-            {
+        internal static string ResourceObsolete {
+            get {
                 return ResourceManager.GetString("ResourceObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleCountSuppressed
-        {
-            get
-            {
+        internal static string RuleCountSuppressed {
+            get {
                 return ResourceManager.GetString("RuleCountSuppressed", resourceCulture);
             }
         }
-
-        /// <summary>
-        /// Looks up localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;.
-        /// </summary>
-        /// <value></value>
-        internal static string RuleSuppressionGroup
-        {
-            get
-            {
-                return ResourceManager.GetString("RuleSuppressionGroup", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        /// Looks up localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;.
-        /// </summary>
-        /// <value></value>
-        internal static string RuleSuppressionGroupCount
-        {
-            get
-            {
-                return ResourceManager.GetString("RuleSuppressionGroupCount", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported errors..
         /// </summary>
-        internal static string RuleErrorPipelineException
-        {
-            get
-            {
+        internal static string RuleErrorPipelineException {
+            get {
                 return ResourceManager.GetString("RuleErrorPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported failure..
         /// </summary>
-        internal static string RuleFailPipelineException
-        {
-            get
-            {
+        internal static string RuleFailPipelineException {
+            get {
                 return ResourceManager.GetString("RuleFailPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
         /// </summary>
-        internal static string RuleInconclusive
-        {
-            get
-            {
+        internal static string RuleInconclusive {
+            get {
                 return ResourceManager.GetString("RuleInconclusive", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find a matching rule. Please check that Path, Name and Tag parameters are correct..
         /// </summary>
-        internal static string RuleNotFound
-        {
-            get
-            {
+        internal static string RuleNotFound {
+            get {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find required rule definition parameter &apos;{0}&apos; on rule at {1}..
         /// </summary>
-        internal static string RuleParameterNotFound
-        {
-            get
-            {
+        internal static string RuleParameterNotFound {
+            get {
                 return ResourceManager.GetString("RuleParameterNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No matching .Rule.ps1 files were found. Rule definitions should be saved into script files with the .Rule.ps1 extension..
         /// </summary>
-        internal static string RulePathNotFound
-        {
-            get
-            {
+        internal static string RulePathNotFound {
+            get {
                 return ResourceManager.GetString("RulePathNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to at Rule &apos;{0}&apos;, {1}: line {2}.
         /// </summary>
-        internal static string RuleStackTrace
-        {
-            get
-            {
+        internal static string RuleStackTrace {
+            get {
                 return ResourceManager.GetString("RuleStackTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleSuppressed
-        {
-            get
-            {
+        internal static string RuleSuppressed {
+            get {
                 return ResourceManager.GetString("RuleSuppressed", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;..
+        /// </summary>
+        internal static string RuleSuppressionGroup {
+            get {
+                return ResourceManager.GetString("RuleSuppressionGroup", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;..
+        /// </summary>
+        internal static string RuleSuppressionGroupCount {
+            get {
+                return ResourceManager.GetString("RuleSuppressionGroupCount", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
         /// </summary>
-        internal static string ScanModule
-        {
-            get
-            {
+        internal static string ScanModule {
+            get {
                 return ResourceManager.GetString("ScanModule", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files: {0}.
         /// </summary>
-        internal static string ScanSource
-        {
-            get
-            {
+        internal static string ScanSource {
+            get {
                 return ResourceManager.GetString("ScanSource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The script was not found..
         /// </summary>
-        internal static string ScriptNotFound
-        {
-            get
-            {
+        internal static string ScriptNotFound {
+            get {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}.
         /// </summary>
-        internal static string SelectorMatchTrace
-        {
-            get
-            {
+        internal static string SelectorMatchTrace {
+            get {
                 return ResourceManager.GetString("SelectorMatchTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1}.
         /// </summary>
-        internal static string SelectorTrace
-        {
-            get
-            {
+        internal static string SelectorTrace {
+            get {
                 return ResourceManager.GetString("SelectorTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Can not serialize a null PSObject..
         /// </summary>
-        internal static string SerializeNullPSObject
-        {
-            get
-            {
+        internal static string SerializeNullPSObject {
+            get {
                 return ResourceManager.GetString("SerializeNullPSObject", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Create path.
         /// </summary>
-        internal static string ShouldCreatePath
-        {
-            get
-            {
+        internal static string ShouldCreatePath {
+            get {
                 return ResourceManager.GetString("ShouldCreatePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Write file.
         /// </summary>
-        internal static string ShouldWriteFile
-        {
-            get
-            {
+        internal static string ShouldWriteFile {
+            get {
                 return ResourceManager.GetString("ShouldWriteFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The source was not found..
         /// </summary>
-        internal static string SourceNotFound
-        {
-            get
-            {
+        internal static string SourceNotFound {
+            get {
                 return ResourceManager.GetString("SourceNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Using invariant culture may cause rule infomation to be displayed incorrectly. Consider using -Culture or set the Output.Culture option..
         /// </summary>
-        internal static string UsingInvariantCulture
-        {
-            get
-            {
+        internal static string UsingInvariantCulture {
+            get {
                 return ResourceManager.GetString("UsingInvariantCulture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The variable &apos;${0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string VariableConditionScope
-        {
-            get
-            {
+        internal static string VariableConditionScope {
+            get {
                 return ResourceManager.GetString("VariableConditionScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The version constraint &apos;{0}&apos; is not valid..
         /// </summary>
-        internal static string VersionConstraintInvalid
-        {
-            get
-            {
+        internal static string VersionConstraintInvalid {
+            get {
                 return ResourceManager.GetString("VersionConstraintInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The Within parameter Value must be a string when the Like parameter is used..
         /// </summary>
-        internal static string WithinLikeNotString
-        {
-            get
-            {
+        internal static string WithinLikeNotString {
+            get {
                 return ResourceManager.GetString("WithinLikeNotString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Within: {0}.
         /// </summary>
-        internal static string WithinTrue
-        {
-            get
-            {
+        internal static string WithinTrue {
+            get {
                 return ResourceManager.GetString("WithinTrue", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -327,4 +327,7 @@
   <data name="AliasSuppression" xml:space="preserve">
     <value>Suppression for the rule '{0}' was configured using the alias '{1}'. Consider updating the suppression to use the name or id directly.</value>
   </data>
+  <data name="InvalidResourceName" xml:space="preserve">
+    <value>The resource name '{0}' is not valid at {1}. Each resource name must be between 3-128 characters in length, must start and end with a letter or number, and only contain letters, numbers, hyphens, dots, or underscores. See https://aka.ms/ps-rule/naming for more information.</value>
+  </data>
 </root>

--- a/tests/PSRule.Tests/FromFileName.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFileName.Rule.jsonc
@@ -1,0 +1,16 @@
+[
+    {
+        // Synopsis: An example rule for unit testing.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRule_"
+        },
+        "spec": {
+            "condition": {
+                "field": "Name",
+                "exists": true
+            }
+        }
+    }
+]

--- a/tests/PSRule.Tests/FromFileName.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileName.Rule.ps1
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Rules for unit testing of rule names
+#
+
+Rule 'Rule "1"' {
+    $True
+}

--- a/tests/PSRule.Tests/FromFileName.Rule.yaml
+++ b/tests/PSRule.Tests/FromFileName.Rule.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# Rules for unit testing of rule names
+#
+
+---
+# Synopsis: An example rule for unit testing.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: 'Yaml+Rule'
+spec:
+  condition:
+    field: 'Name'
+    exists: true

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -2611,11 +2611,10 @@ Describe 'Rules' -Tag 'Common', 'Rules' {
 
         It 'Error on missing parameter' {
             $filteredResult = @($messages | Where-Object { $_.Exception.ErrorId -eq 'PSRule.Parse.RuleParameterNotFound' });
-            $filteredResult.Length | Should -Be 3;
+            $filteredResult.Length | Should -Be 2;
             $filteredResult.Exception | Should -BeOfType PSRule.Pipeline.ParseException;
             $filteredResult[0].Exception.Message | Should -BeLike 'Could not find required rule definition parameter ''Name'' on rule at * line *';
-            $filteredResult[1].Exception.Message | Should -BeLike 'Could not find required rule definition parameter ''Name'' on rule at * line *';
-            $filteredResult[2].Exception.Message | Should -BeLike 'Could not find required rule definition parameter ''Body'' on rule at * line *';
+            $filteredResult[1].Exception.Message | Should -BeLike 'Could not find required rule definition parameter ''Body'' on rule at * line *';
         }
 
         It 'Error on invalid ErrorAction' {
@@ -2623,6 +2622,13 @@ Describe 'Rules' -Tag 'Common', 'Rules' {
             $filteredResult.Length | Should -Be 1;
             $filteredResult.Exception | Should -BeOfType PSRule.Pipeline.ParseException;
             $filteredResult[0].Exception.Message | Should -BeLike 'An invalid ErrorAction (*) was specified for rule at *';
+        }
+
+        It 'Error on invalid name' {
+            $filteredResult = @($messages | Where-Object { $_.Exception.ErrorId -eq 'PSRule.Parse.InvalidResourceName' });
+            $filteredResult.Length | Should -Be 1;
+            $filteredResult.Exception | Should -BeOfType PSRule.Pipeline.ParseException;
+            $filteredResult[0].Exception.Message | Should -BeLike "The resource name '' is not valid at * line 16. Each resource name must be between 3-128 characters in length, must start and end with a letter or number, and only contain letters, numbers, hyphens, dots, or underscores. See https://aka.ms/ps-rule/naming for more information.";
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -58,6 +58,15 @@
     <None Update="FromFileConventions.Rule.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="FromFileName.Rule.jsonc">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="FromFileName.Rule.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="FromFileName.Rule.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ModuleConfig.Rule.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Tests/ResourceValidatorTests.cs
+++ b/tests/PSRule.Tests/ResourceValidatorTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using PSRule.Configuration;
+using PSRule.Host;
+using PSRule.Pipeline;
+using PSRule.Runtime;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace PSRule
+{
+    public sealed class ResourceValidatorTests
+    {
+        [Fact]
+        public void ResourceName()
+        {
+            var writer = new TestWriter(GetOption());
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, new OptionContext(), null), writer);
+
+            // Get good rules
+            var rule = HostHelper.GetRule(GetSource(), context, includeDependencies: false);
+            Assert.NotNull(rule);
+            Assert.Empty(writer.Errors);
+
+            // Get invalid rule names YAML
+            rule = HostHelper.GetRule(GetSource("FromFileName.Rule.yaml"), context, includeDependencies: false);
+            Assert.NotNull(rule);
+            Assert.NotEmpty(writer.Errors);
+            Assert.Equal("PSRule.Parse.InvalidResourceName", writer.Errors[0].FullyQualifiedErrorId);
+
+            // Get invalid rule names JSON
+            writer.Errors.Clear();
+            rule = HostHelper.GetRule(GetSource("FromFileName.Rule.jsonc"), context, includeDependencies: false);
+            Assert.NotNull(rule);
+            Assert.NotEmpty(writer.Errors);
+            Assert.Equal("PSRule.Parse.InvalidResourceName", writer.Errors[0].FullyQualifiedErrorId);
+        }
+
+        #region Helper methods
+
+        private static Source[] GetSource(string path = "FromFile.Rule.yaml")
+        {
+            var builder = new SourcePipelineBuilder(null, null);
+            builder.Directory(GetSourcePath(path));
+            return builder.Build();
+        }
+
+        private static PSRuleOption GetOption()
+        {
+            return new PSRuleOption();
+        }
+
+        private static string GetSourcePath(string fileName)
+        {
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Tests/RuleLanguageAstTests.cs
+++ b/tests/PSRule.Tests/RuleLanguageAstTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using PSRule.Host;
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class RuleLanguageAstTests
+    {
+        [Fact]
+        public void RuleName()
+        {
+            var scriptAst = System.Management.Automation.Language.Parser.ParseFile(GetSourcePath("FromFileName.Rule.ps1"), out _, out _);
+            var visitor = new RuleLanguageAst(null);
+            scriptAst.Visit(visitor);
+
+            Assert.Equal("PSRule.Parse.InvalidResourceName", visitor.Errors[0].FullyQualifiedErrorId);
+        }
+
+        #region Helper methods
+
+        private static string GetSourcePath(string fileName)
+        {
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Tests/TestWriter.cs
+++ b/tests/PSRule.Tests/TestWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using System.Management.Automation;
 using PSRule.Configuration;
 using PSRule.Pipeline;
 
@@ -9,15 +10,26 @@ namespace PSRule
 {
     internal sealed class TestWriter : PipelineWriter
     {
+        internal List<ErrorRecord> Errors = new List<ErrorRecord>();
         internal List<string> Warnings = new List<string>();
         internal List<object> Output = new List<object>();
 
         public TestWriter(PSRuleOption option)
             : base(null, option) { }
 
+        public override void WriteError(ErrorRecord errorRecord)
+        {
+            Errors.Add(errorRecord);
+        }
+
         public override void WriteWarning(string message)
         {
             Warnings.Add(message);
+        }
+
+        public override bool ShouldWriteError()
+        {
+            return true;
         }
 
         public override bool ShouldWriteWarning()


### PR DESCRIPTION
## PR Summary

- **Breaking change:** Added validation of resource names.
  - Resource names must now match `^[a-zA-Z0-9][a-zA-Z0-9._-]{1,126}[a-zA-Z0-9]$` to be valid.
  - Invalid rules names will now produce a specific error.
- Fixed unclear error message on invalid rule names.
  
Fixes #1012

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
