### PR TITLE
Added more object path tests

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -20,6 +20,9 @@ What's changed since pre-release v2.2.0-B0021:
     [#1117](https://github.com/microsoft/PSRule/issues/1117)
   - Fixed piped input does not respect excluded paths by @BernieWhite.
     [#1114](https://github.com/microsoft/PSRule/issues/1114)
+- Engineering:
+  - Added more object path tests by @ArmaanMcleod.
+    [#1110](https://github.com/microsoft/PSRule/issues/1110)
 
 ## v2.2.0-B0021 (pre-release)
 

--- a/tests/PSRule.Tests/PathExpressionTests.cs
+++ b/tests/PSRule.Tests/PathExpressionTests.cs
@@ -119,6 +119,18 @@ namespace PSRule
             Assert.Equal("2", actual[1]);
             Assert.Equal("1", actual[2]);
             Assert.Equal("2", actual[3]);
+
+            expression = PathExpression.Create("$[*].Spec.Properties.array2[?(@ == '1' || @ == '2' || @ == '3')]");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject, false, out actual));
+            Assert.NotNull(actual);
+            Assert.Equal(6, actual.Length);
+            Assert.Equal("1", actual[0]);
+            Assert.Equal("2", actual[1]);
+            Assert.Equal("3", actual[2]);
+            Assert.Equal("1", actual[3]);
+            Assert.Equal("2", actual[4]);
+            Assert.Equal("3", actual[5]);
         }
 
         [Fact]
@@ -131,6 +143,18 @@ namespace PSRule
             Assert.Null(actual);
 
             expression = PathExpression.Create("$[*].Spec.Properties.array[?(@.id=='1' && @.id=='1')].id");
+            Assert.True(expression.TryGet(testObject, false, out actual));
+            Assert.NotNull(actual);
+            Assert.Equal(2, actual.Length);
+            Assert.Equal("1", actual[0]);
+            Assert.Equal("1", actual[1]);
+
+            expression = PathExpression.Create("$[*].Spec.Properties.array2[?(@ == '1' && @ == '2')]");
+            Assert.False(expression.TryGet(testObject, false, out actual));
+            Assert.Null(actual);
+
+            expression = PathExpression.Create("$[*].Spec.Properties.array2[?(@ == '1' && @ == '1')]");
+            Assert.True(expression.IsArray);
             Assert.True(expression.TryGet(testObject, false, out actual));
             Assert.NotNull(actual);
             Assert.Equal(2, actual.Length);


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->

Related to #1110

Added more object path tests for current ref comparisons with no dot selector comparisons.

Alot of the other test paths seemed covered already, so not much to add here 🙂. Will add more in the future if I find any.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
