### PR TITLE
Fix NuGet compile issue #1140

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -69,6 +69,7 @@
         "Gitter",
         "hashtable",
         "Kubernetes",
+        "Newtonsoft",
         "NOTCOUNT",
         "proxied",
         "PSRULE",

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- Bug fixes:
+  - Fixed issue building a PSRule project by removing PSRule.psd1 from compile target.
+    [#1140](https://github.com/microsoft/PSRule/issues/1140)
+
 ## v2.2.0-B0131 (pre-release)
 
 What's changed since pre-release v2.2.0-B0089:

--- a/src/PSRule.SDK/PSRule.SDK.csproj
+++ b/src/PSRule.SDK/PSRule.SDK.csproj
@@ -17,6 +17,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
+    <Compile Remove="PSRule.psd1;" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## PR Summary

- Fixed issue building a PSRule project by removing PSRule.psd1 from compile target.

Fixes #1140 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
