### PR TITLE
Remove mdx_truly_sane_lists from docs CI

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -115,7 +115,6 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.details
-  - mdx_truly_sane_lists
   - pymdownx.tasklist
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,5 +4,4 @@ pymdown-extensions==9.5
 mike==1.1.2
 mkdocs-simple-hooks==0.1.5
 mkdocs-git-revision-date-plugin==0.3.2
-mdx-truly-sane-lists==1.2
 mkdocs-redirects==1.0.4


### PR DESCRIPTION
## PR Summary

- Removed `mdx_truly_sane_lists` python module as it is failing to install and blocking CI process.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
