### PR TITLE
Added output path information #1074

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -15,14 +15,19 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v2.2.0-B0021:
 
+- General improvements:
+  - Added informational message when output has been written to disk by @BernieWhite.
+    [#1074](https://github.com/microsoft/PSRule/issues/1074)
+    - The `Output.Footer` option now supports `OutputFile` which reports the output file path.
+      This is enabled by default.
+- Engineering:
+  - Added more object path tests by @ArmaanMcleod.
+    [#1110](https://github.com/microsoft/PSRule/issues/1110)
 - Bug fixes:
   - Fixed output of reason with wide format by @BernieWhite.
     [#1117](https://github.com/microsoft/PSRule/issues/1117)
   - Fixed piped input does not respect excluded paths by @BernieWhite.
     [#1114](https://github.com/microsoft/PSRule/issues/1114)
-- Engineering:
-  - Added more object path tests by @ArmaanMcleod.
-    [#1110](https://github.com/microsoft/PSRule/issues/1110)
 
 ## v2.2.0-B0021 (pre-release)
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1876,10 +1876,11 @@ The following information can be shown or hidden by configuring this option.
 
 - `RuleCount` (1) - Shows a summary of rules processed.
 - `RunInfo` (2) - Shows information about the run.
+- `OutputFile` (4) - Shows information about the output file if an output path is set.
 
 Additionally the following rollup options exist:
 
-- `Default` - Shows `RuleCount`, and `RunInfo`.
+- `Default` - Shows `RuleCount`, `RunInfo`, and `OutputFile`.
 This is the default option.
 
 This option can be configured using one of the named values described above.

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -454,8 +454,8 @@
                 },
                 "footer": {
                     "title": "Footer format",
-                    "description": "The information displayed for Assert-PSRule footer. The default is Default which includes RuleCount, and RunInfo.",
-                    "markdownDescription": "The information displayed for Assert-PSRule footer. The default is `Default` which includes `RuleCount`, and `RunInfo`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#outputfooter)",
+                    "description": "The information displayed for Assert-PSRule footer. The default is Default which includes RuleCount, RunInfo, and OutputFile.",
+                    "markdownDescription": "The information displayed for Assert-PSRule footer. The default is `Default` which includes `RuleCount`, `RunInfo`, and `OutputFile`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#outputfooter)",
                     "oneOf": [
                         {
                             "type": "string",
@@ -463,11 +463,13 @@
                                 "None",
                                 "RuleCount",
                                 "RunInfo",
+                                "OutputFile",
                                 "Default"
                             ]
                         },
                         {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 0
                         }
                     ],
                     "default": "Default"

--- a/src/PSRule/Configuration/FooterFormat.cs
+++ b/src/PSRule/Configuration/FooterFormat.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -29,6 +29,14 @@ namespace PSRule.Configuration
         /// </summary>
         RunInfo = 2,
 
-        Default = RuleCount | RunInfo
+        /// <summary>
+        /// Information about the output file if an output path is set.
+        /// </summary>
+        OutputFile = 4,
+
+        /// <summary>
+        /// The default footer output.
+        /// </summary>
+        Default = RuleCount | RunInfo | OutputFile
     }
 }

--- a/src/PSRule/Pipeline/AssertPipeline.cs
+++ b/src/PSRule/Pipeline/AssertPipeline.cs
@@ -181,6 +181,11 @@ namespace PSRule.Pipeline
             return GetWriter();
         }
 
+        protected override PipelineWriter GetOutput(bool writeHost = false)
+        {
+            return base.GetOutput(writeHost: true);
+        }
+
         private AssertWriter GetWriter()
         {
             if (_Writer == null)
@@ -189,7 +194,7 @@ namespace PSRule.Pipeline
                 _Writer = new AssertWriter(
                     option: Option,
                     source: Source,
-                    inner: GetOutput(),
+                    inner: GetOutput(writeHost: true),
                     next: next,
                     style: Option.Output.Style ?? OutputOption.Default.Style.Value,
                     resultVariableName: _ResultVariableName,

--- a/src/PSRule/Pipeline/Output/FileOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/FileOutputWriter.cs
@@ -1,8 +1,10 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.IO;
+using System.Management.Automation;
 using System.Text;
+using System.Threading;
 using PSRule.Configuration;
 using PSRule.Resources;
 
@@ -13,16 +15,20 @@ namespace PSRule.Pipeline.Output
     /// </summary>
     internal sealed class FileOutputWriter : PipelineWriter
     {
+        private const string Source = "PSRule";
+
         private readonly Encoding _Encoding;
         private readonly string _Path;
         private readonly ShouldProcess _ShouldProcess;
+        private readonly bool _WriteHost;
 
-        internal FileOutputWriter(PipelineWriter inner, PSRuleOption option, Encoding encoding, string path, ShouldProcess shouldProcess)
+        internal FileOutputWriter(PipelineWriter inner, PSRuleOption option, Encoding encoding, string path, ShouldProcess shouldProcess, bool writeHost)
             : base(inner, option)
         {
             _Encoding = encoding;
             _Path = path;
             _ShouldProcess = shouldProcess;
+            _WriteHost = writeHost;
         }
 
         public override void WriteObject(object sendToPipeline, bool enumerateCollection)
@@ -35,12 +41,31 @@ namespace PSRule.Pipeline.Output
             var rootedPath = PSRuleOption.GetRootedPath(_Path);
             var parentPath = Directory.GetParent(rootedPath);
             if (!parentPath.Exists && _ShouldProcess(target: parentPath.FullName, action: PSRuleResources.ShouldCreatePath))
-            {
                 Directory.CreateDirectory(path: parentPath.FullName);
-            }
+
             if (_ShouldProcess(target: rootedPath, action: PSRuleResources.ShouldWriteFile))
             {
                 File.WriteAllText(path: rootedPath, contents: o.ToString(), encoding: _Encoding);
+                InfoOutputPath(rootedPath);
+            }
+        }
+
+        private void InfoOutputPath(string rootedPath)
+        {
+            if (!Option.Output.Footer.GetValueOrDefault(OutputOption.Default.Footer.Value).HasFlag(FooterFormat.OutputFile))
+                return;
+
+            var message = string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.InfoOutputPath, rootedPath);
+            if (_WriteHost)
+            {
+                WriteHost(new HostInformationMessage
+                {
+                    Message = message
+                });
+            }
+            else
+            {
+                WriteInformation(new InformationRecord(message, Source));
             }
         }
     }

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -300,7 +300,7 @@ namespace PSRule.Pipeline
             };
         }
 
-        protected PipelineWriter GetOutput()
+        protected virtual PipelineWriter GetOutput(bool writeHost = false)
         {
             // Redirect to file instead
             return !string.IsNullOrEmpty(Option.Output.Path)
@@ -309,7 +309,8 @@ namespace PSRule.Pipeline
                     option: Option,
                     encoding: Option.Output.GetEncoding(),
                     path: Option.Output.Path,
-                    shouldProcess: HostContext.ShouldProcess
+                    shouldProcess: HostContext.ShouldProcess,
+                    writeHost: writeHost
                 )
                 : (PipelineWriter)_Output;
         }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -205,6 +205,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Output written to the following file: &apos;{0}&apos;.
+        /// </summary>
+        internal static string InfoOutputPath {
+            get {
+                return ResourceManager.GetString("InfoOutputPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported..
         /// </summary>
         internal static string InvalidErrorAction {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -336,4 +336,7 @@
   <data name="RuleSuppressionGroupExtendedCount" xml:space="preserve">
     <value>{0} rule/s were suppressed by suppression group '{1}' for '{2}'. {3}</value>
   </data>
+  <data name="InfoOutputPath" xml:space="preserve">
+    <value>Output written to the following file: '{0}'</value>
+  </data>
 </root>


### PR DESCRIPTION
## PR Summary

 - Added informational message when output has been written to disk.

Fixes #1074 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
