### PR TITLE
Report full path in detailed results #1169

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.3.0-B0015:
+
+- General improvements
+  - Improved reporting of full object path from pre-processed results by @BernieWhite.
+    [#1169](https://github.com/microsoft/PSRule/issues/1169)
+
 ## v2.3.0-B0015 (pre-release)
 
 What's changed since pre-release v2.3.0-B0006:

--- a/src/PSRule/Commands/RuleKeyword.cs
+++ b/src/PSRule/Commands/RuleKeyword.cs
@@ -83,7 +83,7 @@ namespace PSRule.Commands
 
         protected static void WriteReason(string path, string text, params object[] args)
         {
-            RunspaceContext.CurrentThread.WriteReason(new ResultReason(Operand.FromPath(path), text, args));
+            RunspaceContext.CurrentThread.WriteReason(new ResultReason(RunspaceContext.CurrentThread.TargetObject.Path, Operand.FromPath(path), text, args));
         }
 
         protected static bool TryReason(string path, string text, object[] args)

--- a/src/PSRule/Common/ExpressionHelpers.cs
+++ b/src/PSRule/Common/ExpressionHelpers.cs
@@ -455,7 +455,7 @@ namespace PSRule
             }
             else if (targetInfo != null)
             {
-                return PSRuleOption.GetRootedPath(targetInfo.Path, normalize: true);
+                return PSRuleOption.GetRootedPath(targetInfo.File, normalize: true);
             }
             else if (baseObject is string s)
             {

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -17,6 +17,7 @@ namespace PSRule
     {
         private const string PROPERTY_SOURCE = "source";
         private const string PROPERTY_ISSUE = "issue";
+        private const string PROPERTY_PATH = "path";
 
         public static T PropertyValue<T>(this PSObject o, string propertyName)
         {
@@ -90,8 +91,8 @@ namespace PSRule
             if (TryTargetInfo(o, out targetInfo))
                 return;
 
-            targetInfo = new PSRuleTargetInfo();
-            o.Members.Add(targetInfo);
+            o.Members.Add(new PSRuleTargetInfo());
+            TryTargetInfo(o, out targetInfo);
         }
 
         public static void SetTargetInfo(this PSObject o, PSRuleTargetInfo targetInfo)
@@ -115,12 +116,21 @@ namespace PSRule
             return o.TryTargetInfo(out var targetInfo) ? targetInfo.Issue.ToArray() : Array.Empty<TargetIssueInfo>();
         }
 
+        public static string GetTargetPath(this PSObject o)
+        {
+            return o.TryTargetInfo(out var targetInfo) ? targetInfo.Path : string.Empty;
+        }
+
         public static void ConvertTargetInfoProperty(this PSObject o)
         {
             if (o == null || !TryProperty(o, PSRuleTargetInfo.PropertyName, out PSObject value))
                 return;
 
             UseTargetInfo(o, out var targetInfo);
+            if (TryProperty(value, PROPERTY_PATH, out string path) && targetInfo.Path == null)
+            {
+                targetInfo.Path = path;
+            }
             if (TryProperty(value, PROPERTY_SOURCE, out Array sources))
             {
                 for (var i = 0; i < sources.Length; i++)

--- a/src/PSRule/Configuration/InputOption.cs
+++ b/src/PSRule/Configuration/InputOption.cs
@@ -117,7 +117,7 @@ namespace PSRule.Configuration
         public bool? IgnoreGitPath { get; set; }
 
         /// <summary>
-        /// Determines if objects are ignore based on their file source path.
+        /// Determines if objects are ignored based on their file source path.
         /// </summary>
         [DefaultValue(null)]
         public bool? IgnoreObjectSource { get; set; }

--- a/src/PSRule/Definitions/Expressions/ExpressionContext.cs
+++ b/src/PSRule/Definitions/Expressions/ExpressionContext.cs
@@ -76,7 +76,7 @@ namespace PSRule.Definitions.Expressions
                 return;
 
             _Reason ??= new List<ResultReason>();
-            _Reason.Add(new ResultReason(operand, text, args));
+            _Reason.Add(new ResultReason(RunspaceContext.CurrentThread?.TargetObject?.Path, operand, text, args));
         }
 
         public void Reason(string text, params object[] args)
@@ -85,7 +85,7 @@ namespace PSRule.Definitions.Expressions
                 return;
 
             _Reason ??= new List<ResultReason>();
-            _Reason.Add(new ResultReason(null, text, args));
+            _Reason.Add(new ResultReason(RunspaceContext.CurrentThread?.TargetObject?.Path, null, text, args));
         }
 
         internal ResultReason[] GetReasons()

--- a/src/PSRule/Definitions/IRuleResultV2.cs
+++ b/src/PSRule/Definitions/IRuleResultV2.cs
@@ -87,6 +87,11 @@ namespace PSRule.Definitions
         /// </summary>
         string Path { get; }
 
+        /// <summary>
+        /// The object path including the path of the parent object.
+        /// </summary>
+        string FullPath { get; }
+
         string Message { get; }
 
         string Format();

--- a/src/PSRule/Definitions/ResultReason.cs
+++ b/src/PSRule/Definitions/ResultReason.cs
@@ -12,14 +12,23 @@ namespace PSRule.Definitions
         private string _Message;
         private readonly IOperand _Operand;
 
-        internal ResultReason(IOperand operand, string text, object[] args)
+        internal ResultReason(string parentPath, IOperand operand, string text, object[] args)
         {
             _Operand = operand;
             Text = text;
             Args = args;
+            FullPath = ObjectPathJoin(parentPath, operand?.Path);
         }
 
-        public string Path => _Operand.Path;
+        /// <summary>
+        /// The object path that failed.
+        /// </summary>
+        public string Path => _Operand?.Path;
+
+        /// <summary>
+        /// The object path including the path of the parent object.
+        /// </summary>
+        public string FullPath { get; }
 
         public string Text { get; }
 
@@ -46,6 +55,14 @@ namespace PSRule.Definitions
                 Message
             );
             return _Formatted;
+        }
+
+        private string ObjectPathJoin(string parentPath, string path)
+        {
+            if (string.IsNullOrEmpty(parentPath))
+                return path;
+
+            return string.IsNullOrEmpty(path) ? parentPath : string.Concat(parentPath, ".", path);
         }
     }
 }

--- a/src/PSRule/Pipeline/TargetObject.cs
+++ b/src/PSRule/Pipeline/TargetObject.cs
@@ -47,8 +47,11 @@ namespace PSRule.Pipeline
         internal TargetObject(PSObject o, TargetSourceCollection source)
         {
             Value = o;
+            Value.ConvertTargetInfoProperty();
+            Value.ConvertTargetInfoType();
             Source = ReadSourceInfo(source);
             Issue = ReadIssueInfo(null);
+            Path = ReadPath();
             _Annotations = new Dictionary<Type, TargetObjectAnnotation>();
         }
 
@@ -57,6 +60,8 @@ namespace PSRule.Pipeline
         internal TargetSourceCollection Source { get; private set; }
 
         internal TargetIssueCollection Issue { get; private set; }
+
+        internal string Path { get; }
 
         internal Hashtable GetData()
         {
@@ -79,14 +84,17 @@ namespace PSRule.Pipeline
             return (T)value;
         }
 
+        private string ReadPath()
+        {
+            return Value.GetTargetPath();
+        }
+
         private TargetSourceCollection ReadSourceInfo(TargetSourceCollection source)
         {
             var result = source ?? new TargetSourceCollection();
             if (ExpressionHelpers.GetBaseObject(Value) is ITargetInfo targetInfo)
                 result.Add(targetInfo.Source);
 
-            Value.ConvertTargetInfoProperty();
-            Value.ConvertTargetInfoType();
             result.AddRange(Value.GetSourceInfo());
             return result;
         }
@@ -94,7 +102,6 @@ namespace PSRule.Pipeline
         private TargetIssueCollection ReadIssueInfo(TargetIssueCollection issue)
         {
             var result = issue ?? new TargetIssueCollection();
-            Value.ConvertTargetInfoProperty();
             result.AddRange(Value.GetIssueInfo());
             return result;
         }

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -66,7 +66,7 @@ namespace PSRule.Runtime
             if (Result || string.IsNullOrEmpty(text))
                 return;
 
-            _Reason.Add(new ResultReason(operand, text, args));
+            _Reason.Add(new ResultReason(RunspaceContext.CurrentThread?.TargetObject?.Path, operand, text, args));
         }
 
         /// <summary>

--- a/src/PSRule/Runtime/PSRuleMemberInfo.cs
+++ b/src/PSRule/Runtime/PSRuleMemberInfo.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Management.Automation;
 using Newtonsoft.Json;
 using PSRule.Data;
@@ -9,9 +11,12 @@ using PSRule.Resources;
 
 namespace PSRule.Runtime
 {
+    [DebuggerDisplay("Instance = {_Instance}")]
     internal sealed class PSRuleTargetInfo : PSMemberInfo
     {
         internal const string PropertyName = "_PSRule";
+
+        private readonly string _Instance = Guid.NewGuid().ToString();
 
         public PSRuleTargetInfo()
         {
@@ -29,17 +34,21 @@ namespace PSRule.Runtime
             if (targetInfo == null)
                 return;
 
+            Path = targetInfo.Path;
             Source = targetInfo.Source;
             Issue = targetInfo.Issue;
         }
 
-        public string Path
+        public string File
         {
             get
             {
                 return Source.Count == 0 ? null : Source[0].File;
             }
         }
+
+        [JsonProperty(PropertyName = "path")]
+        public string Path { get; set; }
 
         [JsonProperty(PropertyName = "source")]
         public List<TargetSourceInfo> Source { get; internal set; }
@@ -70,7 +79,9 @@ namespace PSRule.Runtime
             if (targetInfo == null)
                 return;
 
+            Path = targetInfo.Path;
             Source.AddUnique(targetInfo?.Source);
+            Issue.AddUnique(targetInfo?.Issue);
         }
 
         internal void WithSource(TargetSourceInfo source)

--- a/tests/PSRule.Tests/ObjectFromFile.json
+++ b/tests/PSRule.Tests/ObjectFromFile.json
@@ -38,6 +38,7 @@
             }
         }, // Some comments
         "_PSRule": {
+            "path": "master.items[0]",
             "source": [
                 {
                     "file": "some-file.json",

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -852,7 +852,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result[0].Source[0].File | Should -Be 'some-file.json';
             $result[0].Source[0].Line | Should -Be 1;
             $result[1].Source[0].File.Split([char[]]@('\', '/'))[-1] | Should -Be 'ObjectFromFile.json';
-            $result[1].Source[0].Line | Should -Be 58;
+            $result[1].Source[0].Line | Should -Be 59;
 
             # Multiple file
             $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputPath $inputFiles);

--- a/tests/PSRule.Tests/TargetInfoTests.cs
+++ b/tests/PSRule.Tests/TargetInfoTests.cs
@@ -49,5 +49,18 @@ namespace PSRule
             Assert.Equal("Issue.1", actual[0].Name);
             Assert.Equal("Some issue", actual[0].Message);
         }
+
+        [Fact]
+        public void TargetPath()
+        {
+            var info = new PSObject();
+            info.Properties.Add(new PSNoteProperty("path", "resources[0]"));
+            var o = new PSObject();
+            o.Properties.Add(new PSNoteProperty("_PSRule", info));
+            o.ConvertTargetInfoProperty();
+
+            var actual = o.GetTargetPath();
+            Assert.Equal("resources[0]", actual);
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

- Improved reporting of full object path from pre-processed results.

Fixes #1169 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
