### PR TITLE
Added support for NuGet symbol packages #1173

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -18,6 +18,9 @@ What's changed since pre-release v2.3.0-B0030:
 - General improvements:
   - Added support for full path from JSON objects by @BernieWhite.
     [#1174](https://github.com/microsoft/PSRule/issues/1174)
+- Engineering:
+  - Added publishing support for NuGet symbol packages @BernieWhite.
+    [#1173](https://github.com/microsoft/PSRule/issues/1173)
 
 ## v2.3.0-B0030 (pre-release)
 

--- a/src/PSRule.Badges/PSRule.Badges.csproj
+++ b/src/PSRule.Badges/PSRule.Badges.csproj
@@ -10,10 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="Resources\en.json" />
   </ItemGroup>
 

--- a/src/PSRule.Benchmark/PSRule.Benchmark.csproj
+++ b/src/PSRule.Benchmark/PSRule.Benchmark.csproj
@@ -1,18 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="..\PSRule.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{3ec0912f-bfc7-4b53-a1a1-0ba993c6282e}</ProjectGuid>
-    <Authors>Bernie White</Authors>
-    <RepositoryUrl>https://github.com/microsoft/PSRule</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://aka.ms/ps-rule</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <EnableNuget>false</EnableNuget>
     <IsPackable>false</IsPackable>
-    <Company>Microsoft Corporation</Company>
-    <Copyright>Copyright (c) Microsoft Corporation. Licensed under the MIT License.</Copyright>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/src/PSRule.BuildTool/PSRule.BuildTool.csproj
+++ b/src/PSRule.BuildTool/PSRule.BuildTool.csproj
@@ -1,39 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
+  <Import Project="..\PSRule.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <Authors>Bernie White</Authors>
     <AssemblyTitle>PSRule.BuildTool</AssemblyTitle>
-    <RepositoryUrl>https://github.com/microsoft/PSRule</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://aka.ms/ps-rule</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <EnableNuget>false</EnableNuget>
     <IsPackable>false</IsPackable>
-    <Version>0.0.1</Version>
-    <Company>Microsoft Corporation</Company>
-    <Copyright>Copyright (c) Microsoft Corporation. Licensed under the MIT License.</Copyright>
-    <Description>Tools for building PSRule.
-
-This project uses GitHub Issues to track bugs and feature requests. See GitHub project for more information.</Description>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
-    <DefineConstants>Windows</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/src/PSRule.Common.props
+++ b/src/PSRule.Common.props
@@ -4,10 +4,12 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <DebugType>portable</DebugType>
     <NeutralLanguage>en-US</NeutralLanguage>
     <DebugSymbols>true</DebugSymbols>
-    <NeutralLanguage>en-US</NeutralLanguage>
+    <DebugType>portable</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <!-- Package metadata -->
@@ -43,6 +45,10 @@ This project uses GitHub Issues to track bugs and feature requests. See GitHub p
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\docs\assets\package_icon.png">

--- a/src/PSRule.SDK/README.md
+++ b/src/PSRule.SDK/README.md
@@ -1,3 +1,3 @@
-# PSRule SDK package for .NET
+# PSRule SDK for .NET
 
-This is a meta package that contains PSRule libraries for .NET.
+This package allows you to consume PSRule for .NET.

--- a/src/PSRule.Tool/PSRule.Tool.csproj
+++ b/src/PSRule.Tool/PSRule.Tool.csproj
@@ -16,10 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">

--- a/src/PSRule/PSRule.csproj
+++ b/src/PSRule/PSRule.csproj
@@ -12,10 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Manatee.Json" Version="13.0.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/PSRule/README.md
+++ b/src/PSRule/README.md
@@ -1,3 +1,4 @@
 # PSRule library for .NET
 
-Microsoft.PSRule provides core functionality of PSRule.
+Provides core functionality of PSRule.
+To consume, use Microsoft.PSRule.SDK.


### PR DESCRIPTION
## PR Summary

- Added support for publishing symbols with NuGet packages.

Fixes #1173 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
