### PR TITLE
Update pathing for SDK package #1146

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v2.2.0:
+
+- Bug fixes:
+  - Fixed path within SDK package causes `psd1` to compile by @BernieWhite.
+    [#1146](https://github.com/microsoft/PSRule/issues/1146)
+
 ## v2.2.0
 
 What's changed since v2.1.0:

--- a/src/PSRule.SDK/PSRule.SDK.csproj
+++ b/src/PSRule.SDK/PSRule.SDK.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>Microsoft.PSRule.SDK</AssemblyName>
     <PackageId>Microsoft.PSRule.SDK</PackageId>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +14,7 @@
   <ItemGroup>
     <Content Include="PSRule.psd1;">
       <PackageCopyToOutput>true</PackageCopyToOutput>
-      <PackagePath>contentFiles\any\any\Modules\PSRule\;content\Modules\PSRule\</PackagePath>
+      <PackagePath>contentFiles\any\any\Modules\PSRule;content\Modules\PSRule</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>


### PR DESCRIPTION
## PR Summary

- Fixed path within SDK package causes `psd1` to compile.

Fixes #1146 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
