### PR TITLE
Added PathPrefix method to add path prefix #1198

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.3.0-B0130:
+
+- General improvements:
+  - Added `PathPrefix` method to add an object path prefix to assertion reasons by @BernieWhite.
+    [#1198](https://github.com/microsoft/PSRule/issues/1198)
+
 ## v2.3.0-B0130 (pre-release)
 
 What's changed since pre-release v2.3.0-B0100:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -1663,6 +1663,9 @@ The following methods are available:
   This method can be chained, similar to `Reason`.
 - `ReasonIf(<string> path, <bool> condition, <string> text, params <object[]> args)` - Replaces the reason if the condition is true.
   This method can be chained, similar to `ReasonFrom`.
+- `PathPrefix(<string> path)` - Adds a path prefix to any reasons.
+  This method can be chained.
+  For usage see examples below.
 - `GetReason()` - Gets any reasons currently associated with the failed result.
 - `Complete()` - Returns `$True` (Pass) or `$False` (Fail) to the rule record.
   If the assertion failed, any reasons are automatically added to the rule record.
@@ -1698,6 +1701,17 @@ Rule 'Assert.HasCustomValue' {
     $Assert.
         HasDefaultValue($TargetObject, 'value', 'test').
         Reason($LocalizedData.NonDefaultValue, 'value', $TargetObject.value)
+}
+```
+
+In this example, the built-in reason has a path prefix added to any reasons.
+
+```powershell
+Rule 'Assert.ChildHasFieldValue' {
+    $items = @($TargetObject.items)
+    for ($i = 0; $i -lt $items.Length; $i++) {
+        $Assert.HasFieldValue($items[$i], 'Name').PathPrefix("items[$i]")
+    }
 }
 ```
 

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -90,6 +90,18 @@ namespace PSRule.Runtime
         }
 
         /// <summary>
+        /// Adds a logical path prefix on to each reason path.
+        /// </summary>
+        /// <param name="prefix">A string to prefix on each path.</param>
+        public AssertResult PathPrefix(string prefix)
+        {
+            for (var i = 0; _Reason != null && i < _Reason.Count; i++)
+                _Reason[i].Prefix = prefix;
+
+            return this;
+        }
+
+        /// <summary>
         /// Replace the existing reason with the supplied format string.
         /// </summary>
         /// <param name="text">The text of a reason to use. This text should already be localized for the currently culture.</param>

--- a/src/PSRule/Runtime/Operand.cs
+++ b/src/PSRule/Runtime/Operand.cs
@@ -60,6 +60,11 @@ namespace PSRule.Runtime
         /// The object path to the operand.
         /// </summary>
         string Path { get; }
+
+        /// <summary>
+        /// A logical prefix to add to the object path.
+        /// </summary>
+        string Prefix { get; set; }
     }
 
     internal sealed class Operand : IOperand
@@ -79,6 +84,8 @@ namespace PSRule.Runtime
         public object Value { get; }
 
         public string Path { get; }
+
+        public string Prefix { get; set; }
 
         public OperandKind Kind { get; }
 
@@ -109,7 +116,13 @@ namespace PSRule.Runtime
 
         public override string ToString()
         {
-            return string.IsNullOrEmpty(Path) || Kind == OperandKind.Target ? null : string.Concat(Enum.GetName(typeof(OperandKind), Kind), " ", Path, ": ");
+            return string.IsNullOrEmpty(Path) || Kind == OperandKind.Target ? null : OperandString();
+        }
+
+        private string OperandString()
+        {
+            var kind = Enum.GetName(typeof(OperandKind), Kind);
+            return string.IsNullOrEmpty(Prefix) ? string.Concat(kind, " ", Path, ": ") : string.Concat(kind, " ", Prefix, ".", Path, ": ");
         }
     }
 }

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -79,6 +79,10 @@ namespace PSRule
             Assert.Equal("Path value2: New New Reason", actual1.ToString());
             Assert.Equal("Path value2: New New Reason", actual1.GetReason()[0]);
 
+            // WithPathPrefix
+            actual1.PathPrefix("resources[0]");
+            Assert.Equal("Path resources[0].value2: New New Reason", actual1.GetReason()[0]);
+
             // Aggregate results
             Assert.True(assert.AnyOf(actual2, actual3).Result);
             Assert.True(assert.AnyOf(actual2).Result);
@@ -91,8 +95,8 @@ namespace PSRule
             Assert.Equal("Fail reason", test1.GetReason()[0]);
 
             var test2 = assert.AllOf(actual1, actual2, actual3);
-            Assert.Equal("Path value2: New New Reason Fail reason", test2.ToString());
-            Assert.Equal(new string[] { "Path value2: New New Reason", "Fail reason" }, test2.GetReason());
+            Assert.Equal("Path resources[0].value2: New New Reason Fail reason", test2.ToString());
+            Assert.Equal(new string[] { "Path resources[0].value2: New New Reason", "Fail reason" }, test2.GetReason());
             Assert.True(assert.AllOf(actual2, actual2).Result);
             Assert.True(assert.AllOf(actual2).Result);
             Assert.False(assert.AllOf().Result);

--- a/tests/PSRule.Tests/FromFile.Rule.ps1
+++ b/tests/PSRule.Tests/FromFile.Rule.ps1
@@ -472,3 +472,8 @@ Rule 'PS1RuleWarningLevel' -Level 'Warning' -Tag @{ test = 'Level' } {
 Rule 'PS1RuleInfoLevel' -Level 'Information' -Tag @{ test = 'Level' } {
     $Assert.HasFieldValue($TargetObject, 'name', 'TestObject1');
 }
+
+# Synopsis: Test WithPathPrefix.
+Rule 'WithPathPrefix' {
+    $Assert.HasFieldValue($TargetObject, 'Name', 'TestValue').PathPrefix('item');
+}

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1320,7 +1320,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
                 $warningMessages = $outwarnings.ToArray();
-                $warningMessages.Length | Should -Be 152;
+                $warningMessages.Length | Should -Be 154;
 
                 $warningMessages | Should -BeOfType [System.Management.Automation.WarningRecord];
                 $warningMessages.Message | Should -MatchExactly "Rule '.\\[a-zA-Z0-9]+' was suppressed by suppression group '.\\SuppressWithTargetNameAnd(Null|Empty)Rule' for 'TestObject[1-2]'. Ignore test objects for all \((null|empty)\) rules."
@@ -1364,9 +1364,9 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
                 $warningMessages.Length | Should -Be 2;
 
                 $warningMessages[0] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[0].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'. Ignore test objects for all (null) rules."
+                $warningMessages[0].Message | Should -BeExactly "77 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndNullRule' for 'TestObject1'. Ignore test objects for all (null) rules."
                 $warningMessages[1] | Should -BeOfType [System.Management.Automation.WarningRecord];
-                $warningMessages[1].Message | Should -BeExactly "76 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'. Ignore test objects for all (empty) rules."
+                $warningMessages[1].Message | Should -BeExactly "77 rule/s were suppressed by suppression group '.\SuppressWithTargetNameAndEmptyRule' for 'TestObject2'. Ignore test objects for all (empty) rules."
             }
 
             It 'No warnings' {


### PR DESCRIPTION
## PR Summary

- Added `PathPrefix` method to add an object path prefix to assertion reasons.

Fixes #1198 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
