### PR TITLE
Added object path descendant selector #1133

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.2.0-B0089:
+
+- General improvements:
+  - Added descendant selector to object path syntax.
+    [#1133](https://github.com/microsoft/PSRule/issues/1133)
+    - Use `..` to traverse into child objects, for example `$..name` finds names for all nested objects.
+
 ## v2.2.0-B0089 (pre-release)
 
 What's changed since pre-release v2.2.0-B0052:

--- a/src/PSRule/Runtime/ObjectPath/PathTokenizer.cs
+++ b/src/PSRule/Runtime/ObjectPath/PathTokenizer.cs
@@ -173,12 +173,13 @@ namespace PSRule.Runtime.ObjectPath
 
             private bool TryConsumeBooleanExpression(ref int position, ITokenWriter tokens)
             {
-                if (!TryConsumeRef(ref position, tokens) && !TryConsumeDotSelector(ref position, tokens) && !TryConsumeNot(ref position, tokens))
+                if (!TryConsumeRef(ref position, tokens) && !TryConsumeDescendantSelector(ref position, tokens) && !TryConsumeDotSelector(ref position, tokens) && !TryConsumeNot(ref position, tokens))
                     return false;
 
                 if (tokens.Last.Type == PathTokenType.NotOperator)
                     TryConsumeRef(ref position, tokens);
 
+                TryConsumeDescendantSelector(ref position, tokens);
                 TryConsumeDotSelector(ref position, tokens);
                 TryConsumeComparisonOperator(ref position, tokens);
                 TryConsumePrimitive(ref position, tokens);

--- a/tests/PSRule.Tests/PathExpressionTests.cs
+++ b/tests/PSRule.Tests/PathExpressionTests.cs
@@ -259,6 +259,36 @@ namespace PSRule
             Assert.Equal("3", actual[0]);
         }
 
+        [Fact]
+        public void WithDescendant()
+        {
+            var testObject = GetJsonContent();
+
+            var expression = PathExpression.Create("$[*]..Value2");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject, true, out object[] actual));
+            Assert.NotNull(actual);
+            Assert.Single(actual);
+            Assert.Equal(2L, actual[0]);
+
+            expression = PathExpression.Create("$[*]..id");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject, true, out actual));
+            Assert.NotNull(actual);
+            Assert.Equal(4, actual.Length);
+            Assert.Equal("1", actual[0]);
+            Assert.Equal("2", actual[1]);
+            Assert.Equal("1", actual[2]);
+            Assert.Equal("2", actual[3]);
+
+            expression = PathExpression.Create("$[?@..Value2].TargetName");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject, true, out actual));
+            Assert.NotNull(actual);
+            Assert.Single(actual);
+            Assert.Equal("TestObject2", actual[0]);
+        }
+
         #region Helper methods
 
         private object GetJsonContent()

--- a/tests/PSRule.Tests/PathTokenizerTests.cs
+++ b/tests/PSRule.Tests/PathTokenizerTests.cs
@@ -375,6 +375,7 @@ namespace PSRule
             var path = new string[]
             {
                 "$[?@.Spec.Properties.Kind].TargetName",
+                "$[?@..Value2].TargetName",
             };
 
             // $[?@.Spec.Properties.Kind].TargetName
@@ -392,6 +393,18 @@ namespace PSRule
             Assert.Equal(PathTokenType.EndFilter, actual[6].Type);
             Assert.Equal(PathTokenType.DotSelector, actual[7].Type);
             Assert.Equal("TargetName", actual[7].As<string>());
+
+            // $[?@.Spec.Properties.Kind].TargetName
+            actual = PathTokenizer.Get(path[1]);
+            Assert.Equal(6, actual.Length);
+            Assert.Equal(PathTokenType.RootRef, actual[0].Type);
+            Assert.Equal(PathTokenType.StartFilter, actual[1].Type);
+            Assert.Equal(PathTokenType.CurrentRef, actual[2].Type);
+            Assert.Equal(PathTokenType.DescendantSelector, actual[3].Type);
+            Assert.Equal("Value2", actual[3].As<string>());
+            Assert.Equal(PathTokenType.EndFilter, actual[4].Type);
+            Assert.Equal(PathTokenType.DotSelector, actual[5].Type);
+            Assert.Equal("TargetName", actual[5].As<string>());
         }
 
         [Fact]


### PR DESCRIPTION
## PR Summary

- Added descendant selector to object path syntax.
  [#1133](https://github.com/microsoft/PSRule/issues/1133)
  - Use `..` to traverse into child objects, for example `$..name` finds names for all nested objects.

Fixes #1133 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
