### PR TITLE
Added custom suppression message #1046

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -3,7 +3,7 @@
 #
 
 # NOTES:
-# This worflow uses PSRule, CodeQL, and DevSkim.
+# This workflow uses PSRule, CodeQL, and DevSkim.
 # You can read more about these linting tools and configuration options here:
 #   PSRule - https://aka.ms/ps-rule and https://github.com/Microsoft/PSRule.Rules.MSFT.OSS
 #   CodeQL - https://codeql.github.com/docs/codeql-overview/about-codeql/
@@ -36,7 +36,6 @@ jobs:
       with:
         modules: PSRule.Rules.MSFT.OSS
         prerelease: true
-        version: 2.0.0-B2202024
         outputFormat: Sarif
         outputPath: reports/ps-rule-results.sarif
 

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -15,6 +15,14 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v2.1.0-B0015:
 
+- General improvements:
+  - Added custom suppression message during PSRule runs. [#1046](https://github.com/microsoft/PSRule/issues/1046)
+    - When a rule is suppressed using a suppression group the synopsis is shown in the suppression warning.
+    - Configure the suppression group synopsis to display a custom message.
+    - Suppression groups synopsis can be localized using markdown documentation.
+    - Use markdown to set a culture specific synopsis.
+    - Custom suppression messages are not supported when suppressing individual rules using `ps-rule.yaml`.
+    - See [about_PSRule_SuppressionGroups] for details.
 - Bug fixes:
   - **Important change:** Fixed source scope not updated in multi-module runs. [#1053](https://github.com/microsoft/PSRule/issues/1053)
     - Several properties of rule and language block elements have been renamed to improve consistency.

--- a/docs/concepts/PSRule/en-US/about_PSRule_Docs.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Docs.md
@@ -8,8 +8,11 @@ Describes usage of documentation within PSRule.
 
 ## LONG DESCRIPTION
 
-PSRule includes a built-in documentation system that provide culture specific help and metadata for rules.
-Rule documentation is composed of markdown files that can be optionally shipped with a module.
+PSRule includes a built-in documentation system that provide culture specific help and metadata for resources.
+Documentation is composed of markdown files that can be optionally shipped with a module.
+
+When markdown documentation is defined, this content will be used instead of inline synopsis comments.
+Markdown documentation is supported for rules and suppression groups.
 
 ### Getting documentation
 
@@ -43,7 +46,7 @@ For example:
 Get-PSRuleHelp <rule-name> -Online
 ```
 
-### Creating documentation
+### Creating documentation for rules
 
 Rule documentation is composed of markdown files, one per rule.
 When creating rules for more then one culture, a separate markdown file is created per rule per culture.
@@ -63,14 +66,6 @@ Rule 'storageAccounts.UseHttps' -If { ResourceType 'Microsoft.Storage/storageAcc
     $TargetObject.Properties.supportsHttpsTrafficOnly
 }
 ```
-
-This directory PSRule will look for these markdown files depends on how the rules are packaged:
-
-- If the rules are loose (not part of a module), PSRule will search for documentation in the `.\<culture>\` subdirectory relative to where the rule script _.ps1_ file is located.
-- When the rules are shipped as part of a module, PSRule will search for documentation in the `.\<culture>\` subdirectory relative to where the module manifest _.psd1_ file is located.
-
-The `<culture>` subdirectory will be the current culture that PowerShell is executed under (the same as `(Get-Culture).Name`).
-Alternatively, the culture can set by using the `-Culture` parameter of PSRule cmdlets.
 
 The markdown of each file uses following structure.
 
@@ -107,6 +102,40 @@ Optionally, one or more annotations formatted as YAML key value pairs can be inc
 i.e. `severity: Critical`
 
 Additional sections such as `EXAMPLES` can be included although are not exposed with `Get-PSRuleHelp`.
+
+### Creating documentation for suppression groups
+
+Suppression groups support documentation similar to rules that allows a synopsis to be defined.
+Other sections can be added to the markdown content, but are ignored.
+Set the synopsis in markdown to allow a culture specific message to be displayed.
+
+The markdown of each file uses following structure.
+
+```text
+---
+{{ Annotations }}
+---
+
+# {{ Name of suppression group }}
+
+## SYNOPSIS
+
+{{ A brief summary of the suppression group }}
+
+```
+
+### Storing markdown files
+
+The location PSRule uses to find markdown documentation depends on how the rules/ resources are packaged.
+In each case, documentation will be in a culture `/<culture>/`specific subdirectory.
+Resources can be either shipped as part of a module, or standalone.
+
+- When resources are standalone, the culture subdirectory is relative to the `*.Rule.*` file.
+- When packaged in a module, the culture subdirectory is relative to the module manifest `.psd1` file.
+
+The `<culture>` subdirectory will be the current culture that PowerShell is executed under.
+To determine the current culture use `(Get-Culture).Name`.
+Alternatively, the culture can set by using the `-Culture` parameter of PSRule cmdlets.
 
 ## NOTE
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md
@@ -9,13 +9,15 @@ Describes PSRule Suppression Groups including how to use and author them.
 ## LONG DESCRIPTION
 
 PSRule executes rules to validate an object from input.
-When an evaluating an object from input, PSRule can use suppression groups to suppress rules based on a [Selector](about_PSRule_Selectors.md).
+When an evaluating each object, PSRule can use suppression groups to suppress rules based on a condition.
+Suppression groups use a [Selector](about_PSRule_Selectors.md) to determine if the rule is suppressed.
 
-## Defining suppression groups
+### Defining suppression groups
 
-Suppression groups can be defined with either YAML or JSON format, and can be included with a module or a standalone `.Rule.yaml` or `.Rule.jsonc` file.
-In either case, define a suppression group within a file ending with the `.Rule.yaml` or `.Rule.jsonc` extension.
-A suppression group can be defined side-by-side with other resources such as rules, baselines or module configurations.
+Suppression groups can be defined using either YAML or JSON format.
+A suppression group can be in a standalone file or included in a module.
+Define suppression groups in `.Rule.yaml` or `.Rule.jsonc` files.
+Each suppression group may be defined individually or side-by-side with resources such as rules or baselines.
 
 Suppression groups can also be defined within `.json` files.
 We recommend using `.jsonc` to view [JSON with Comments](https://code.visualstudio.com/docs/languages/json#_json-with-comments) in Visual Studio Code.
@@ -51,10 +53,27 @@ spec:
 ]
 ```
 
+Set the `synopsis` to describe the justification for the suppression.
 Within the `rule` array, one or more rule names can be used.
 If no rules are specified, suppression will occur for all rules.
 Within the `if` object, one or more conditions or logical operators can be used.
 When the `if` condition is `true` the object will be suppressed for the current rule.
+
+### Documentation
+
+Suppression groups can be configured with a synopsis.
+When set, the synopsis will be included in output for any suppression warnings that are shown.
+The synopsis helps provide justification for the suppression, in a short single line message.
+To set the synopsis, include a comment above the suppression group `apiVersion` property.
+
+Alternatively, a localized synopsis can be provided in a separate markdown file.
+See [about_PSRule_Docs](about_PSRule_Docs.md) for details.
+
+Some examples of a suppression group synopsis include:
+
+- _Ignore test objects by name._
+- _Ignore test objects by type._
+- _Ignore objects with non-production tag._
 
 ## EXAMPLES
 
@@ -64,7 +83,7 @@ When the `if` condition is `true` the object will be suppressed for the current 
 # Example SuppressionGroups.Rule.yaml
 
 ---
-# Synopsis: Suppress with target name
+# Synopsis: Ignore test objects by name.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:
@@ -80,7 +99,7 @@ spec:
     - 'TestObject2'
 
 ---
-# Synopsis: Suppress with target type
+# Synopsis: Ignore test objects by type.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:
@@ -100,7 +119,7 @@ spec:
 // Example SuppressionGroups.Rule.jsonc
 [
   {
-    // Synopsis: Suppress with target name
+    // Synopsis: Ignore test objects by name.
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "SuppressionGroup",
     "metadata": {
@@ -121,7 +140,7 @@ spec:
     }
   },
   {
-    // Synopsis: Suppress with target type
+    // Synopsis: Ignore test objects by type.
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "SuppressionGroup",
     "metadata": {

--- a/docs/creating-your-pipeline.md
+++ b/docs/creating-your-pipeline.md
@@ -57,35 +57,64 @@ Configuration options for PSRule are set within the `ps-rule.yaml` file.
 
 To prevent a rule executing you can either:
 
-- **Exclude** &mdash; The rule is not executed for any resource.
-- **Suppress** &mdash; The rule is not executed for a specific resource by name.
+- **Exclude rules by name** &mdash; The rule is not executed for any object.
+- **Suppress rules by name** &mdash; The rule is not executed for a specific object by name.
+- **Suppress rules by condition** &mdash; The rule is not executed for matching objects.
 
-To exclude a rule, set `Rule.Exclude` option within the `ps-rule.yaml` file.
+=== "Exclude by name"
 
-[:octicons-book-24: Docs][3]
+    To exclude a rule, set `Rule.Exclude` option within the `ps-rule.yaml` file.
 
-```yaml
-rule:
-  exclude:
-  # Ignore the following rules for all resources
-  - Azure.VM.UseHybridUseBenefit
-  - Azure.VM.Standalone
-```
+    [:octicons-book-24: Docs][3]
 
-To suppress a rule, set `Suppression` option within the `ps-rule.yaml` file.
+    ```yaml
+    rule:
+      exclude:
+      # Ignore the following rules for all objects
+      - Azure.VM.UseHybridUseBenefit
+      - Azure.VM.Standalone
+    ```
 
-[:octicons-book-24: Docs][4]
+=== "Suppression by name"
 
-```yaml
-suppression:
-  Azure.AKS.AuthorizedIPs:
-  # Exclude the following externally managed AKS clusters
-  - aks-cluster-prod-eus-001
-  Azure.Storage.SoftDelete:
-  # Exclude the following non-production storage accounts
-  - storagedeveus6jo36t
-  - storagedeveus1df278
-```
+    To suppress an individual rule, set `Suppression` option within the `ps-rule.yaml` file.
+
+    [:octicons-book-24: Docs][4]
+
+    ```yaml
+    suppression:
+      Azure.AKS.AuthorizedIPs:
+      # Exclude the following externally managed AKS clusters
+      - aks-cluster-prod-eus-001
+      Azure.Storage.SoftDelete:
+      # Exclude the following non-production storage accounts
+      - storagedeveus6jo36t
+      - storagedeveus1df278
+    ```
+
+=== "Suppression by condition"
+
+    To suppress an rules by condition, create a suppression group.
+
+    [:octicons-book-24: Docs][5]
+
+    ```yaml
+    ---
+    # Synopsis: Ignore test objects by name.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: SuppressionGroup
+    metadata:
+      name: SuppressWithTargetName
+    spec:
+      rule:
+      - 'FromFile1'
+      - 'FromFile2'
+      if:
+        name: '.'
+        in:
+        - 'TestObject1'
+        - 'TestObject2'
+    ```
 
 !!! tip
     Use comments within `ps-rule.yaml` to describe the reason why rules are excluded or suppressed.
@@ -94,3 +123,4 @@ suppression:
 
   [3]: concepts/PSRule/en-US/about_PSRule_Options.md#ruleexclude
   [4]: concepts/PSRule/en-US/about_PSRule_Options.md#suppression
+  [5]: concepts/PSRule/en-US/about_PSRule_SuppressionGroups.md

--- a/src/PSRule/Commands/ExportConventionCommand.cs
+++ b/src/PSRule/Commands/ExportConventionCommand.cs
@@ -76,9 +76,10 @@ namespace PSRule.Commands
 
             context.VerboseFoundResource(name: Name, moduleName: source.Module, scriptName: MyInvocation.ScriptName);
 
-            var helpInfo = new ResourceHelpInfo(
-                synopsis: commentMetadata.Synopsis
-            );
+            var helpInfo = new ResourceHelpInfo(Name)
+            {
+                Synopsis = new InfoString(commentMetadata.Synopsis, null)
+            };
 
 #pragma warning disable CA2000 // Dispose objects before losing scope, needs to be passed to pipeline
             var block = new ScriptBlockConvention(

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -117,7 +117,7 @@ namespace PSRule.Commands
 
             CheckDependsOn();
             var ps = GetCondition(context, id, source, errorPreference);
-            var info = PSRule.Host.HostHelper.GetHelpInfo(context, Name, metadata.Synopsis) ?? new RuleHelpInfo(
+            var info = PSRule.Host.HostHelper.GetRuleHelpInfo(context, Name, metadata.Synopsis) ?? new RuleHelpInfo(
                 name: Name,
                 displayName: Name,
                 moduleName: source.Module

--- a/src/PSRule/Common/ResourceHelpInfoExtensions.cs
+++ b/src/PSRule/Common/ResourceHelpInfoExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Definitions;
+
+namespace PSRule
+{
+    internal static class ResourceHelpInfoExtensions
+    {
+        public static void Update(this IResourceHelpInfo info, IResourceHelpInfo other)
+        {
+            if (info == null || other == null)
+                return;
+
+            if (other.Synopsis != null && other.Synopsis.HasValue)
+                info.Synopsis = other.Synopsis;
+
+            if (other.Description != null && other.Description.HasValue)
+                info.Description = other.Description;
+        }
+    }
+}

--- a/src/PSRule/Definitions/Baselines/Baseline.cs
+++ b/src/PSRule/Definitions/Baselines/Baseline.cs
@@ -26,7 +26,7 @@ namespace PSRule.Definitions.Baselines
     [Spec(Specs.V1, Specs.Baseline)]
     public sealed class Baseline : InternalResource<BaselineSpec>, IResource
     {
-        public Baseline(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, BaselineSpec spec)
+        public Baseline(string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, BaselineSpec spec)
             : base(ResourceKind.Baseline, apiVersion, source, metadata, info, extent, spec) { }
 
         [YamlIgnore()]
@@ -37,7 +37,7 @@ namespace PSRule.Definitions.Baselines
         /// </summary>
         [JsonIgnore]
         [YamlIgnore]
-        public string Synopsis => Info.Synopsis;
+        public string Synopsis => Info.Synopsis.Text;
     }
 
     public sealed class BaselineSpec : Spec, IBaselineSpec

--- a/src/PSRule/Definitions/Conventions/ScriptBlockConvention.cs
+++ b/src/PSRule/Definitions/Conventions/ScriptBlockConvention.cs
@@ -40,7 +40,7 @@ namespace PSRule.Definitions.Conventions
             Extent = extent;
         }
 
-        public ResourceHelpInfo Info { get; }
+        public IResourceHelpInfo Info { get; }
 
         public ResourceFlags Flags { get; }
 

--- a/src/PSRule/Definitions/IResourceHelpInfo.cs
+++ b/src/PSRule/Definitions/IResourceHelpInfo.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Newtonsoft.Json;
+
+namespace PSRule.Definitions
+{
+    public interface IResourceHelpInfo
+    {
+        InfoString Synopsis { get; set; }
+
+        InfoString Description { get; set; }
+    }
+
+    internal sealed class ResourceHelpInfo : IResourceHelpInfo
+    {
+        internal ResourceHelpInfo(string name)
+        {
+            //Synopsis = synopsis;
+        }
+
+        [JsonProperty(PropertyName = "synopsis")]
+        public InfoString Synopsis { get; set; }
+
+        [JsonProperty(PropertyName = "synopsis")]
+        public InfoString Description { get; set; }
+    }
+}

--- a/src/PSRule/Definitions/ISuppressionInfo.cs
+++ b/src/PSRule/Definitions/ISuppressionInfo.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace PSRule.Definitions
+{
+    /// <summary>
+    /// Information related to suppression of a rule.
+    /// </summary>
+    internal interface ISuppressionInfo
+    {
+        ResourceId Id { get; }
+
+        InfoString Synopsis { get; }
+
+        int Count { get; }
+    }
+
+    internal sealed class ISuppressionInfoComparer : IEqualityComparer<ISuppressionInfo>
+    {
+        public bool Equals(ISuppressionInfo x, ISuppressionInfo y)
+        {
+            if (object.Equals(x, null) || object.Equals(y, null))
+                return object.Equals(x, y);
+
+            return x.Equals(y);
+        }
+
+        public int GetHashCode(ISuppressionInfo obj)
+        {
+            return obj.GetHashCode();
+        }
+    }
+}

--- a/src/PSRule/Definitions/ISuppressionInfo.cs
+++ b/src/PSRule/Definitions/ISuppressionInfo.cs
@@ -21,10 +21,7 @@ namespace PSRule.Definitions
     {
         public bool Equals(ISuppressionInfo x, ISuppressionInfo y)
         {
-            if (object.Equals(x, null) || object.Equals(y, null))
-                return object.Equals(x, y);
-
-            return x.Equals(y);
+            return object.Equals(x, null) || object.Equals(y, null) ? object.Equals(x, y) : x.Equals(y);
         }
 
         public int GetHashCode(ISuppressionInfo obj)

--- a/src/PSRule/Definitions/InfoString.cs
+++ b/src/PSRule/Definitions/InfoString.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Definitions
+{
+    public sealed class InfoString
+    {
+        private string _Text;
+        private string _Markdown;
+
+        internal InfoString() { }
+
+        internal InfoString(string text, string markdown)
+        {
+            Text = text;
+            Markdown = markdown ?? text;
+        }
+
+        public bool HasValue
+        {
+            get { return Text != null || Markdown != null; }
+        }
+
+        public string Text
+        {
+            get { return _Text; }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                    _Text = value;
+            }
+        }
+
+        public string Markdown
+        {
+            get { return _Markdown; }
+            set
+            {
+                if (!string.IsNullOrEmpty(value))
+                    _Markdown = value;
+            }
+        }
+    }
+}

--- a/src/PSRule/Definitions/ModuleConfigs/ModuleConfig.cs
+++ b/src/PSRule/Definitions/ModuleConfigs/ModuleConfig.cs
@@ -14,7 +14,7 @@ namespace PSRule.Definitions.ModuleConfigs
     [Spec(Specs.V1, Specs.ModuleConfig)]
     internal sealed class ModuleConfigV1 : InternalResource<ModuleConfigV1Spec>
     {
-        public ModuleConfigV1(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, ModuleConfigV1Spec spec)
+        public ModuleConfigV1(string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, ModuleConfigV1Spec spec)
             : base(ResourceKind.ModuleConfig, apiVersion, source, metadata, info, extent, spec) { }
 
         /// <summary>
@@ -22,7 +22,7 @@ namespace PSRule.Definitions.ModuleConfigs
         /// </summary>
         [JsonIgnore]
         [YamlIgnore]
-        public string Synopsis => Info.Synopsis;
+        public string Synopsis => Info.Synopsis.Text;
     }
 
     /// <summary>

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -102,6 +102,11 @@ namespace PSRule.Definitions
         /// The source location of the resource.
         /// </summary>
         ISourceExtent Extent { get; }
+
+        /// <summary>
+        /// Additional information about the resource.
+        /// </summary>
+        IResourceHelpInfo Info { get; }
     }
 
     internal interface IResourceVisitor
@@ -340,20 +345,10 @@ namespace PSRule.Definitions
         public string Module { get; set; }
     }
 
-    public sealed class ResourceHelpInfo
-    {
-        internal ResourceHelpInfo(string synopsis)
-        {
-            Synopsis = synopsis;
-        }
-
-        public string Synopsis { get; private set; }
-    }
-
     [DebuggerDisplay("Kind = {Kind}, Id = {Id}")]
     public abstract class Resource<TSpec> where TSpec : Spec, new()
     {
-        protected Resource(ResourceKind kind, string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, TSpec spec)
+        protected Resource(ResourceKind kind, string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, TSpec spec)
         {
             Kind = kind;
             ApiVersion = apiVersion;
@@ -382,7 +377,7 @@ namespace PSRule.Definitions
         public SourceFile Source { get; }
 
         [YamlIgnore()]
-        public readonly ResourceHelpInfo Info;
+        public IResourceHelpInfo Info { get; }
 
         /// <summary>
         /// Resource metadata details.
@@ -414,7 +409,7 @@ namespace PSRule.Definitions
     {
         private readonly Dictionary<Type, ResourceAnnotation> _Annotations;
 
-        private protected InternalResource(ResourceKind kind, string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, TSpec spec)
+        private protected InternalResource(ResourceKind kind, string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, TSpec spec)
             : base(kind, apiVersion, source, metadata, info, extent, spec)
         {
             _Annotations = new Dictionary<Type, ResourceAnnotation>();

--- a/src/PSRule/Definitions/Rules/Rule.cs
+++ b/src/PSRule/Definitions/Rules/Rule.cs
@@ -60,7 +60,7 @@ namespace PSRule.Definitions.Rules
     {
         internal const SeverityLevel DEFAULT_LEVEL = SeverityLevel.Error;
 
-        public RuleV1(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, RuleV1Spec spec)
+        public RuleV1(string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, RuleV1Spec spec)
             : base(ResourceKind.Rule, apiVersion, source, metadata, info, extent, spec)
         {
             Ref = ResourceHelper.GetIdNullable(source.Module, metadata.Ref, ResourceIdKind.Ref);
@@ -88,7 +88,7 @@ namespace PSRule.Definitions.Rules
         /// </summary>
         [JsonIgnore]
         [YamlIgnore]
-        public string Synopsis => Info.Synopsis;
+        public string Synopsis => Info.Synopsis.Text;
 
         ResourceId? IDependencyTarget.Ref => Ref;
 
@@ -107,7 +107,7 @@ namespace PSRule.Definitions.Rules
 
         ResourceTags IRuleV1.Tag => Metadata.Tags;
 
-        string IRuleV1.Description => Info.Synopsis;
+        string IRuleV1.Description => Info.Synopsis.Text;
     }
 
     internal sealed class RuleV1Spec : Spec, IRuleSpec

--- a/src/PSRule/Definitions/Selectors/Selector.cs
+++ b/src/PSRule/Definitions/Selectors/Selector.cs
@@ -9,7 +9,7 @@ namespace PSRule.Definitions.Selectors
     [Spec(Specs.V1, Specs.Selector)]
     internal sealed class SelectorV1 : InternalResource<SelectorV1Spec>
     {
-        public SelectorV1(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, SelectorV1Spec spec)
+        public SelectorV1(string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, SelectorV1Spec spec)
             : base(ResourceKind.Selector, apiVersion, source, metadata, info, extent, spec) { }
     }
 

--- a/src/PSRule/Definitions/SpecFactory.cs
+++ b/src/PSRule/Definitions/SpecFactory.cs
@@ -75,7 +75,10 @@ namespace PSRule.Definitions
 
         public IResource CreateInstance(SourceFile source, ResourceMetadata metadata, CommentMetadata comment, ISourceExtent extent, object spec)
         {
-            var info = new ResourceHelpInfo(comment.Synopsis);
+            var info = new ResourceHelpInfo(metadata.Name)
+            {
+                Synopsis = new InfoString(comment.Synopsis, null)
+            };
             return (IResource)Activator.CreateInstance(typeof(T), ApiVersion, source, metadata, info, extent, spec);
         }
     }

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroup.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroup.cs
@@ -9,7 +9,7 @@ namespace PSRule.Definitions.SuppressionGroups
     [Spec(Specs.V1, Specs.SuppressionGroup)]
     internal sealed class SuppressionGroupV1 : InternalResource<SuppressionGroupV1Spec>
     {
-        public SuppressionGroupV1(string apiVersion, SourceFile source, ResourceMetadata metadata, ResourceHelpInfo info, ISourceExtent extent, SuppressionGroupV1Spec spec)
+        public SuppressionGroupV1(string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, SuppressionGroupV1Spec spec)
             : base(ResourceKind.SuppressionGroup, apiVersion, source, metadata, info, extent, spec) { }
     }
 

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
@@ -11,6 +11,60 @@ namespace PSRule.Definitions.SuppressionGroups
     internal sealed class SuppressionGroupVisitor
     {
         private readonly LanguageExpressionOuterFn _Fn;
+        private readonly SuppressionInfo _Info;
+
+        public SuppressionGroupVisitor(ResourceId id, SourceFile source, ISuppressionGroupSpec spec, IResourceHelpInfo info)
+        {
+            Id = id;
+            Source = source;
+            InstanceId = Guid.NewGuid();
+            Rule = spec.Rule;
+            _Info = new SuppressionInfo(id, info);
+            _Fn = new LanguageExpressionBuilder()
+                .WithRule(Rule)
+                .Build(spec.If);
+        }
+
+        /// <summary>
+        /// Tracking information about the suppression.
+        /// </summary>
+        private sealed class SuppressionInfo : ISuppressionInfo
+        {
+            private readonly IResourceHelpInfo _Info;
+
+            public SuppressionInfo(ResourceId id, IResourceHelpInfo info)
+            {
+                Id = id;
+                _Info = info;
+            }
+
+            public ResourceId Id { get; }
+
+            public InfoString Synopsis => _Info.Synopsis;
+
+            public int Count { get; private set; }
+
+            public override string ToString()
+            {
+                return Id.Value;
+            }
+
+            public override int GetHashCode()
+            {
+                return Id.GetHashCode();
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is SuppressionInfo info &&
+                    Id.Equals(info.Id);
+            }
+
+            internal void Hit()
+            {
+                Count++;
+            }
+        }
 
         public ResourceId Id { get; }
 
@@ -20,23 +74,18 @@ namespace PSRule.Definitions.SuppressionGroups
 
         public string[] Rule { get; }
 
-        public SuppressionGroupVisitor(ResourceId id, SourceFile source, ISuppressionGroupSpec spec)
+        public bool TryMatch(object o, out ISuppressionInfo suppression)
         {
-            Id = id;
-            Source = source;
-            InstanceId = Guid.NewGuid();
-            Rule = spec.Rule;
-            var builder = new LanguageExpressionBuilder();
-            _Fn = builder
-                .WithRule(Rule)
-                .Build(spec.If);
-        }
-
-        public bool Match(object o)
-        {
+            suppression = null;
             var context = new ExpressionContext(Source);
             context.Debug(PSRuleResources.SelectorMatchTrace, Id);
-            return _Fn(context, o).GetValueOrDefault(false);
+            if (_Fn(context, o).GetValueOrDefault(false))
+            {
+                _Info.Hit();
+                suppression = _Info;
+                return true;
+            }
+            return false;
         }
     }
 }

--- a/src/PSRule/Help/MarkdownConvert.cs
+++ b/src/PSRule/Help/MarkdownConvert.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Management.Automation;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal static class MarkdownConvert
     {

--- a/src/PSRule/Help/MarkdownLexer.cs
+++ b/src/PSRule/Help/MarkdownLexer.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal abstract class MarkdownLexer
     {

--- a/src/PSRule/Help/MarkdownReader.cs
+++ b/src/PSRule/Help/MarkdownReader.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal enum MarkdownReaderMode
     {

--- a/src/PSRule/Help/MarkdownStream.cs
+++ b/src/PSRule/Help/MarkdownStream.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Diagnostics;
 using System.Linq;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal delegate bool CharacterMatchDelegate(char c);
 

--- a/src/PSRule/Help/MarkdownToken.cs
+++ b/src/PSRule/Help/MarkdownToken.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Diagnostics;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     public enum MarkdownTokenType
     {

--- a/src/PSRule/Help/MarkdownTokenExtensions.cs
+++ b/src/PSRule/Help/MarkdownTokenExtensions.cs
@@ -1,7 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal static class MarkdownTokenExtensions
     {

--- a/src/PSRule/Help/MetadataLexer.cs
+++ b/src/PSRule/Help/MetadataLexer.cs
@@ -1,9 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal sealed class MetadataLexer : MarkdownLexer
     {

--- a/src/PSRule/Help/Models.cs
+++ b/src/PSRule/Help/Models.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using PSRule.Definitions;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     /// <summary>
     /// Define options that determine how markdown will be rendered.
@@ -57,25 +57,60 @@ namespace PSRule.Parser
         public string Uri;
     }
 
-    internal sealed class RuleDocument
+    internal interface IHelpDocument
+    {
+        string Name { get; }
+
+        InfoString Synopsis { get; set; }
+
+        InfoString Description { get; set; }
+
+        Link[] Links { get; set; }
+    }
+
+    internal sealed class RuleDocument : IHelpDocument
     {
         public RuleDocument(string name)
         {
             Name = name;
         }
 
-        public readonly string Name;
+        public string Name { get; }
 
-        public TextBlock Synopsis;
+        public InfoString Synopsis { get; set; }
 
-        public TextBlock Description;
+        public InfoString Description { get; set; }
 
-        public TextBlock Notes;
+        public TextBlock Notes { get; set; }
 
-        public TextBlock Recommendation;
+        public TextBlock Recommendation { get; set; }
 
-        public Link[] Links;
+        public Link[] Links { get; set; }
 
-        public ResourceTags Annotations;
+        public ResourceTags Annotations { get; set; }
+    }
+
+    internal sealed class ResourceHelpDocument : IHelpDocument
+    {
+        public ResourceHelpDocument(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+
+        public InfoString Synopsis { get; set; }
+
+        public InfoString Description { get; set; }
+
+        public Link[] Links { get; set; }
+
+        internal IResourceHelpInfo ToInfo()
+        {
+            return new ResourceHelpInfo(Name)
+            {
+                Synopsis = Synopsis
+            };
+        }
     }
 }

--- a/src/PSRule/Help/ResourceHelpLexer.cs
+++ b/src/PSRule/Help/ResourceHelpLexer.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Help
+{
+    internal sealed class ResourceHelpLexer : HelpLexer
+    {
+        public ResourceHelpLexer() { }
+
+        public ResourceHelpDocument Process(TokenStream stream)
+        {
+            // Look for yaml header
+            stream.MoveTo(0);
+            var metadata = YamlHeader(stream);
+            ResourceHelpDocument doc = null;
+
+            // Process sections
+            while (!stream.EOF)
+            {
+                if (IsHeading(stream.Current, RULE_NAME_HEADING_LEVEL))
+                {
+                    doc = new ResourceHelpDocument(stream.Current.Text)
+                    {
+                        //Annotations = ResourceTags.FromDictionary(metadata)
+                    };
+                }
+                else if (doc != null && IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL))
+                {
+                    var matching = Synopsis(stream, doc) ||
+                        Description(stream, doc) ||
+                        Links(stream, doc);
+
+                    if (matching)
+                        continue;
+                }
+
+                // Skip the current token
+                stream.Next();
+            }
+            return doc;
+        }
+    }
+}

--- a/src/PSRule/Help/RuleHelpLexer.cs
+++ b/src/PSRule/Help/RuleHelpLexer.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Definitions;
+using PSRule.Resources;
+
+namespace PSRule.Help
+{
+    /// <summary>
+    /// A lexer that interprets markdown as rule help.
+    /// </summary>
+    internal sealed class RuleHelpLexer : HelpLexer
+    {
+        public RuleHelpLexer() { }
+
+        public RuleDocument Process(TokenStream stream)
+        {
+            // Look for yaml header
+            stream.MoveTo(0);
+            var metadata = YamlHeader(stream);
+            RuleDocument doc = null;
+
+            // Process sections
+            while (!stream.EOF)
+            {
+                if (IsHeading(stream.Current, RULE_NAME_HEADING_LEVEL))
+                {
+                    doc = new RuleDocument(stream.Current.Text)
+                    {
+                        Annotations = ResourceTags.FromDictionary(metadata)
+                    };
+                }
+                else if (doc != null && IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL))
+                {
+                    var matching = Synopsis(stream, doc) ||
+                        Description(stream, doc) ||
+                        Recommendation(stream, doc) ||
+                        Notes(stream, doc) ||
+                        Links(stream, doc);
+
+                    if (matching)
+                        continue;
+                }
+
+                // Skip the current token
+                stream.Next();
+            }
+            return doc;
+        }
+
+        /// <summary>
+        /// Read recommendation.
+        /// </summary>
+        private static bool Recommendation(TokenStream stream, RuleDocument doc)
+        {
+            if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Recommendation))
+                return false;
+
+            doc.Recommendation = TextBlock(stream);
+            stream.SkipUntilHeader();
+            return true;
+        }
+
+        /// <summary>
+        /// Read notes.
+        /// </summary>
+        private static bool Notes(TokenStream stream, RuleDocument doc)
+        {
+            if (!IsHeading(stream.Current, RULE_ENTRIES_HEADING_LEVEL, DocumentStrings.Notes))
+                return false;
+
+            doc.Notes = TextBlock(stream, includeNonYamlFencedBlocks: true);
+            stream.SkipUntilHeader();
+            return true;
+        }
+    }
+}

--- a/src/PSRule/Help/TokenStream.cs
+++ b/src/PSRule/Help/TokenStream.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 
-namespace PSRule.Parser
+namespace PSRule.Help
 {
     internal static class TokenStreamExtensions
     {

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -242,7 +242,7 @@ namespace PSRule.Pipeline
                 var result = new InvokeResult();
                 var ruleCounter = 0;
                 var suppressedRuleCounter = 0;
-                var suppressionGroupCounter = new Dictionary<string, int>();
+                var suppressionGroupCounter = new Dictionary<ISuppressionInfo, int>(new ISuppressionInfoComparer());
 
                 // Process rule blocks ordered by dependency graph
                 foreach (var ruleBlockTarget in _RuleGraph.GetSingleTarget())
@@ -271,13 +271,13 @@ namespace PSRule.Pipeline
                                 Context.WarnRuleSuppressed(ruleId: ruleRecord.RuleId);
                         }
                         // Check for suppression group
-                        else if (_SuppressionGroupFilter.TrySuppressionGroup(ruleId: ruleRecord.RuleId, targetObject, out var suppressionGroupId))
+                        else if (_SuppressionGroupFilter.TrySuppressionGroup(ruleId: ruleRecord.RuleId, targetObject, out var suppression))
                         {
                             ruleRecord.OutcomeReason = RuleOutcomeReason.Suppressed;
                             if (!_IsSummary)
-                                Context.WarnRuleSuppressionGroup(ruleId: ruleRecord.RuleId, suppressionGroupId);
+                                Context.WarnRuleSuppressionGroup(ruleId: ruleRecord.RuleId, suppression);
                             else
-                                suppressionGroupCounter[suppressionGroupId] = suppressionGroupCounter.TryGetValue(suppressionGroupId, out var count) ? ++count : 1;
+                                suppressionGroupCounter[suppression] = suppressionGroupCounter.TryGetValue(suppression, out var count) ? ++count : 1;
                         }
                         else
                         {
@@ -320,7 +320,7 @@ namespace PSRule.Pipeline
                         Context.WarnRuleCountSuppressed(ruleCount: suppressedRuleCounter);
 
                     foreach (var keyValuePair in suppressionGroupCounter)
-                        Context.WarnRuleSuppressionGroupCount(ruleCount: keyValuePair.Value, suppressionGroupId: keyValuePair.Key);
+                        Context.WarnRuleSuppressionGroupCount(suppression: keyValuePair.Key, count: keyValuePair.Value);
                 }
                 return result;
             }

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -183,12 +183,12 @@ namespace PSRule.Pipeline
             }
             else if (resource.Kind == ResourceKind.SuppressionGroup && resource is SuppressionGroupV1 suppressionGroup)
             {
-                var suppressionGroupVisitor = new SuppressionGroupVisitor(
+                SuppressionGroup.Add(new SuppressionGroupVisitor(
                     id: suppressionGroup.Id,
                     source: suppressionGroup.Source,
-                    spec: suppressionGroup.Spec
-                );
-                SuppressionGroup.Add(suppressionGroupVisitor);
+                    spec: suppressionGroup.Spec,
+                    info: suppressionGroup.Info
+                ));
             }
         }
 

--- a/src/PSRule/Pipeline/PipelineReciever.cs
+++ b/src/PSRule/Pipeline/PipelineReciever.cs
@@ -9,7 +9,7 @@ using System.Management.Automation;
 using System.Net;
 using Newtonsoft.Json;
 using PSRule.Data;
-using PSRule.Parser;
+using PSRule.Help;
 using PSRule.Runtime;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;

--- a/src/PSRule/Pipeline/PipelineWriterExtensions.cs
+++ b/src/PSRule/Pipeline/PipelineWriterExtensions.cs
@@ -12,7 +12,7 @@ namespace PSRule.Pipeline
     {
         internal static void DebugMessage(this IPipelineWriter logger, string message)
         {
-            if (!logger.ShouldWriteDebug())
+            if (logger == null || !logger.ShouldWriteDebug())
                 return;
 
             logger.WriteDebug(new DebugRecord(message));
@@ -20,7 +20,7 @@ namespace PSRule.Pipeline
 
         internal static void WarnUsingInvariantCulture(this IPipelineWriter writer)
         {
-            if (!writer.ShouldWriteWarning())
+            if (writer == null || !writer.ShouldWriteWarning())
                 return;
 
             writer.WriteWarning(PSRuleResources.UsingInvariantCulture);
@@ -28,7 +28,7 @@ namespace PSRule.Pipeline
 
         internal static void WarnRulePathNotFound(this IPipelineWriter writer)
         {
-            if (!writer.ShouldWriteWarning())
+            if (writer == null || !writer.ShouldWriteWarning())
                 return;
 
             writer.WriteWarning(PSRuleResources.RulePathNotFound);
@@ -36,7 +36,7 @@ namespace PSRule.Pipeline
 
         internal static void WarnModuleManifestBaseline(this IPipelineWriter writer, string moduleName)
         {
-            if (!writer.ShouldWriteWarning())
+            if (writer == null || !writer.ShouldWriteWarning())
                 return;
 
             writer.WriteWarning(PSRuleResources.ModuleManifestBaseline, moduleName);
@@ -44,7 +44,7 @@ namespace PSRule.Pipeline
 
         internal static void WriteWarning(this IPipelineWriter writer, string message, params object[] args)
         {
-            if (!writer.ShouldWriteWarning() || string.IsNullOrEmpty(message))
+            if (writer == null || !writer.ShouldWriteWarning() || string.IsNullOrEmpty(message))
                 return;
 
             writer.WriteWarning(Format(message, args));
@@ -52,7 +52,7 @@ namespace PSRule.Pipeline
 
         internal static void ErrorRequiredVersionMismatch(this IPipelineWriter writer, string moduleName, string moduleVersion, string requiredVersion)
         {
-            if (!writer.ShouldWriteError())
+            if (writer == null || !writer.ShouldWriteError())
                 return;
 
             writer.WriteError(
@@ -64,7 +64,7 @@ namespace PSRule.Pipeline
 
         internal static void ErrorReadFileFailed(this IPipelineWriter writer, string path, Exception innerException)
         {
-            if (!writer.ShouldWriteError())
+            if (writer == null || !writer.ShouldWriteError())
                 return;
 
             writer.WriteError(
@@ -76,12 +76,15 @@ namespace PSRule.Pipeline
 
         internal static void WriteError(this IPipelineWriter writer, PipelineException exception, string errorId, ErrorCategory errorCategory)
         {
+            if (writer == null)
+                return;
+
             writer.WriteError(new ErrorRecord(exception, errorId, errorCategory, null));
         }
 
         internal static void WriteDebug(this IPipelineWriter writer, string message, params object[] args)
         {
-            if (!writer.ShouldWriteDebug() || string.IsNullOrEmpty(message))
+            if (writer == null || !writer.ShouldWriteDebug() || string.IsNullOrEmpty(message))
                 return;
 
             writer.WriteDebug(new DebugRecord

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -538,6 +538,24 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;. {3}.
+        /// </summary>
+        internal static string RuleSuppressionGroupExtended {
+            get {
+                return ResourceManager.GetString("RuleSuppressionGroupExtended", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;. {3}.
+        /// </summary>
+        internal static string RuleSuppressionGroupExtendedCount {
+            get {
+                return ResourceManager.GetString("RuleSuppressionGroupExtendedCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
         /// </summary>
         internal static string ScanModule {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -330,4 +330,10 @@
   <data name="InvalidResourceName" xml:space="preserve">
     <value>The resource name '{0}' is not valid at {1}. Each resource name must be between 3-128 characters in length, must start and end with a letter or number, and only contain letters, numbers, hyphens, dots, or underscores. See https://aka.ms/ps-rule/naming for more information.</value>
   </data>
+  <data name="RuleSuppressionGroupExtended" xml:space="preserve">
+    <value>Rule '{0}' was suppressed by suppression group '{1}' for '{2}'. {3}</value>
+  </data>
+  <data name="RuleSuppressionGroupExtendedCount" xml:space="preserve">
+    <value>{0} rule/s were suppressed by suppression group '{1}' for '{2}'. {3}</value>
+  </data>
 </root>

--- a/src/PSRule/Rules/Rule.cs
+++ b/src/PSRule/Rules/Rule.cs
@@ -124,6 +124,8 @@ namespace PSRule.Rules
 
         string IResource.Name => Name;
 
+        IResourceHelpInfo IResource.Info => Info;
+
         ResourceTags IResource.Tags => Tag;
 
         [Obsolete("Use Source property instead.")]

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -115,6 +115,8 @@ namespace PSRule.Rules
 
         ResourceTags IResource.Tags => Tag;
 
+        IResourceHelpInfo IResource.Info => Info;
+
         string IRuleV1.RuleName => Name;
 
         ResourceTags IRuleV1.Tag => Tag;

--- a/src/PSRule/Rules/RuleHelpInfo.cs
+++ b/src/PSRule/Rules/RuleHelpInfo.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections;
 using System.Text;
 using Newtonsoft.Json;
+using PSRule.Definitions;
 using YamlDotNet.Serialization;
 
 namespace PSRule.Rules
@@ -12,7 +13,7 @@ namespace PSRule.Rules
     /// <summary>
     /// Output view helper class for rule help.
     /// </summary>
-    public sealed class RuleHelpInfo
+    public sealed class RuleHelpInfo : IResourceHelpInfo
     {
         private const string ONLINE_HELP_LINK_ANNOTATION = "online version";
 
@@ -92,6 +93,12 @@ namespace PSRule.Rules
         /// </summary>
         [JsonProperty(PropertyName = "annotations")]
         public Hashtable Annotations { get; internal set; }
+
+        [JsonIgnore, YamlIgnore]
+        InfoString IResourceHelpInfo.Synopsis { get; set; }
+
+        [JsonIgnore, YamlIgnore]
+        InfoString IResourceHelpInfo.Description { set; get; }
 
         /// <summary>
         /// Get the URI for the online version of the documentation.

--- a/src/PSRule/Rules/SuppressionFilter.cs
+++ b/src/PSRule/Rules/SuppressionFilter.cs
@@ -18,9 +18,7 @@ namespace PSRule.Rules
     {
         private readonly HashSet<SuppressionKey> _Index;
         private readonly bool _IsEmpty;
-
         private readonly ResourceIndex _ResourceIndex;
-
         private readonly Dictionary<string, List<SuppressionGroupVisitor>> _RuleSuppressionGroupIndex;
 
         public SuppressionFilter(RunspaceContext context, SuppressionOption option, ResourceIndex resourceIndex)
@@ -125,24 +123,21 @@ namespace PSRule.Rules
         }
 
         /// <summary>
-        /// Attempts to fetch suppression group from rule suppression group index
+        /// Attempts to fetch suppression group from rule suppression group index.
         /// </summary>
         /// <param name="ruleId">The key rule id which indexes suppression groups</param>
         /// <param name="targetObject">Th target object we are invoking</param>
         /// <param name="suppressionGroupId">The Id of the matched suppression group</param>
         /// <returns>Boolean indicating if suppression group has been found</returns>
-        public bool TrySuppressionGroup(string ruleId, TargetObject targetObject, out string suppressionGroupId)
+        public bool TrySuppressionGroup(string ruleId, TargetObject targetObject, out ISuppressionInfo suppression)
         {
-            suppressionGroupId = string.Empty;
+            suppression = null;
             if (_RuleSuppressionGroupIndex.TryGetValue(ruleId, out var suppressionGroupVisitors))
             {
                 foreach (var visitor in suppressionGroupVisitors)
                 {
-                    if (visitor.Match(targetObject.Value))
-                    {
-                        suppressionGroupId = visitor.Id.Value;
+                    if (visitor.TryMatch(targetObject.Value, out suppression))
                         return true;
-                    }
                 }
             }
             return false;

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -253,31 +253,31 @@ namespace PSRule.Runtime
         public void WarnRuleCountSuppressed(int ruleCount)
         {
             if (Writer == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
-            {
                 return;
-            }
 
             Writer.WriteWarning(PSRuleResources.RuleCountSuppressed, ruleCount, Binding.TargetName);
         }
 
-        public void WarnRuleSuppressionGroup(string ruleId, string suppressionGroupId)
+        public void WarnRuleSuppressionGroup(string ruleId, ISuppressionInfo suppression)
         {
-            if (Writer == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
-            {
+            if (Writer == null || suppression == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
                 return;
-            }
 
-            Writer.WriteWarning(PSRuleResources.RuleSuppressionGroup, ruleId, suppressionGroupId, Binding.TargetName);
+            if (suppression.Synopsis != null && suppression.Synopsis.HasValue)
+                Writer.WriteWarning(PSRuleResources.RuleSuppressionGroupExtended, ruleId, suppression.Id, Binding.TargetName, suppression.Synopsis.Text);
+            else
+                Writer.WriteWarning(PSRuleResources.RuleSuppressionGroup, ruleId, suppression.Id, Binding.TargetName);
         }
 
-        public void WarnRuleSuppressionGroupCount(int ruleCount, string suppressionGroupId)
+        public void WarnRuleSuppressionGroupCount(ISuppressionInfo suppression, int count)
         {
-            if (Writer == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
-            {
+            if (Writer == null || suppression == null || !Writer.ShouldWriteWarning() || !_SuppressedRuleWarning)
                 return;
-            }
 
-            Writer.WriteWarning(PSRuleResources.RuleSuppressionGroupCount, ruleCount, suppressionGroupId, Binding.TargetName);
+            if (suppression.Synopsis != null && suppression.Synopsis.HasValue)
+                Writer.WriteWarning(PSRuleResources.RuleSuppressionGroupExtendedCount, count, suppression.Id, Binding.TargetName, suppression.Synopsis.Text);
+            else
+                Writer.WriteWarning(PSRuleResources.RuleSuppressionGroupCount, count, suppression.Id, Binding.TargetName);
         }
 
         public void ErrorInvaildRuleResult()

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1292,7 +1292,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False -OutputCulture 'en-US';
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1300,17 +1300,17 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 6;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[0].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject1'.";
+                $warningMessages[0].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject1'. Ignore test objects by name.";
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[1].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject1'.";
+                $warningMessages[1].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject1'. Ignore test objects by name.";
                 $warningMessages[2] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[2].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject1'.";
+                $warningMessages[2].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject1'. Ignore objects with non-production tag.";
                 $warningMessages[3] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[3].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
+                $warningMessages[3].Message | Should -BeExactly "Rule '.\FromFile1' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'. Ignore test objects by name.";
                 $warningMessages[4] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[4].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'.";
+                $warningMessages[4].Message | Should -BeExactly "Rule '.\FromFile2' was suppressed by suppression group '.\SuppressWithTargetName' for 'TestObject2'. Ignore test objects by name.";
                 $warningMessages[5] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[5].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'.";
+                $warningMessages[5].Message | Should -BeExactly "Rule '.\WithTag2' was suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'. Ignore objects with non-production tag.";
             }
 
             It 'Show warnings for all rules when rule property is null or empty' {
@@ -1322,7 +1322,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 152;
 
                 $warningMessages | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages.Message | Should -MatchExactly "Rule '.\\[a-zA-Z0-9]+' was suppressed by suppression group '.\\SuppressWithTargetNameAnd(Null|Empty)Rule' for 'TestObject[1-2]'."
+                $warningMessages.Message | Should -MatchExactly "Rule '.\\[a-zA-Z0-9]+' was suppressed by suppression group '.\\SuppressWithTargetNameAnd(Null|Empty)Rule' for 'TestObject[1-2]'. Ignore test objects for all \((null|empty)\) rules."
             }
 
             It 'No warnings' {
@@ -1337,7 +1337,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False -OutputCulture 'en-US';
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1345,13 +1345,13 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 4;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[0].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject1'.";
+                $warningMessages[0].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject1'. Ignore test objects by type.";
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[1].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject1'.";
+                $warningMessages[1].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject1'. Ignore objects with non-production tag.";
                 $warningMessages[2] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[2].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject2'.";
+                $warningMessages[2].Message | Should -BeExactly "2 rule/s were suppressed by suppression group '.\SuppressWithTestType' for 'TestObject2'. Ignore test objects by type.";
                 $warningMessages[3] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[3].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'.";
+                $warningMessages[3].Message | Should -BeExactly "1 rule/s were suppressed by suppression group '.\SuppressWithNonProdTag' for 'TestObject2'. Ignore objects with non-production tag.";
             }
 
             It 'Show warnings for all rules when rule property is null or empty' {
@@ -1363,9 +1363,9 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 2;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[0].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'."
+                $warningMessages[0].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'. Ignore test objects for all (null) rules."
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[1].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'."
+                $warningMessages[1].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'. Ignore test objects for all (empty) rules."
             }
 
             It 'No warnings' {

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -37,6 +37,9 @@
     <None Update="Dockerfile">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="en\SuppressWithNonProdTag.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="FromFile.Rule.jsonc">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Tests/RuleDocumentTests.cs
+++ b/tests/PSRule.Tests/RuleDocumentTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using PSRule.Definitions;
-using PSRule.Parser;
+using PSRule.Help;
 using Xunit;
 
 namespace PSRule
@@ -67,7 +67,7 @@ namespace PSRule
 
             var result = new RuleDocument(name: "Use specific tags")
             {
-                Synopsis = new TextBlock(text: "Containers should use specific tags instead of latest."),
+                Synopsis = new InfoString("Containers should use specific tags instead of latest.", null),
                 Annotations = ResourceTags.FromHashtable(annotations),
                 Recommendation = new TextBlock(text: @"Deployments or pods should identify a specific tag to use for container images instead of latest. When latest is used it may be hard to determine which version of the image is running.
 When using variable tags such as v1.0 (which may refer to v1.0.0 or v1.0.1) consider using imagePullPolicy: Always to ensure that the an out-of-date cached image is not used.
@@ -88,7 +88,7 @@ The latest tag automatically uses imagePullPolicy: Always instead of the default
 
         private RuleDocument GetDocument(TokenStream stream)
         {
-            var lexer = new RuleLexer();
+            var lexer = new RuleHelpLexer();
             return lexer.Process(stream);
         }
 

--- a/tests/PSRule.Tests/SuppressionGroupTests.cs
+++ b/tests/PSRule.Tests/SuppressionGroupTests.cs
@@ -26,9 +26,15 @@ namespace PSRule
             var suppressionGroup = HostHelper.GetSuppressionGroup(GetSource(path), context).ToArray();
             Assert.NotNull(suppressionGroup);
             Assert.Equal(3, suppressionGroup.Length);
+
             Assert.Equal("SuppressWithTargetName", suppressionGroup[0].Name);
+            Assert.Equal("Ignore test objects by name.", suppressionGroup[0].Info.Synopsis.Text);
+
             Assert.Equal("SuppressWithTestType", suppressionGroup[1].Name);
+            Assert.Equal("Ignore test objects by type.", suppressionGroup[1].Info.Synopsis.Text);
+
             Assert.Equal("SuppressWithNonProdTag", suppressionGroup[2].Name);
+            Assert.Equal("Ignore objects with non-production tag.", suppressionGroup[2].Info.Synopsis.Text);
         }
 
         #region Helper methods

--- a/tests/PSRule.Tests/SuppressionGroupTests.cs
+++ b/tests/PSRule.Tests/SuppressionGroupTests.cs
@@ -20,7 +20,7 @@ namespace PSRule
         [InlineData("SuppressionGroups.Rule.jsonc")]
         public void ReadSuppressionGroup(string path)
         {
-            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, new OptionContext(), null), null);
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, null, null, null, GetOptionContext(), null), null);
             context.Init(GetSource(path));
             context.Begin();
             var suppressionGroup = HostHelper.GetSuppressionGroup(GetSource(path), context).ToArray();
@@ -44,6 +44,11 @@ namespace PSRule
             var option = new PSRuleOption();
             option.Output.Culture = new string[] { "en-US" };
             return option;
+        }
+
+        private static OptionContext GetOptionContext()
+        {
+            return new OptionContextBuilder(GetOption(), null, null, null).Build();
         }
 
         private static Source[] GetSource(string path)

--- a/tests/PSRule.Tests/SuppressionGroupTests.cs
+++ b/tests/PSRule.Tests/SuppressionGroupTests.cs
@@ -42,7 +42,7 @@ namespace PSRule
         private static PSRuleOption GetOption()
         {
             var option = new PSRuleOption();
-            option.Output.Culture = new string[] { "en-US" };
+            option.Output.Culture = new string[] { "en-US", "en" };
             return option;
         }
 

--- a/tests/PSRule.Tests/SuppressionGroupTests.cs
+++ b/tests/PSRule.Tests/SuppressionGroupTests.cs
@@ -41,7 +41,9 @@ namespace PSRule
 
         private static PSRuleOption GetOption()
         {
-            return new PSRuleOption();
+            var option = new PSRuleOption();
+            option.Output.Culture = new string[] { "en-US" };
+            return option;
         }
 
         private static Source[] GetSource(string path)

--- a/tests/PSRule.Tests/SuppressionGroups.Rule.jsonc
+++ b/tests/PSRule.Tests/SuppressionGroups.Rule.jsonc
@@ -3,7 +3,7 @@
 // Suppression groups for unit testing
 [
     {
-        // Synopsis: Suppress with target name
+        // Synopsis: Ignore test objects by name.
         "apiVersion": "github.com/microsoft/PSRule/v1",
         "kind": "SuppressionGroup",
         "metadata": {
@@ -24,7 +24,7 @@
         }
     },
     {
-        // Synopsis: Suppress with target type
+        // Synopsis: Ignore test objects by type.
         "apiVersion": "github.com/microsoft/PSRule/v1",
         "kind": "SuppressionGroup",
         "metadata": {

--- a/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
+++ b/tests/PSRule.Tests/SuppressionGroups.Rule.yaml
@@ -4,7 +4,7 @@
 # Suppression groups for unit testing
 
 ---
-# Synopsis: Suppress with target name
+# Synopsis: Ignore test objects by name.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:
@@ -20,7 +20,7 @@ spec:
     - 'TestObject2'
 
 ---
-# Synopsis: Suppress with target type
+# Synopsis: Ignore test objects by type.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:

--- a/tests/PSRule.Tests/SuppressionGroups2.Rule.yaml
+++ b/tests/PSRule.Tests/SuppressionGroups2.Rule.yaml
@@ -4,7 +4,7 @@
 # Suppression groups for unit testing
 
 ---
-# Synopsis: Suppress with target name for all(null) rules
+# Synopsis: Ignore test objects for all (null) rules.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:
@@ -15,7 +15,7 @@ spec:
     equals: 'TestObject1'
 
 ---
-# Synopsis: Suppress with target name for all(empty) rules
+# Synopsis: Ignore test objects for all (empty) rules.
 apiVersion: github.com/microsoft/PSRule/v1
 kind: SuppressionGroup
 metadata:

--- a/tests/PSRule.Tests/en/SuppressWithNonProdTag.md
+++ b/tests/PSRule.Tests/en/SuppressWithNonProdTag.md
@@ -1,0 +1,6 @@
+
+# Suppress with non-production tag
+
+## Synopsis
+
+Ignore objects with non-production tag.


### PR DESCRIPTION
## PR Summary

  - Added custom suppression message during PSRule runs. #1046
    - When a rule is suppressed using a suppression group the synopsis is shown in the suppression warning.
    - Configure the suppression group synopsis to display a custom message.
    - Suppression groups synopsis can be localized using markdown documentation.
    - Use markdown to set a culture specific synopsis.
    - Custom suppression messages are not supported when suppressing individual rules using `ps-rule.yaml`.

Fixes #1046 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
