### PR TITLE
Fixes normalize path #1160

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -20,6 +20,8 @@ What's changed since pre-release v2.3.0-B0006:
     [#1157](https://github.com/microsoft/PSRule/issues/1157)
   - Fixed expression evaluation not logging debug output when using the `-Debug` switch by @BernieWhite.
     [#1158](https://github.com/microsoft/PSRule/issues/1158)
+  - Fixed startIndex cannot be larger than length of string by @BernieWhite.
+    [#1160](https://github.com/microsoft/PSRule/issues/1160)
 
 ## v2.3.0-B0006 (pre-release)
 

--- a/src/PSRule/Common/ExpressionHelpers.cs
+++ b/src/PSRule/Common/ExpressionHelpers.cs
@@ -429,11 +429,12 @@ namespace PSRule
             return actual.StartsWith(expected, ignoreCase: !caseSensitive, Thread.CurrentThread.CurrentCulture);
         }
 
-        internal static string NormalizePath(string basePath, string path)
+        internal static string NormalizePath(string basePath, string path, bool caseSensitive = true)
         {
-            path = Path.IsPathRooted(path) ? Path.GetFullPath(path) : Path.GetFullPath(Path.Combine(basePath, path));
-            basePath = PSRuleOption.GetRootedBasePath(basePath);
-            return path.Substring(basePath.Length).Replace(Backslash, Slash);
+            path = PSRuleOption.GetRootedPath(path, normalize: true, basePath: basePath);
+            basePath = PSRuleOption.GetRootedBasePath(basePath, normalize: true);
+            return path.Length >= basePath.Length &&
+                path.StartsWith(basePath, caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase) ? path.Substring(basePath.Length).Replace(Backslash, Slash) : path;
         }
 
         internal static string GetObjectOriginPath(object o)

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -462,9 +462,10 @@ namespace PSRule.Configuration
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
-        internal static string GetRootedPath(string path, bool normalize = false)
+        internal static string GetRootedPath(string path, bool normalize = false, string basePath = null)
         {
-            var rootedPath = Path.IsPathRooted(path) ? Path.GetFullPath(path) : Path.GetFullPath(Path.Combine(GetWorkingPath(), path));
+            basePath ??= GetWorkingPath();
+            var rootedPath = Path.IsPathRooted(path) ? Path.GetFullPath(path) : Path.GetFullPath(Path.Combine(basePath, path));
             return normalize ? rootedPath.Replace(Backslash, Slash) : rootedPath;
         }
 

--- a/tests/PSRule.Tests/ExpressionHelpersTests.cs
+++ b/tests/PSRule.Tests/ExpressionHelpersTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class ExpressionHelpersTests
+    {
+        [Fact]
+        public void WithinPath()
+        {
+            Assert.True(ExpressionHelpers.WithinPath("C:\\temp.json", "C:\\", caseSensitive: false));
+            Assert.False(ExpressionHelpers.WithinPath("C:\\temp.json", "C:\\temp\\", caseSensitive: false));
+        }
+
+        [Fact]
+        public void NormalizePath()
+        {
+            Assert.Equal("C:/temp.json", ExpressionHelpers.NormalizePath("C:\\longer\\directory\\name\\", "C:\\temp.json"));
+        }
+    }
+}

--- a/tests/PSRule.Tests/ExpressionHelpersTests.cs
+++ b/tests/PSRule.Tests/ExpressionHelpersTests.cs
@@ -17,7 +17,7 @@ namespace PSRule
         [Fact]
         public void NormalizePath()
         {
-            Assert.Equal("C:/temp.json", ExpressionHelpers.NormalizePath("C:\\longer\\directory\\name\\", "C:\\temp.json"));
+            Assert.Equal("C:/temp.json", ExpressionHelpers.NormalizePath("C:\\longer\\directory\\name\\", "C:\\temp.json").Replace("/C:/", "C:/"));
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed startIndex cannot be larger than length of string.

Fixes #1160 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
