### PR TITLE
Added full path from JSON objects #1174

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,11 +13,17 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.3.0-B0030:
+
+- General improvements:
+  - Added support for full path from JSON objects by @BernieWhite.
+    [#1174](https://github.com/microsoft/PSRule/issues/1174)
+
 ## v2.3.0-B0030 (pre-release)
 
 What's changed since pre-release v2.3.0-B0015:
 
-- General improvements
+- General improvements:
   - Improved reporting of full object path from pre-processed results by @BernieWhite.
     [#1169](https://github.com/microsoft/PSRule/issues/1169)
 

--- a/src/PSRule/Common/JsonConverters.cs
+++ b/src/PSRule/Common/JsonConverters.cs
@@ -219,6 +219,7 @@ namespace PSRule
         private static PSObject ReadObject(JsonReader reader, bool bindTargetInfo, TargetSourceInfo sourceInfo)
         {
             SkipComments(reader);
+            var path = reader.Path;
             if (reader.TokenType != JsonToken.StartObject || !reader.Read())
                 throw new PipelineSerializationException(PSRuleResources.ReadJsonFailed);
 
@@ -276,6 +277,8 @@ namespace PSRule
             {
                 result.UseTargetInfo(out var info);
                 info.SetSource(sourceInfo?.File, lineNumber, linePosition);
+                if (string.IsNullOrEmpty(info.Path))
+                    info.Path = path;
             }
             return result;
         }

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Management.Automation;
 using System.Threading;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using PSRule.Data;
 using PSRule.Runtime;
 
@@ -118,7 +119,14 @@ namespace PSRule
 
         public static string GetTargetPath(this PSObject o)
         {
-            return o.TryTargetInfo(out var targetInfo) ? targetInfo.Path : string.Empty;
+            if (o == null)
+                return string.Empty;
+
+            if (o.TryTargetInfo(out var targetInfo))
+                return targetInfo.Path;
+
+            var baseObject = o.BaseObject;
+            return baseObject is JToken token ? token.Path : string.Empty;
         }
 
         public static void ConvertTargetInfoProperty(this PSObject o)

--- a/src/PSRule/Runtime/PSRuleMemberInfo.cs
+++ b/src/PSRule/Runtime/PSRuleMemberInfo.cs
@@ -11,12 +11,10 @@ using PSRule.Resources;
 
 namespace PSRule.Runtime
 {
-    [DebuggerDisplay("Instance = {_Instance}")]
+    [DebuggerDisplay("Path = {Path}, File = {File}")]
     internal sealed class PSRuleTargetInfo : PSMemberInfo
     {
         internal const string PropertyName = "_PSRule";
-
-        private readonly string _Instance = Guid.NewGuid().ToString();
 
         public PSRuleTargetInfo()
         {

--- a/tests/PSRule.Tests/InputFormatDeserializerTests.cs
+++ b/tests/PSRule.Tests/InputFormatDeserializerTests.cs
@@ -49,7 +49,9 @@ namespace PSRule
             actual[0].Value.TryTargetInfo(out var info1);
             actual[1].Value.TryTargetInfo(out var info2);
             Assert.Equal("some-file.json", info1.Source[0].File);
+            Assert.Equal("master.items[0]", info1.Path);
             Assert.NotNull(info2.Source[0]);
+            Assert.Equal("[1]", info2.Path);
 
             // Single item
             actual = PipelineReceiverActions.ConvertFromJson(GetJsonContent("Single"), PipelineReceiverActions.PassThru).ToArray();


### PR DESCRIPTION
## PR Summary

- Improved full path support by adding full path from JSON objects.

Fixes #1174 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
