### PR TITLE
Fixes repository information not in output #1219

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -20,6 +20,9 @@ What's changed since v2.3.2:
     [#1209](https://github.com/microsoft/PSRule/issues/1209)
   - Bump Microsoft.NET.Test.Sdk to v17.3.0.
     [#1213](https://github.com/microsoft/PSRule/pull/1208)
+- Bug fixes:
+  - Fixed repository information not in output by @BernieWhite.
+    [#1219](https://github.com/microsoft/PSRule/issues/1219)
 
 ## v2.3.2
 

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -776,8 +776,8 @@
                 "url": {
                     "type": "string",
                     "title": "Repository URL",
-                    "description": "The URL to the repository.",
-                    "markdownDescription": "The URL to the repository."
+                    "description": "Sets the repository URL reported in output. By default, the repository URL is detected from environment variables set by the build system.",
+                    "markdownDescription": "Sets the repository URL reported in output. By default, the repository URL is detected from environment variables set by the build system. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#repositoryurl)"
                 }
             },
             "additionalProperties": false

--- a/src/PSRule/Common/GitHelper.cs
+++ b/src/PSRule/Common/GitHelper.cs
@@ -10,8 +10,8 @@ namespace PSRule
     /// Helper for working with Git and CI tools.
     /// </summary>
     /// <remarks>
-    /// Azure Pipelines: https://docs.microsoft.com/azure/devops/pipelines/build/variables
-    /// GitHub Actions: https://docs.github.com/actions/learn-github-actions/environment-variables#default-environment-variables
+    /// Docs for <seealso href="https://docs.microsoft.com/azure/devops/pipelines/build/variables">Azure Pipelines</seealso> and
+    /// <seealso href="https://docs.github.com/actions/learn-github-actions/environment-variables#default-environment-variables">GitHub Actions</seealso>.
     /// </remarks>
     internal static class GitHelper
     {

--- a/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/AssertFormatter.cs
@@ -410,7 +410,8 @@ namespace PSRule.Pipeline.Formatters
             if (!Option.Output.Banner.GetValueOrDefault(BannerFormat.Default).HasFlag(BannerFormat.RepositoryInfo))
                 return;
 
-            if (!GitHelper.TryRepository(out var repository))
+            var repository = Option.Repository.Url;
+            if (string.IsNullOrEmpty(repository))
                 return;
 
             WriteLineFormat(FormatterStrings.Repository_Url, repository);

--- a/src/PSRule/Pipeline/Output/SarifOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/SarifOutputWriter.cs
@@ -53,7 +53,7 @@ namespace PSRule.Pipeline.Output
         /// </remarks>
         private static IList<VersionControlDetails> GetVersionControl(RepositoryOption option)
         {
-            var repository = option.Url ?? (GitHelper.TryRepository(out var url) ? url : null);
+            var repository = option.Url;
             return new List<VersionControlDetails>()
             {
                 new VersionControlDetails

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -193,6 +193,7 @@ namespace PSRule.Pipeline
             Option.Output = new OutputOption(option.Output);
             Option.Output.Outcome = Option.Output.Outcome ?? OutputOption.Default.Outcome;
             Option.Output.Banner = Option.Output.Banner ?? OutputOption.Default.Banner;
+            Option.Repository = GetRepository(Option.Repository);
             return this;
         }
 
@@ -353,6 +354,15 @@ namespace PSRule.Pipeline
                 result.AddRange(parent);
 
             return result.Count == 0 ? null : result.ToArray();
+        }
+
+        protected static RepositoryOption GetRepository(RepositoryOption repository)
+        {
+            var result = new RepositoryOption(repository);
+            if (string.IsNullOrEmpty(result.Url) && GitHelper.TryRepository(out var url))
+                result.Url = url;
+
+            return result;
         }
 
         protected PathFilter GetInputObjectSourceFilter()

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -1667,6 +1667,11 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     }
 
     Context 'Read Repository.Url' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Repository.Url | Should -BeNullOrEmpty;
+        }
+
         It 'from Hashtable' {
             $option = New-PSRuleOption -Option @{ 'Repository.Url' = 'https://github.com/microsoft/PSRule.UnitTest' };
             $option.Repository.Url | Should -Be 'https://github.com/microsoft/PSRule.UnitTest';


### PR DESCRIPTION
## PR Summary

- Fixed repository information not in output.

Fixes #1219 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
