### PR TITLE
Fixes object path for self identifier #1204

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,6 +89,7 @@
     "omnisharp.enableEditorConfigSupport": true,
     "omnisharp.enableRoslynAnalyzers": true,
     "git.branchProtection": [
-        "main"
+        "main",
+        "release/*"
     ]
 }

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,6 +13,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v2.3.0:
+
+- Bug fixes:
+  - Fixed object path join handling of self path identifier by @BernieWhite.
+    [#1204](https://github.com/microsoft/PSRule/issues/1204)
+
 ## v2.3.0
 
 What's changed since v2.2.0:

--- a/src/PSRule/Definitions/ResultReason.cs
+++ b/src/PSRule/Definitions/ResultReason.cs
@@ -92,22 +92,14 @@ namespace PSRule.Definitions
             return _Formatted;
         }
 
-        private string ObjectPathJoin(string parentPath, string path)
-        {
-            if (string.IsNullOrEmpty(parentPath))
-                return path;
-
-            return string.IsNullOrEmpty(path) ? parentPath : string.Concat(parentPath, ".", path);
-        }
-
         private string GetPath()
         {
-            return ObjectPathJoin(Prefix, Operand?.Path);
+            return Runtime.Operand.JoinPath(Prefix, Operand?.Path);
         }
 
         private string GetFullPath()
         {
-            return ObjectPathJoin(_ParentPath, Path);
+            return Runtime.Operand.JoinPath(_ParentPath, Path);
         }
     }
 }

--- a/src/PSRule/Runtime/Operand.cs
+++ b/src/PSRule/Runtime/Operand.cs
@@ -69,6 +69,9 @@ namespace PSRule.Runtime
 
     internal sealed class Operand : IOperand
     {
+        private const string Dot = ".";
+        private const string Space = " ";
+
         private Operand(OperandKind kind, object value)
         {
             Kind = kind;
@@ -114,6 +117,14 @@ namespace PSRule.Runtime
             return new Operand(OperandKind.Target, null, null);
         }
 
+        internal static string JoinPath(string p1, string p2)
+        {
+            if (IsEmptyPath(p1))
+                return p2;
+
+            return IsEmptyPath(p2) ? p1 : string.Concat(p1, Dot, p2);
+        }
+
         public override string ToString()
         {
             return string.IsNullOrEmpty(Path) || Kind == OperandKind.Target ? null : OperandString();
@@ -122,7 +133,14 @@ namespace PSRule.Runtime
         private string OperandString()
         {
             var kind = Enum.GetName(typeof(OperandKind), Kind);
-            return string.IsNullOrEmpty(Prefix) ? string.Concat(kind, " ", Path, ": ") : string.Concat(kind, " ", Prefix, ".", Path, ": ");
+            return IsEmptyPath(Prefix) ? string.Concat(kind, Space, Path, ": ") : string.Concat(kind, Space, Prefix, Dot, Path, ": ");
+        }
+
+        private static bool IsEmptyPath(string s)
+        {
+            return string.IsNullOrEmpty(s) ||
+                string.IsNullOrWhiteSpace(s) ||
+                s == Dot;
         }
     }
 }

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -82,6 +82,10 @@ namespace PSRule
             // WithPathPrefix
             actual1.PathPrefix("resources[0]");
             Assert.Equal("Path resources[0].value2: New New Reason", actual1.GetReason()[0]);
+            actual4.PathPrefix("resources[0]");
+            Assert.Equal("Path resources[0].Name: Test reason", actual4.GetReason()[0]);
+            actual4.PathPrefix(".");
+            Assert.Equal("Path Name: Test reason", actual4.GetReason()[0]);
 
             // Aggregate results
             Assert.True(assert.AnyOf(actual2, actual3).Result);


### PR DESCRIPTION
## PR Summary

- Fixed handling of object path joins when self-identifier is used.

Fixes #1204 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
