### PR TITLE
Fix JSON parsing and null ref #1051 #1054 #1052

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -12,6 +12,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v2.0.0:
+
+- Bug fixes:
+  - Fixed read JSON failed with comments. [#1051](https://github.com/microsoft/PSRule/issues/1051)
+  - Fixed null reference on elapsed time when required module check fails. [#1054](https://github.com/microsoft/PSRule/issues/1054)
+  - Fixed failed to read JSON objects with a empty property name. [#1052](https://github.com/microsoft/PSRule/issues/1052)
+
 ## v2.0.0
 
 What's changed since v1.11.1:

--- a/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
@@ -473,7 +473,7 @@ namespace PSRule.Pipeline.Formatters
 
         private void FooterRunInfo()
         {
-            if (!Option.Output.Footer.GetValueOrDefault(FooterFormat.Default).HasFlag(FooterFormat.RunInfo))
+            if (PipelineContext.CurrentThread == null || !Option.Output.Footer.GetValueOrDefault(FooterFormat.Default).HasFlag(FooterFormat.RunInfo))
                 return;
 
             var elapsed = PipelineContext.CurrentThread.RunTime.Elapsed;

--- a/tests/PSRule.Tests/ObjectFromFile.json
+++ b/tests/PSRule.Tests/ObjectFromFile.json
@@ -1,7 +1,13 @@
+// Some comments
 [
+    // Some comments
     {
+        // Some comments
         "TargetName": "TestObject1",
-        "Spec": {
+        "Spec": { // Some comments
+            "": {
+                "Key": "value"
+            },
             "Properties": {
                 "Value1": 1,
                 "Kind": "Test",
@@ -29,7 +35,7 @@
                     ]
                 ]
             }
-        },
+        }, // Some comments
         "_PSRule": {
             "source": [
                 {

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -851,7 +851,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result[0].Source[0].File | Should -Be 'some-file.json';
             $result[0].Source[0].Line | Should -Be 1;
             $result[1].Source[0].File.Split([char[]]@('\', '/'))[-1] | Should -Be 'ObjectFromFile.json';
-            $result[1].Source[0].Line | Should -Be 51;
+            $result[1].Source[0].Line | Should -Be 57;
 
             # Multiple file
             $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputPath $inputFiles);

--- a/tests/PSRule.Tests/PathExpressionTests.cs
+++ b/tests/PSRule.Tests/PathExpressionTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using PSRule.Runtime.ObjectPath;
 using Xunit;
 
@@ -213,8 +214,14 @@ namespace PSRule
 
         private object GetJsonContent()
         {
+            var settings = new JsonLoadSettings
+            {
+                CommentHandling = CommentHandling.Ignore
+            };
             var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ObjectFromFile.json");
-            return JsonConvert.DeserializeObject<object>(File.ReadAllText(path));
+            using var stream = new StreamReader(path);
+            using var reader = new JsonTextReader(stream);
+            return JToken.Load(reader, settings);
         }
 
         #endregion Helper methods


### PR DESCRIPTION
## PR Summary

- Fixed read JSON failed with comments. #1051
- Fixed null reference on elapsed time when required module check fails. #1054
- Fixed failed to read JSON objects with a empty property name. #1052

Fixes #1051 
Fixes #1054 
Fixes #1052 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
