### PR TITLE
Pre-release v2.3.0-B0163

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,11 +13,16 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.3.0-B0163 (pre-release)
+
 What's changed since pre-release v2.3.0-B0130:
 
 - General improvements:
   - Added `PathPrefix` method to add an object path prefix to assertion reasons by @BernieWhite.
     [#1198](https://github.com/microsoft/PSRule/issues/1198)
+- Engineering:
+  - Bump xunit to v2.4.2.
+    [#1200](https://github.com/microsoft/PSRule/pull/1200)
 
 ## v2.3.0-B0130 (pre-release)
 


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v2.3.0-B0130:

- General improvements:
  - Added `PathPrefix` method to add an object path prefix to assertion reasons by @BernieWhite.
    [#1198](https://github.com/microsoft/PSRule/issues/1198)
- Engineering:
  - Bump xunit to v2.4.2.
    [#1200](https://github.com/microsoft/PSRule/pull/1200)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
