### PR TITLE
Pre-release v2.2.0-B0175

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.2.0-B0175 (pre-release)
+
+What's changed since pre-release v2.2.0-B0131:
+
 - Bug fixes:
   - Fixed issue building a PSRule project by removing PSRule.psd1 from compile target.
     [#1140](https://github.com/microsoft/PSRule/issues/1140)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v2.2.0-B0131:

- Bug fixes:
  - Fixed issue building a PSRule project by removing PSRule.psd1 from compile target.
    [#1140](https://github.com/microsoft/PSRule/issues/1140)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
