### PR TITLE
Revert "Bump pymdown-extensions from 9.3 to 9.4 (#1066)"

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
 mkdocs==1.3.0
 mkdocs-material==8.2.11
-pymdown-extensions==9.4
+pymdown-extensions==9.3
 mike==1.1.2
 mkdocs-simple-hooks==0.1.5
 mkdocs-git-revision-date-plugin==0.3.2


### PR DESCRIPTION
This reverts commit 52ff32d0cdecdfb685035951dceb1e53aaa330d7.

## PR Summary

- Compatibility issue with mkdocs-material v8.2.11.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
