### PR TITLE
Added initial function support #1227

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,6 +58,18 @@
         ],
         "files.insertFinalNewline": true
     },
+    "[jsonc]": {
+        "editor.tabSize": 4,
+        "editor.tabCompletion": "on",
+        "editor.quickSuggestions": {
+            "strings": true
+        },
+        "editor.suggest.insertMode": "replace",
+        "gitlens.codeLens.scopes": [
+            "document"
+        ],
+        "files.insertFinalNewline": true
+    },
     "files.associations": {
         "**/.azure-pipelines/*.yaml": "azure-pipelines",
         "**/.azure-pipelines/jobs/*.yaml": "azure-pipelines",
@@ -67,6 +79,7 @@
         "APPSERVICEMININSTANCECOUNT",
         "cmdlet",
         "cmdlets",
+        "concat",
         "datetime",
         "deserialize",
         "deserialized",

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -11,7 +11,20 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
   [2]: https://microsoft.github.io/PSRule/latest/deprecations/#deprecations-for-v3
 
+**Experimental features**:
+
+- Functions within YAML expressions can be used to perform manipulation prior to testing a condition.
+
 ## Unreleased
+
+What's changed since pre-release v2.4.0-B0022:
+
+- New features:
+  - **Experimental**: Added support for functions within YAML and JSON expressions.
+    [#1227](https://github.com/microsoft/PSRule/issues/1227)
+    - Added conversion functions `boolean`, `string`, and `integer`.
+    - Added lookup functions `configuration`, and `path`.
+    - Added string functions `concat`, `substring`.
 
 ## v2.4.0-B0022 (pre-release)
 

--- a/docs/expressions/functions.md
+++ b/docs/expressions/functions.md
@@ -1,0 +1,127 @@
+# Expression functions
+
+!!! Abstract
+    Functions are an advanced lanaguage feature specific to YAML and JSON resources.
+    That extend the language to allow for more complex use cases with expressions.
+
+!!! Experimental
+    Functions are a work in progress and subject to change.
+    We hope to add more functions, broader support, and more detailed documentation in the future.
+    [Join or start a disucssion][1] to let us know how we can improve this feature going forward.
+
+  [1]: https://github.com/microsoft/PSRule/discussions
+
+## Using functions
+
+It may be necessary to perform minor transformation before evaluating a condition.
+
+- `boolean` - Convert a value to a boolean.
+- `string` - Convert a value to a string.
+- `integer` - Convert a value to an integer.
+- `concat` - Concatenate multiple values.
+- `substring` - Extract a substring from a string.
+- `configuration` - Get a configuration value.
+- `path` - Get a value from an object path.
+
+## Supported conditions
+
+Currently functions are only supported on a subset of conditions.
+The conditions that are supported are:
+
+- `equals`
+- `notEquals`
+- `count`
+- `less`
+- `lessOrEquals`
+- `greater`
+- `greaterOrEquals`
+
+## Examples
+
+```yaml
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example1
+spec:
+  if:
+    value:
+      $:
+        substring:
+          path: name
+        length: 7
+    equals: TestObj
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example2
+spec:
+  if:
+    value:
+      $:
+        configuration: 'ConfigArray'
+    count: 5
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example3
+spec:
+  if:
+    value:
+      $:
+        boolean: true
+    equals: true
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example4
+spec:
+  if:
+    value:
+      $:
+        concat:
+        - path: name
+        - string: '-'
+        - path: name
+    equals: TestObject1-TestObject1
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example5
+spec:
+  if:
+    value:
+      $:
+        integer: 6
+    greater: 5
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example6
+spec:
+  if:
+    value: TestObject1-TestObject1
+    equals:
+      $:
+        concat:
+        - path: name
+        - string: '-'
+        - path: name
+```

--- a/docs/specs/function-spec.md
+++ b/docs/specs/function-spec.md
@@ -1,0 +1,34 @@
+# PSRule function expressions spec (draft)
+
+This is a spec for implementing function expressions in PSRule v2.
+
+## Synopsis
+
+Functions are available to handle complex conditions within YAML and JSON expressions.
+
+## Schema driven
+
+While functions allow handing for complex use cases, they should still remain schema driven.
+A schema driven design allows auto-completion and validation during authoring in a broad set of tools.
+
+## Syntax
+
+Functions can be used within YAML and JSON expressions by using the `$` object property.
+For example:
+
+```yaml
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example1
+spec:
+  if:
+    value:
+      $:
+        substring:
+          path: name
+        length: 3
+    equals: abc
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,8 @@ nav:
       - Azure resource tagging example: scenarios/azure-tags/azure-tags.md
       - Kubernetes resource validation example: scenarios/kubernetes-resources/kubernetes-resources.md
     - Concepts:
+      - Expressions:
+        - Functions: expressions/functions.md
       - Using within continuous integration: scenarios/validation-pipeline/validation-pipeline.md
     # - Troubleshooting: troubleshooting.md
     - License and contributing: license-contributing.md

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -1,23 +1,26 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
-    "oneOf": [
-        {
-            "$ref": "#/definitions/rule-v1"
-        },
-        {
-            "$ref": "#/definitions/baseline-v1"
-        },
-        {
-            "$ref": "#/definitions/moduleConfig-v1"
-        },
-        {
-            "$ref": "#/definitions/selector-v1"
-        },
-        {
-            "$ref": "#/definitions/suppressionGroup-v1"
-        }
-    ],
+    "$ref": "#/definitions/resource-v1",
     "definitions": {
+        "resource-v1": {
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/rule-v1"
+                },
+                {
+                    "$ref": "#/definitions/baseline-v1"
+                },
+                {
+                    "$ref": "#/definitions/moduleConfig-v1"
+                },
+                {
+                    "$ref": "#/definitions/selector-v1"
+                },
+                {
+                    "$ref": "#/definitions/suppressionGroup-v1"
+                }
+            ]
+        },
         "resource-metadata": {
             "type": "object",
             "title": "Metadata",
@@ -808,6 +811,9 @@
             "oneOf": [
                 {
                     "$ref": "#/definitions/selectorPropertyField"
+                },
+                {
+                    "$ref": "#/definitions/selectorPropertyValue"
                 }
             ]
         },
@@ -815,6 +821,9 @@
             "oneOf": [
                 {
                     "$ref": "#/definitions/selectorPropertyField"
+                },
+                {
+                    "$ref": "#/definitions/selectorPropertyValue"
                 },
                 {
                     "$ref": "#/definitions/selectorPropertyType"
@@ -839,6 +848,16 @@
             },
             "required": [
                 "field"
+            ]
+        },
+        "selectorPropertyValue": {
+            "properties": {
+                "value": {
+                    "$ref": "#/definitions/selectorExpressionValue"
+                }
+            },
+            "required": [
+                "value"
             ]
         },
         "selectorPropertyType": {
@@ -1270,10 +1289,18 @@
             "type": "object",
             "properties": {
                 "greater": {
-                    "type": "integer",
                     "title": "Greater",
                     "description": "Must be greater then the specified value.",
-                    "markdownDescription": "Must be greater then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greater)"
+                    "markdownDescription": "Must be greater then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greater)",
+                    "oneOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "object",
+                            "$ref": "#/definitions/fn"
+                        }
+                    ]
                 },
                 "convert": {
                     "type": "boolean",
@@ -1936,15 +1963,351 @@
         "selectorExpressionValue": {
             "oneOf": [
                 {
-                    "type": "string"
+                    "type": "string",
+                    "title": "Value from string",
+                    "description": "A value to compare."
                 },
                 {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "title": "Value from boolean",
+                    "description": "A value to compare."
                 },
                 {
-                    "type": "integer"
+                    "type": "integer",
+                    "title": "Value from integer",
+                    "description": "A value to compare."
+                },
+                {
+                    "type": "object",
+                    "title": "Value for object",
+                    "description": "A value to compare.",
+                    "not": {
+                        "propertyNames": {
+                            "enum": [
+                                "$"
+                            ]
+                        }
+                    }
+                },
+                {
+                    "$ref": "#/definitions/fn"
                 }
             ]
+        },
+        "fn": {
+            "title": "Value from function",
+            "description": "A function expression that once evaluated specifies the value.",
+            "markdownDescription": "A function expression that once evaluated specifies the value.",
+            "properties": {
+                "$": {
+                    "type": "object",
+                    "title": "Value from function",
+                    "description": "A function expression that once evaluated specifies the value.",
+                    "markdownDescription": "A function expression that once evaluated specifies the value.",
+                    "$ref": "#/definitions/fn/definitions/function"
+                }
+            },
+            "required": [
+                "$"
+            ],
+            "definitions": {
+                "function": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/substring"
+                        },
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/string"
+                        },
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/boolean"
+                        },
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/integer"
+                        },
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/concat"
+                        },
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/path"
+                        },
+                        {
+                            "$ref": "#/definitions/fn/definitions/function/definitions/configuration"
+                        }
+                    ],
+                    "definitions": {
+                        "equal": {
+                            "type": "object",
+                            "properties": {
+                                "equal": {
+                                    "type": "array",
+                                    "title": "Equal",
+                                    "description": "The equal operator checks for equity between two operands.",
+                                    "markdownDescription": "The `equal` operator checks for equity two operands.",
+                                    "items": {
+                                        "oneOf": [
+                                            {
+                                                "$ref": "#/definitions/fn/definitions/function"
+                                            },
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "boolean"
+                                            }
+                                        ]
+                                    },
+                                    "additionalItems": false,
+                                    "minItems": 2,
+                                    "maxItems": 2
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "equal"
+                            ]
+                        },
+                        "substring": {
+                            "type": "object",
+                            "properties": {
+                                "substring": {
+                                    "title": "Substring",
+                                    "description": "The substring function, copies a number of characters from input starting from a zero based position.",
+                                    "markdownDescription": "The `substring` function, copies a number of characters from input starting from a zero based position.",
+                                    "oneOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn/definitions/function",
+                                            "defaultSnippets": [
+                                                {
+                                                    "label": "From string",
+                                                    "description": "Set value to a specific value.",
+                                                    "body": ""
+                                                },
+                                                {
+                                                    "label": "From configuration",
+                                                    "description": "Configure length from configuration.",
+                                                    "body": {
+                                                        "configuration": "${1}"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "start": {
+                                    "title": "Start",
+                                    "description": "The zero based position to start copying characters from.",
+                                    "default": 0,
+                                    "oneOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn/definitions/function"
+                                        }
+                                    ],
+                                    "defaultSnippets": [
+                                        {
+                                            "label": "From integer",
+                                            "description": "Set start to a specific value.",
+                                            "body": 0
+                                        },
+                                        {
+                                            "label": "From configuration",
+                                            "description": "Configure start from configuration.",
+                                            "body": {
+                                                "configuration": "${1}"
+                                            }
+                                        }
+                                    ]
+                                },
+                                "length": {
+                                    "title": "Length",
+                                    "description": "The number of character to copy from the source string.",
+                                    "oneOf": [
+                                        {
+                                            "type": "integer",
+                                            "minimum": 0
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn/definitions/function"
+                                        }
+                                    ],
+                                    "defaultSnippets": [
+                                        {
+                                            "label": "From integer",
+                                            "description": "Set length to a specific value.",
+                                            "body": 0
+                                        },
+                                        {
+                                            "label": "From configuration",
+                                            "description": "Configure length from configuration.",
+                                            "body": {
+                                                "configuration": "${1}"
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "substring"
+                            ],
+                            "defaultSnippets": [
+                                {
+                                    "label": "Substring from string",
+                                    "description": "Set value to a specific value.",
+                                    "body": {
+                                        "substring": "${1}",
+                                        "length": "${2}"
+                                    }
+                                },
+                                {
+                                    "label": "Substring from configuration",
+                                    "description": "Configure length from configuration.",
+                                    "body": {
+                                        "substring": {
+                                            "configuration": "${1}"
+                                        },
+                                        "length": "${2}"
+                                    }
+                                }
+                            ]
+                        },
+                        "string": {
+                            "type": "object",
+                            "properties": {
+                                "string": {
+                                    "title": "String",
+                                    "oneOf": [
+                                        {
+                                            "type": "string",
+                                            "description": "A literal string value."
+                                        },
+                                        {
+                                            "type": "object",
+                                            "description": "Converts the operand in to a string value.",
+                                            "$ref": "#/definitions/fn/definitions/function"
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "string"
+                            ]
+                        },
+                        "integer": {
+                            "type": "object",
+                            "properties": {
+                                "integer": {
+                                    "title": "Integer",
+                                    "oneOf": [
+                                        {
+                                            "type": "integer",
+                                            "description": "A literal integer value."
+                                        },
+                                        {
+                                            "type": "object",
+                                            "description": "Converts the operand in to an integer.",
+                                            "$ref": "#/definitions/fn/definitions/function"
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "integer"
+                            ]
+                        },
+                        "boolean": {
+                            "type": "object",
+                            "properties": {
+                                "boolean": {
+                                    "title": "Boolean",
+                                    "oneOf": [
+                                        {
+                                            "type": "boolean",
+                                            "description": "A literal boolean value.",
+                                            "markdownDescription": "A literal boolean value."
+                                        },
+                                        {
+                                            "type": "object",
+                                            "description": "Converts the operand to a boolean value.",
+                                            "markdownDescription": "Converts the operand to a boolean value.",
+                                            "$ref": "#/definitions/fn/definitions/function"
+                                        }
+                                    ]
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "boolean"
+                            ]
+                        },
+                        "concat": {
+                            "type": "object",
+                            "properties": {
+                                "concat": {
+                                    "type": "array",
+                                    "description": "The concat function combines two or more operands.",
+                                    "markdownDescription": "The `concat` function combines two or more operands.",
+                                    "items": {
+                                        "$ref": "#/definitions/fn/definitions/function"
+                                    },
+                                    "additionalItems": false,
+                                    "minItems": 2
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "concat"
+                            ]
+                        },
+                        "path": {
+                            "type": "object",
+                            "properties": {
+                                "path": {
+                                    "type": "string",
+                                    "title": "Path",
+                                    "description": "The path function returns a value from an object path.",
+                                    "markdownDescription": "The `path` function returns a value from an object path."
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "path"
+                            ]
+                        },
+                        "configuration": {
+                            "type": "object",
+                            "properties": {
+                                "configuration": {
+                                    "type": "string",
+                                    "title": "Configuration",
+                                    "description": "The configuration function returns a value retrieved from configuration by name.",
+                                    "markdownDescription": "The `configuration` function returns a value retrieved from configuration by name.",
+                                    "minLength": 1
+                                }
+                            },
+                            "additionalProperties": false,
+                            "required": [
+                                "configuration"
+                            ]
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/PSRule/Common/DictionaryExtensions.cs
+++ b/src/PSRule/Common/DictionaryExtensions.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -83,9 +84,24 @@ namespace PSRule
             if (!dictionary.TryGetValue(key, out var o))
                 return false;
 
-            if (o is long lvalue || (o is string svalue && long.TryParse(svalue, out lvalue)))
+            if (ExpressionHelpers.TryLong(o, true, out var i_value))
             {
-                value = lvalue;
+                value = i_value;
+                return true;
+            }
+            return false;
+        }
+
+        [DebuggerStepThrough]
+        public static bool TryGetInt(this IDictionary<string, object> dictionary, string key, out int? value)
+        {
+            value = null;
+            if (!dictionary.TryGetValue(key, out var o))
+                return false;
+
+            if (ExpressionHelpers.TryInt(o, true, out var i_value))
+            {
+                value = i_value;
                 return true;
             }
             return false;
@@ -101,6 +117,21 @@ namespace PSRule
             if (o is string svalue)
             {
                 value = svalue;
+                return true;
+            }
+            return false;
+        }
+
+        [DebuggerStepThrough]
+        public static bool TryGetEnumerable(this IDictionary<string, object> dictionary, string key, out IEnumerable value)
+        {
+            value = null;
+            if (!dictionary.TryGetValue(key, out var o))
+                return false;
+
+            if (o is IEnumerable evalue)
+            {
+                value = evalue;
                 return true;
             }
             return false;

--- a/src/PSRule/Common/JsonReaderExtensions.cs
+++ b/src/PSRule/Common/JsonReaderExtensions.cs
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.Diagnostics;
 using Newtonsoft.Json;
 using PSRule.Definitions;
+using PSRule.Pipeline;
+using PSRule.Resources;
 
 namespace PSRule
 {
@@ -28,6 +32,38 @@ namespace PSRule
 
             extent = new SourceExtent(file, lineNumber, linePosition);
             return true;
+        }
+
+        [DebuggerStepThrough]
+        public static bool TryConsume(this JsonReader reader, JsonToken token)
+        {
+            if (reader.TokenType != token)
+                return false;
+
+            reader.Read();
+            return true;
+        }
+
+        [DebuggerStepThrough]
+        public static void Consume(this JsonReader reader, JsonToken token)
+        {
+            if (reader.TokenType != token)
+                throw new PipelineSerializationException(PSRuleResources.ReadJsonFailedExpectedToken, Enum.GetName(typeof(JsonToken), reader.TokenType));
+
+            reader.Read();
+        }
+
+        /// <summary>
+        /// Skip JSON comments.
+        /// </summary>
+        [DebuggerStepThrough]
+        public static bool SkipComments(this JsonReader reader)
+        {
+            var hasComments = false;
+            while (reader.TokenType == JsonToken.Comment && reader.Read())
+                hasComments = true;
+
+            return hasComments;
         }
     }
 }

--- a/src/PSRule/Definitions/Expressions/Exceptions.cs
+++ b/src/PSRule/Definitions/Expressions/Exceptions.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+using PSRule.Pipeline;
+
+namespace PSRule.Definitions.Expressions
+{
+    /// <summary>
+    /// A base class for runtime exceptions.
+    /// </summary>
+    public abstract class SelectorException : PipelineException
+    {
+        protected SelectorException()
+            : base() { }
+
+        protected SelectorException(string message)
+            : base(message) { }
+
+        protected SelectorException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        protected SelectorException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+    }
+
+    [Serializable]
+    public sealed class ExpressionParseException : SelectorException
+    {
+        public ExpressionParseException()
+        {
+        }
+
+        public ExpressionParseException(string message)
+            : base(message) { }
+
+        public ExpressionParseException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        internal ExpressionParseException(string expression, string message)
+            : base(message)
+        {
+            Expression = expression;
+        }
+
+        internal ExpressionParseException(string expression, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Expression = expression;
+        }
+
+        private ExpressionParseException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        public string Expression { get; }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            base.GetObjectData(info, context);
+        }
+    }
+
+    public abstract class ExpressionException : SelectorException
+    {
+        protected ExpressionException()
+        {
+        }
+
+        protected ExpressionException(string message)
+            : base(message) { }
+
+        protected ExpressionException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        protected ExpressionException(string expression, string message)
+            : base(message)
+        {
+            Expression = expression;
+        }
+
+        protected ExpressionException(string expression, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Expression = expression;
+        }
+
+        protected ExpressionException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        public string Expression { get; }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            base.GetObjectData(info, context);
+        }
+    }
+
+    [Serializable]
+    public sealed class ExpressionReferenceException : SelectorException
+    {
+        public ExpressionReferenceException()
+        {
+        }
+
+        public ExpressionReferenceException(string message)
+            : base(message) { }
+
+        public ExpressionReferenceException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        internal ExpressionReferenceException(string expression, string message)
+            : base(message)
+        {
+            Expression = expression;
+        }
+
+        internal ExpressionReferenceException(string expression, string message, Exception innerException)
+            : base(message, innerException)
+        {
+            Expression = expression;
+        }
+
+        private ExpressionReferenceException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        public string Expression { get; }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            base.GetObjectData(info, context);
+        }
+    }
+
+
+    [Serializable]
+    public sealed class ExpressionArgumentException : ExpressionException
+    {
+        public ExpressionArgumentException()
+        {
+        }
+
+        public ExpressionArgumentException(string message)
+            : base(message) { }
+
+        public ExpressionArgumentException(string message, Exception innerException)
+            : base(message, innerException) { }
+
+        internal ExpressionArgumentException(string expression, string message)
+            : base(expression, message) { }
+
+        private ExpressionArgumentException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null) throw new ArgumentNullException(nameof(info));
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/src/PSRule/Definitions/Expressions/ExpressionContext.cs
+++ b/src/PSRule/Definitions/Expressions/ExpressionContext.cs
@@ -16,6 +16,8 @@ namespace PSRule.Definitions.Expressions
 
         void Reason(IOperand operand, string text, params object[] args);
 
+        object Current { get; }
+
         RunspaceContext GetContext();
     }
 
@@ -25,12 +27,13 @@ namespace PSRule.Definitions.Expressions
 
         private List<ResultReason> _Reason;
 
-        internal ExpressionContext(SourceFile source, ResourceKind kind)
+        internal ExpressionContext(SourceFile source, ResourceKind kind, object current)
         {
             Source = source;
             LanguageScope = source.Module;
             Kind = kind;
             _NameTokenCache = new Dictionary<string, PathExpression>();
+            Current = current;
         }
 
         public SourceFile Source { get; }
@@ -38,6 +41,8 @@ namespace PSRule.Definitions.Expressions
         public string LanguageScope { get; }
 
         public ResourceKind Kind { get; }
+
+        public object Current { get; }
 
         [DebuggerStepThrough]
         void IBindingContext.CachePathExpression(string path, PathExpression expression)

--- a/src/PSRule/Definitions/Expressions/FunctionBuilder.cs
+++ b/src/PSRule/Definitions/Expressions/FunctionBuilder.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace PSRule.Definitions.Expressions
+{
+    internal delegate object ExpressionFnOuter(IExpressionContext context);
+    internal delegate object ExpressionFn(IExpressionContext context, object[] args);
+
+    internal delegate ExpressionFnOuter ExpressionBuilderFn(IExpressionContext context, LanguageExpression.PropertyBag properties);
+
+    internal abstract class FunctionReader
+    {
+        public abstract bool TryProperty(out string propertyName);
+    }
+
+    internal sealed class FunctionBuilder
+    {
+        private readonly Stack<LanguageExpression.PropertyBag> _Stack;
+        private readonly FunctionFactory _Functions;
+
+        private LanguageExpression.PropertyBag _Current;
+
+        internal FunctionBuilder() : this(new FunctionFactory()) { }
+
+        internal FunctionBuilder(FunctionFactory expressionFactory)
+        {
+            _Functions = expressionFactory;
+            _Stack = new Stack<LanguageExpression.PropertyBag>();
+        }
+
+        public void Push()
+        {
+            _Current = new LanguageExpression.PropertyBag();
+            _Stack.Push(_Current);
+        }
+
+        internal void Add(string name, object value)
+        {
+            _Current.Add(name, value);
+        }
+
+        public ExpressionFnOuter Pop()
+        {
+            var properties = _Stack.Pop();
+            _Current = _Stack.Count > 0 ? _Stack.Peek() : null;
+            return TryFunction(properties, out var descriptor) ? descriptor.Fn(null, properties) : null;
+        }
+
+        private bool TryFunction(LanguageExpression.PropertyBag properties, out IFunctionDescriptor descriptor)
+        {
+            descriptor = null;
+            foreach (var property in properties)
+            {
+                if (_Functions.TryDescriptor(property.Key, out descriptor))
+                    return true;
+            }
+            return false;
+        }
+    }
+
+    internal sealed class FunctionFactory
+    {
+        private readonly Dictionary<string, IFunctionDescriptor> _Descriptors;
+
+        public FunctionFactory()
+        {
+            _Descriptors = new Dictionary<string, IFunctionDescriptor>(StringComparer.OrdinalIgnoreCase);
+            foreach (var d in Functions.Builtin)
+                With(d);
+        }
+
+        public bool TryDescriptor(string name, out IFunctionDescriptor descriptor)
+        {
+            return _Descriptors.TryGetValue(name, out descriptor);
+        }
+
+        public void With(IFunctionDescriptor descriptor)
+        {
+            _Descriptors.Add(descriptor.Name, descriptor);
+        }
+    }
+
+    /// <summary>
+    /// A structure describing a specific function.
+    /// </summary>
+    [DebuggerDisplay("Function: {Name}")]
+    internal sealed class FunctionDescriptor : IFunctionDescriptor
+    {
+        public FunctionDescriptor(string name, ExpressionBuilderFn fn)
+        {
+            Name = name;
+            Fn = fn;
+        }
+
+        /// <inheritdoc/>
+        public string Name { get; }
+
+        /// <inheritdoc/>
+        public ExpressionBuilderFn Fn { get; }
+    }
+
+    /// <summary>
+    /// A structure describing a specific function.
+    /// </summary>
+    internal interface IFunctionDescriptor
+    {
+        /// <summary>
+        /// The name of the function.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// The function delegate.
+        /// </summary>
+        ExpressionBuilderFn Fn { get; }
+    }
+}

--- a/src/PSRule/Definitions/Expressions/Functions.cs
+++ b/src/PSRule/Definitions/Expressions/Functions.cs
@@ -1,0 +1,227 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Threading;
+using PSRule.Resources;
+using PSRule.Runtime;
+using static PSRule.Definitions.Expressions.LanguageExpression;
+
+namespace PSRule.Definitions.Expressions
+{
+    /// <summary>
+    /// Implementation of Azure Resource Manager template functions as ExpressionFn.
+    /// </summary>
+    internal static class Functions
+    {
+        private const string BOOLEAN = "boolean";
+        private const string STRING = "string";
+        private const string INTEGER = "integer";
+        private const string CONCAT = "concat";
+        private const string SUBSTRING = "substring";
+        private const string CONFIGURATION = "configuration";
+        private const string PATH = "path";
+        private const string LENGTH = "length";
+
+        /// <summary>
+        /// The available built-in functions.
+        /// </summary>
+        internal readonly static IFunctionDescriptor[] Builtin = new IFunctionDescriptor[]
+        {
+            new FunctionDescriptor(CONFIGURATION, Configuration),
+            new FunctionDescriptor(PATH, Path),
+            new FunctionDescriptor(BOOLEAN, Boolean),
+            new FunctionDescriptor(STRING, String),
+            new FunctionDescriptor(INTEGER, Integer),
+            new FunctionDescriptor(CONCAT, Concat),
+            new FunctionDescriptor(SUBSTRING, Substring),
+        };
+
+        private static ExpressionFnOuter Boolean(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null ||
+                properties.Count == 0 ||
+                !TryProperty(properties, BOOLEAN, out ExpressionFnOuter next))
+                return null;
+
+            return (context) =>
+            {
+                var value = next(context);
+                ExpressionHelpers.TryBool(value, true, out var b);
+                return b;
+            };
+        }
+
+        private static ExpressionFnOuter String(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null ||
+                properties.Count == 0 ||
+                !TryProperty(properties, STRING, out ExpressionFnOuter next))
+                return null;
+
+            return (context) =>
+            {
+                var value = next(context);
+                ExpressionHelpers.TryString(value, true, out var s);
+                return s;
+            };
+        }
+
+        private static ExpressionFnOuter Integer(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null ||
+                properties.Count == 0 ||
+                !TryProperty(properties, INTEGER, out ExpressionFnOuter next))
+                return null;
+
+            return (context) =>
+            {
+                var value = next(context);
+                ExpressionHelpers.TryInt(value, true, out var i);
+                return i;
+            };
+        }
+
+        private static ExpressionFnOuter Configuration(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null || properties.Count == 0 ||
+                !properties.TryGetString(CONFIGURATION, out var name))
+                return null;
+
+            // Lookup a configuration value.
+            return (context) =>
+            {
+                return context.GetContext().TryGetConfigurationValue(name, out var value) ? value : null;
+            };
+        }
+
+        private static ExpressionFnOuter Path(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null || properties.Count == 0 ||
+                !properties.TryGetString(PATH, out var path))
+                return null;
+
+            return (context) =>
+            {
+                return ObjectHelper.GetPath(context, context.Current, path, false, out object value) ? value : null;
+            };
+        }
+
+        private static ExpressionFnOuter Concat(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null ||
+                properties.Count == 0 ||
+                !properties.TryGetEnumerable(CONCAT, out var values))
+                return null;
+
+            return (context) =>
+            {
+                var sb = new StringBuilder();
+                foreach (var value in values)
+                    sb.Append(Value(context, value));
+
+                return sb.ToString();
+            };
+        }
+
+        private static ExpressionFnOuter Substring(IExpressionContext context, PropertyBag properties)
+        {
+            if (properties == null ||
+                properties.Count == 0 ||
+                !TryProperty(properties, LENGTH, out int? length) ||
+                !TryProperty(properties, SUBSTRING, out ExpressionFnOuter next))
+                return null;
+
+            return (context) =>
+            {
+                var value = next(context);
+                if (value is string s)
+                {
+                    length = s.Length < length ? s.Length : length;
+                    return s.Substring(0, length.Value);
+                }
+                return null;
+            };
+        }
+
+        #region Helper functions
+
+        private static bool TryProperty(PropertyBag properties, string name, out int? value)
+        {
+            return properties.TryGetInt(name, out value);
+        }
+
+        private static bool TryProperty(PropertyBag properties, string name, out ExpressionFnOuter value)
+        {
+            value = null;
+            if (properties.TryGetValue(name, out var v) && v is ExpressionFnOuter fn)
+                value = fn;
+
+            else if (properties.TryGetBool(name, out var b_value))
+                value = (context) => b_value;
+
+            else if (properties.TryGetLong(name, out var l_value))
+                value = (context) => l_value;
+
+            else if (properties.TryGetInt(name, out var i_value))
+                value = (context) => i_value;
+
+            else if (properties.TryGetValue(name, out var o_value))
+                value = (context) => o_value;
+
+            return value != null;
+        }
+
+        private static object Value(IExpressionContext context, object value)
+        {
+            return value is ExpressionFnOuter fn ? fn(context) : value;
+        }
+
+        #endregion Helper functions
+
+        #region Exceptions
+
+        private static ExpressionArgumentException ArgumentsOutOfRange(string expression, object[] args)
+        {
+            var length = args == null ? 0 : args.Length;
+            return new ExpressionArgumentException(
+                expression,
+                string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentsOutOfRange, expression, length)
+            );
+        }
+
+        private static ExpressionArgumentException ArgumentFormatInvalid(string expression)
+        {
+            return new ExpressionArgumentException(
+                expression,
+                string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentFormatInvalid, expression)
+            );
+        }
+
+        private static ExpressionArgumentException ArgumentInvalidInteger(string expression, string operand)
+        {
+            return new ExpressionArgumentException(
+                expression,
+                string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentInvalidInteger, operand, expression)
+            );
+        }
+
+        private static ExpressionArgumentException ArgumentInvalidBoolean(string expression, string operand)
+        {
+            return new ExpressionArgumentException(
+                expression,
+                string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentInvalidBoolean, operand, expression)
+            );
+        }
+
+        private static ExpressionArgumentException ArgumentInvalidString(string expression, string operand)
+        {
+            return new ExpressionArgumentException(
+                expression,
+                string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ArgumentInvalidString, operand, expression)
+            );
+        }
+
+        #endregion Exceptions
+    }
+}

--- a/src/PSRule/Definitions/Expressions/Primitives.cs
+++ b/src/PSRule/Definitions/Expressions/Primitives.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -39,7 +39,7 @@ namespace PSRule.Definitions.Expressions
             if (Type == LanguageExpressionType.Condition)
                 return new LanguageCondition(this, properties);
 
-            return null;
+            return Type == LanguageExpressionType.Function ? new LanguageFunction(this) : null;
         }
     }
 
@@ -102,6 +102,16 @@ namespace PSRule.Definitions.Expressions
         internal void Add(PropertyBag properties)
         {
             Property.AddUnique(properties);
+        }
+    }
+
+    [DebuggerDisplay("Selector {Descriptor.Name}")]
+    internal sealed class LanguageFunction : LanguageExpression
+    {
+        internal LanguageFunction(LanguageExpresssionDescriptor descriptor)
+            : base(descriptor)
+        {
+
         }
     }
 }

--- a/src/PSRule/Definitions/Rules/RuleVisitor.cs
+++ b/src/PSRule/Definitions/Rules/RuleVisitor.cs
@@ -50,7 +50,7 @@ namespace PSRule.Definitions.Rules
 
         public IConditionResult If()
         {
-            var context = new ExpressionContext(Source, ResourceKind.Rule);
+            var context = new ExpressionContext(Source, ResourceKind.Rule, RunspaceContext.CurrentThread.TargetObject.Value);
             context.Debug(PSRuleResources.RuleMatchTrace, Id);
             context.PushScope(RunspaceScope.Rule);
             try

--- a/src/PSRule/Definitions/Selectors/SelectorVisitor.cs
+++ b/src/PSRule/Definitions/Selectors/SelectorVisitor.cs
@@ -42,7 +42,7 @@ namespace PSRule.Definitions.Selectors
 
         public bool Match(object o)
         {
-            var context = new ExpressionContext(Source, ResourceKind.Selector);
+            var context = new ExpressionContext(Source, ResourceKind.Selector, o);
             context.Debug(PSRuleResources.SelectorMatchTrace, Id);
             return _Fn(context, o).GetValueOrDefault(false);
         }

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
@@ -77,7 +77,7 @@ namespace PSRule.Definitions.SuppressionGroups
         public bool TryMatch(object o, out ISuppressionInfo suppression)
         {
             suppression = null;
-            var context = new ExpressionContext(Source, ResourceKind.SuppressionGroup);
+            var context = new ExpressionContext(Source, ResourceKind.SuppressionGroup, o);
             context.Debug(PSRuleResources.SelectorMatchTrace, Id);
             if (_Fn(context, o).GetValueOrDefault(false))
             {

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -260,7 +260,7 @@ namespace PSRule.Host
                         context.EnterSourceScope(source: file);
 
                         using var reader = new StreamReader(file.Path);
-                        var parser = new YamlDotNet.Core.Parser(reader);
+                        var parser = new Parser(reader);
                         parser.TryConsume<StreamStart>(out _);
                         while (parser.Current is DocumentStart)
                         {

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -8,10 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources {
+namespace PSRule.Resources
+{
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,706 +23,980 @@ namespace PSRule.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class PSRuleResources {
-        
+    internal class PSRuleResources
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal PSRuleResources() {
+        internal PSRuleResources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.PSRuleResources", typeof(PSRuleResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
-        ///   Looks up a localized string similar to The {0} resource &apos;{1}&apos; is currently referencing &apos;{2}&apos; using the alias &apos;{3}&apos;. Consider updating the reference to use name or id directly..
+        ///   Looks up a localized string similar to The arguments for &apos;{0}&apos; are not in the expected format or type..
         /// </summary>
-        internal static string AliasReference {
-            get {
+        internal static string ArgumentFormatInvalid
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentFormatInvalid", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid boolean..
+        /// </summary>
+        internal static string ArgumentInvalidBoolean
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentInvalidBoolean", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid integer..
+        /// </summary>
+        internal static string ArgumentInvalidInteger
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentInvalidInteger", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid string..
+        /// </summary>
+        internal static string ArgumentInvalidString
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentInvalidString", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The number of arguments &apos;{1}&apos; is not within the allowed range for &apos;{0}&apos;..
+        /// </summary>
+        internal static string ArgumentsOutOfRange
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentsOutOfRange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The baseline &apos;{0}&apos; is obsolete. Consider switching to an alternative baseline..
+        /// </summary>
+        internal static string AliasReference
+        {
+            get
+            {
                 return ResourceManager.GetString("AliasReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Suppression for the rule &apos;{0}&apos; was configured using the alias &apos;{1}&apos;. Consider updating the suppression to use the name or id directly..
         /// </summary>
-        internal static string AliasSuppression {
-            get {
+        internal static string AliasSuppression
+        {
+            get
+            {
                 return ResourceManager.GetString("AliasSuppression", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Binding functions are not supported in this language mode..
         /// </summary>
-        internal static string ConstrainedTargetBinding {
-            get {
+        internal static string ConstrainedTargetBinding
+        {
+            get
+            {
                 return ResourceManager.GetString("ConstrainedTargetBinding", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0}: The property &apos;${1}.{2}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string DebugPropertyObsolete {
-            get {
+        internal static string DebugPropertyObsolete
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugPropertyObsolete", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target failed If precondition.
         /// </summary>
-        internal static string DebugTargetIfMismatch {
-            get {
+        internal static string DebugTargetIfMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugTargetIfMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target failed Rule precondition.
         /// </summary>
-        internal static string DebugTargetRuleMismatch {
-            get {
+        internal static string DebugTargetRuleMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugTargetRuleMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target failed Type precondition.
         /// </summary>
-        internal static string DebugTargetTypeMismatch {
-            get {
+        internal static string DebugTargetTypeMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("DebugTargetTypeMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A circular rule dependency was detected. The rule &apos;{0}&apos; depends on &apos;{1}&apos; which also depend on &apos;{0}&apos;..
         /// </summary>
-        internal static string DependencyCircularReference {
-            get {
+        internal static string DependencyCircularReference
+        {
+            get
+            {
                 return ResourceManager.GetString("DependencyCircularReference", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The dependency &apos;{0}&apos; for &apos;{1}&apos; could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path..
         /// </summary>
-        internal static string DependencyNotFound {
-            get {
+        internal static string DependencyNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("DependencyNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A rule with the same id &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleId {
-            get {
+        internal static string DuplicateRuleId
+        {
+            get
+            {
                 return ResourceManager.GetString("DuplicateRuleId", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleName {
-            get {
+        internal static string DuplicateRuleName
+        {
+            get
+            {
                 return ResourceManager.GetString("DuplicateRuleName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} : Reported &apos;{1}&apos;. At {2}:{3} char:{4}.
         /// </summary>
-        internal static string ErrorDetailMessage {
-            get {
+        internal static string ErrorDetailMessage
+        {
+            get
+            {
                 return ResourceManager.GetString("ErrorDetailMessage", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to One or more errors occured..
         /// </summary>
-        internal static string ErrorPipelineException {
-            get {
+        internal static string ErrorPipelineException
+        {
+            get
+            {
                 return ResourceManager.GetString("ErrorPipelineException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Exists: {0}.
         /// </summary>
-        internal static string ExistsTrue {
-            get {
+        internal static string ExistsTrue
+        {
+            get
+            {
                 return ResourceManager.GetString("ExistsTrue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to File.
         /// </summary>
-        internal static string FileSourceType {
-            get {
+        internal static string FileSourceType
+        {
+            get
+            {
                 return ResourceManager.GetString("FileSourceType", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to parse expression. The expression may not be valid. Expression: &quot;{0}&quot;.
+        /// </summary>
+        internal static string ExpressionInvalid
+        {
+            get
+            {
+                return ResourceManager.GetString("ExpressionInvalid", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
         /// </summary>
-        internal static string FoundModules {
-            get {
+        internal static string FoundModules
+        {
+            get
+            {
                 return ResourceManager.GetString("FoundModules", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The function &quot;{0}&quot; was not found..
+        /// </summary>
+        internal static string FunctionNotFound
+        {
+            get
+            {
+                return ResourceManager.GetString("FunctionNotFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The language expression index &apos;{0}&apos; is not valid for the object..
+        /// </summary>
+        internal static string IndexInvalid
+        {
+            get
+            {
+                return ResourceManager.GetString("IndexInvalid", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Output written to the following file: &apos;{0}&apos;.
         /// </summary>
-        internal static string InfoOutputPath {
-            get {
+        internal static string InfoOutputPath
+        {
+            get
+            {
                 return ResourceManager.GetString("InfoOutputPath", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported..
         /// </summary>
-        internal static string InvalidErrorAction {
-            get {
+        internal static string InvalidErrorAction
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidErrorAction", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The resource name &apos;{0}&apos; is not valid at {1}. Each resource name must be between 3-128 characters in length, must start and end with a letter or number, and only contain letters, numbers, hyphens, dots, or underscores. See https://aka.ms/ps-rule/naming for more information..
         /// </summary>
-        internal static string InvalidResourceName {
-            get {
+        internal static string InvalidResourceName
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidResourceName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Rule nesting was detected for rule at {0}. Rules must not be nested..
         /// </summary>
-        internal static string InvalidRuleNesting {
-            get {
+        internal static string InvalidRuleNesting
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidRuleNesting", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to An invalid rule result was returned for {0}. Conditions must return boolean $True or $False..
         /// </summary>
-        internal static string InvalidRuleResult {
-            get {
+        internal static string InvalidRuleResult
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidRuleResult", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string KeywordConditionScope {
-            get {
+        internal static string KeywordConditionScope
+        {
+            get
+            {
                 return ResourceManager.GetString("KeywordConditionScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block or script precondition..
         /// </summary>
-        internal static string KeywordRuleScope {
-            get {
+        internal static string KeywordRuleScope
+        {
+            get
+            {
                 return ResourceManager.GetString("KeywordRuleScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can not be nested in a Rule block..
         /// </summary>
-        internal static string KeywordSourceScope {
-            get {
+        internal static string KeywordSourceScope
+        {
+            get
+            {
                 return ResourceManager.GetString("KeywordSourceScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][{0}][Trace] -- {1}: {2}.
         /// </summary>
-        internal static string LanguageExpressionTraceP2 {
-            get {
+        internal static string LanguageExpressionTraceP2
+        {
+            get
+            {
                 return ResourceManager.GetString("LanguageExpressionTraceP2", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][{0}][Trace] -- {1}: {2} {1} {3}.
         /// </summary>
-        internal static string LanguageExpressionTraceP3 {
-            get {
+        internal static string LanguageExpressionTraceP3
+        {
+            get
+            {
                 return ResourceManager.GetString("LanguageExpressionTraceP3", resourceCulture);
             }
         }
-        
+
+        internal static string LanguageExpressionTrace
+        {
+            get
+            {
+                return ResourceManager.GetString("LanguageExpressionTrace", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Please open your browser to the following location: {0}.
         /// </summary>
-        internal static string LaunchBrowser {
-            get {
+        internal static string LaunchBrowser
+        {
+            get
+            {
                 return ResourceManager.GetString("LaunchBrowser", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Wildcard match requires exactly one name..
         /// </summary>
-        internal static string MatchSingleName {
-            get {
+        internal static string MatchSingleName
+        {
+            get
+            {
                 return ResourceManager.GetString("MatchSingleName", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Matches: {0}.
         /// </summary>
-        internal static string MatchTrue {
-            get {
+        internal static string MatchTrue
+        {
+            get
+            {
                 return ResourceManager.GetString("MatchTrue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Update module &apos;{0}&apos; to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config..
         /// </summary>
-        internal static string ModuleManifestBaseline {
-            get {
+        internal static string ModuleManifestBaseline
+        {
+            get
+            {
                 return ResourceManager.GetString("ModuleManifestBaseline", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No valid module can be found with that name..
         /// </summary>
-        internal static string ModuleNotFound {
-            get {
+        internal static string ModuleNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("ModuleNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Target object &apos;{0}&apos; has not been processed because no matching rules were found..
         /// </summary>
-        internal static string ObjectNotProcessed {
-            get {
+        internal static string ObjectNotProcessed
+        {
+            get
+            {
                 return ResourceManager.GetString("ObjectNotProcessed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Object path not found..
         /// </summary>
-        internal static string ObjectPathNotFound {
-            get {
+        internal static string ObjectPathNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("ObjectPathNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Options file does not exist..
         /// </summary>
-        internal static string OptionsNotFound {
-            get {
+        internal static string OptionsNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("OptionsNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to # Source: {0}.
         /// </summary>
-        internal static string OptionsSourceComment {
-            get {
+        internal static string OptionsSourceComment
+        {
+            get
+            {
                 return ResourceManager.GetString("OptionsSourceComment", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
-        internal static string OutcomeError {
-            get {
+        internal static string OutcomeError
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeError", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Fail.
         /// </summary>
-        internal static string OutcomeFail {
-            get {
+        internal static string OutcomeFail
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeFail", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Pass.
         /// </summary>
-        internal static string OutcomePass {
-            get {
+        internal static string OutcomePass
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomePass", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRuleFail {
-            get {
+        internal static string OutcomeRuleFail
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeRuleFail", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PASS] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRulePass {
-            get {
+        internal static string OutcomeRulePass
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeRulePass", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
-        internal static string OutcomeUnknown {
-            get {
+        internal static string OutcomeUnknown
+        {
+            get
+            {
                 return ResourceManager.GetString("OutcomeUnknown", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The language expression property &apos;{0}&apos; doesn&apos;t exist..
+        /// </summary>
+        internal static string PropertyNotFound
+        {
+            get
+            {
+                return ResourceManager.GetString("PropertyNotFound", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The property &apos;${0}.{1}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string PropertyObsolete {
-            get {
+        internal static string PropertyObsolete
+        {
+            get
+            {
                 return ResourceManager.GetString("PropertyObsolete", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize the file &apos;{0}&apos;: {1}.
         /// </summary>
-        internal static string ReadFileFailed {
-            get {
+        internal static string ReadFileFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("ReadFileFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
-        internal static string ReadJsonFailed {
-            get {
+        internal static string ReadJsonFailed
+        {
+            get
+            {
                 return ResourceManager.GetString("ReadJsonFailed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed because the token ({0}) was not expected..
         /// </summary>
-        internal static string ReadJsonFailedExpectedToken {
-            get {
+        internal static string ReadJsonFailedExpectedToken
+        {
+            get
+            {
                 return ResourceManager.GetString("ReadJsonFailedExpectedToken", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The module version &apos;{1}&apos; for &apos;{0}&apos; does not match the required version &apos;{2}&apos;. To continue, first update the module to match the version requirement..
         /// </summary>
-        internal static string RequiredVersionMismatch {
-            get {
+        internal static string RequiredVersionMismatch
+        {
+            get
+            {
                 return ResourceManager.GetString("RequiredVersionMismatch", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The {0} &apos;{1}&apos; is obsolete. Consider switching to an alternative {0}..
         /// </summary>
-        internal static string ResourceObsolete {
-            get {
+        internal static string ResourceObsolete
+        {
+            get
+            {
                 return ResourceManager.GetString("ResourceObsolete", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleCountSuppressed {
-            get {
+        internal static string RuleCountSuppressed
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleCountSuppressed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported errors..
         /// </summary>
-        internal static string RuleErrorPipelineException {
-            get {
+        internal static string RuleErrorPipelineException
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleErrorPipelineException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported failure..
         /// </summary>
-        internal static string RuleFailPipelineException {
-            get {
+        internal static string RuleFailPipelineException
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleFailPipelineException", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
         /// </summary>
-        internal static string RuleInconclusive {
-            get {
+        internal static string RuleInconclusive
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleInconclusive", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][R][Trace] -- {0}.
         /// </summary>
-        internal static string RuleMatchTrace {
-            get {
+        internal static string RuleMatchTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleMatchTrace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find a matching rule. Please check that Path, Name and Tag parameters are correct..
         /// </summary>
-        internal static string RuleNotFound {
-            get {
+        internal static string RuleNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find required rule definition parameter &apos;{0}&apos; on rule at {1}..
         /// </summary>
-        internal static string RuleParameterNotFound {
-            get {
+        internal static string RuleParameterNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleParameterNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No matching .Rule.ps1 files were found. Rule definitions should be saved into script files with the .Rule.ps1 extension..
         /// </summary>
-        internal static string RulePathNotFound {
-            get {
+        internal static string RulePathNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("RulePathNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to at Rule &apos;{0}&apos;, {1}: line {2}.
         /// </summary>
-        internal static string RuleStackTrace {
-            get {
+        internal static string RuleStackTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleStackTrace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleSuppressed {
-            get {
+        internal static string RuleSuppressed
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleSuppressed", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;..
         /// </summary>
-        internal static string RuleSuppressionGroup {
-            get {
+        internal static string RuleSuppressionGroup
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleSuppressionGroup", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;..
         /// </summary>
-        internal static string RuleSuppressionGroupCount {
-            get {
+        internal static string RuleSuppressionGroupCount
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleSuppressionGroupCount", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;. {3}.
         /// </summary>
-        internal static string RuleSuppressionGroupExtended {
-            get {
+        internal static string RuleSuppressionGroupExtended
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleSuppressionGroupExtended", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;. {3}.
         /// </summary>
-        internal static string RuleSuppressionGroupExtendedCount {
-            get {
+        internal static string RuleSuppressionGroupExtendedCount
+        {
+            get
+            {
                 return ResourceManager.GetString("RuleSuppressionGroupExtendedCount", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
         /// </summary>
-        internal static string ScanModule {
-            get {
+        internal static string ScanModule
+        {
+            get
+            {
                 return ResourceManager.GetString("ScanModule", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files: {0}.
         /// </summary>
-        internal static string ScanSource {
-            get {
+        internal static string ScanSource
+        {
+            get
+            {
                 return ResourceManager.GetString("ScanSource", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The script was not found..
         /// </summary>
-        internal static string ScriptNotFound {
-            get {
+        internal static string ScriptNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}.
         /// </summary>
-        internal static string SelectorMatchTrace {
-            get {
+        internal static string SelectorMatchTrace
+        {
+            get
+            {
                 return ResourceManager.GetString("SelectorMatchTrace", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1}.
+        /// </summary>
+        internal static string SelectorTrace
+        {
+            get
+            {
+                return ResourceManager.GetString("SelectorTrace", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Can not serialize a null PSObject..
         /// </summary>
-        internal static string SerializeNullPSObject {
-            get {
+        internal static string SerializeNullPSObject
+        {
+            get
+            {
                 return ResourceManager.GetString("SerializeNullPSObject", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Create path.
         /// </summary>
-        internal static string ShouldCreatePath {
-            get {
+        internal static string ShouldCreatePath
+        {
+            get
+            {
                 return ResourceManager.GetString("ShouldCreatePath", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Write file.
         /// </summary>
-        internal static string ShouldWriteFile {
-            get {
+        internal static string ShouldWriteFile
+        {
+            get
+            {
                 return ResourceManager.GetString("ShouldWriteFile", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The source was not found..
         /// </summary>
-        internal static string SourceNotFound {
-            get {
+        internal static string SourceNotFound
+        {
+            get
+            {
                 return ResourceManager.GetString("SourceNotFound", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Using invariant culture may cause rule infomation to be displayed incorrectly. Consider using -Culture or set the Output.Culture option..
         /// </summary>
-        internal static string UsingInvariantCulture {
-            get {
+        internal static string UsingInvariantCulture
+        {
+            get
+            {
                 return ResourceManager.GetString("UsingInvariantCulture", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The variable &apos;${0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string VariableConditionScope {
-            get {
+        internal static string VariableConditionScope
+        {
+            get
+            {
                 return ResourceManager.GetString("VariableConditionScope", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The version constraint &apos;{0}&apos; is not valid..
         /// </summary>
-        internal static string VersionConstraintInvalid {
-            get {
+        internal static string VersionConstraintInvalid
+        {
+            get
+            {
                 return ResourceManager.GetString("VersionConstraintInvalid", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The Within parameter Value must be a string when the Like parameter is used..
         /// </summary>
-        internal static string WithinLikeNotString {
-            get {
+        internal static string WithinLikeNotString
+        {
+            get
+            {
                 return ResourceManager.GetString("WithinLikeNotString", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Within: {0}.
         /// </summary>
-        internal static string WithinTrue {
-            get {
+        internal static string WithinTrue
+        {
+            get
+            {
                 return ResourceManager.GetString("WithinTrue", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -121,6 +121,25 @@
     <value>The {0} '{1}' is obsolete. Consider switching to an alternative {0}.</value>
     <comment>Occurs when a resource is used that has been flagged as obsolete.</comment>
   </data>
+  <data name="ArgumentFormatInvalid" xml:space="preserve">
+    <value>The arguments for '{0}' are not in the expected format or type.</value>
+  </data>
+  <data name="ArgumentInvalidBoolean" xml:space="preserve">
+    <value>The argument '{0}' for '{1}' is not a valid boolean.</value>
+  </data>
+  <data name="ArgumentInvalidInteger" xml:space="preserve">
+    <value>The argument '{0}' for '{1}' is not a valid integer.</value>
+  </data>
+  <data name="ArgumentInvalidString" xml:space="preserve">
+    <value>The argument '{0}' for '{1}' is not a valid string.</value>
+  </data>
+  <data name="ArgumentsOutOfRange" xml:space="preserve">
+    <value>The number of arguments '{1}' is not within the allowed range for '{0}'.</value>
+  </data>
+  <data name="BaselineObsolete" xml:space="preserve">
+    <value>The baseline '{0}' is obsolete. Consider switching to an alternative baseline.</value>
+    <comment>Occurs when a baseline is used that has been flagged as obsolete.</comment>
+  </data>
   <data name="ConstrainedTargetBinding" xml:space="preserve">
     <value>Binding functions are not supported in this language mode.</value>
   </data>
@@ -164,8 +183,17 @@
   <data name="FileSourceType" xml:space="preserve">
     <value>File</value>
   </data>
+  <data name="ExpressionInvalid" xml:space="preserve">
+    <value>Failed to parse expression. The expression may not be valid. Expression: "{0}"</value>
+  </data>
   <data name="FoundModules" xml:space="preserve">
     <value>[PSRule][D] -- Found {0} PSRule module(s)</value>
+  </data>
+  <data name="FunctionNotFound" xml:space="preserve">
+    <value>The function "{0}" was not found.</value>
+  </data>
+  <data name="IndexInvalid" xml:space="preserve">
+    <value>The language expression index '{0}' is not valid for the object.</value>
   </data>
   <data name="InvalidErrorAction" xml:space="preserve">
     <value>An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported.</value>
@@ -228,6 +256,9 @@
   </data>
   <data name="OutcomeUnknown" xml:space="preserve">
     <value>Unknown</value>
+  </data>
+  <data name="PropertyNotFound" xml:space="preserve">
+    <value>The language expression property '{0}' doesn't exist.</value>
   </data>
   <data name="PropertyObsolete" xml:space="preserve">
     <value>The property '${0}.{1}' is obsolete and will be removed in the next major version.</value>

--- a/src/PSRule/Resources/ReasonStrings.Designer.cs
+++ b/src/PSRule/Resources/ReasonStrings.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources
-{
+namespace PSRule.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,85 +22,80 @@ namespace PSRule.Resources
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class ReasonStrings
-    {
-
+    internal class ReasonStrings {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal ReasonStrings()
-        {
+        internal ReasonStrings() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.ReasonStrings", typeof(ReasonStrings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; contains &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_Contains
-        {
-            get
-            {
+        internal static string Assert_Contains {
+            get {
                 return ResourceManager.GetString("Assert_Contains", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of items is &apos;{0}&apos; instead of &apos;{1}&apos;..
+        /// </summary>
+        internal static string Assert_Count {
+            get {
+                return ResourceManager.GetString("Assert_Count", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not match the expression &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_DoesNotMatch
-        {
-            get
-            {
+        internal static string Assert_DoesNotMatch {
+            get {
                 return ResourceManager.GetString("Assert_DoesNotMatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; ends with &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_EndsWith
-        {
-            get
-            {
+        internal static string Assert_EndsWith {
+            get {
                 return ResourceManager.GetString("Assert_EndsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Does not exist..
         /// </summary>
@@ -114,135 +108,129 @@ namespace PSRule.Resources
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only lowercase characters..
         /// </summary>
-        internal static string Assert_IsLower
-        {
-            get
-            {
+        internal static string Assert_IsLower {
+            get {
                 return ResourceManager.GetString("Assert_IsLower", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value is null..
+        /// </summary>
+        internal static string Assert_IsNull {
+            get {
+                return ResourceManager.GetString("Assert_IsNull", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Is null or empty..
         /// </summary>
-        internal static string Assert_IsNullOrEmpty
-        {
-            get
-            {
+        internal static string Assert_IsNullOrEmpty {
+            get {
                 return ResourceManager.GetString("Assert_IsNullOrEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Is set to &apos;{0}&apos;..
         /// </summary>
-        internal static string Assert_IsSetTo
-        {
-            get
-            {
+        internal static string Assert_IsSetTo {
+            get {
                 return ResourceManager.GetString("Assert_IsSetTo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only uppercase characters..
         /// </summary>
-        internal static string Assert_IsUpper
-        {
-            get
-            {
+        internal static string Assert_IsUpper {
+            get {
                 return ResourceManager.GetString("Assert_IsUpper", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is like &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_Like
-        {
-            get
-            {
+        internal static string Assert_Like {
+            get {
                 return ResourceManager.GetString("Assert_Like", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; matches the expression &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_Matches
-        {
-            get
-            {
+        internal static string Assert_Matches {
+            get {
                 return ResourceManager.GetString("Assert_Matches", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not an array..
         /// </summary>
-        internal static string Assert_NotArray
-        {
-            get
-            {
+        internal static string Assert_NotArray {
+            get {
                 return ResourceManager.GetString("Assert_NotArray", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not a boolean..
         /// </summary>
-        internal static string Assert_NotBoolean
-        {
-            get
-            {
+        internal static string Assert_NotBoolean {
+            get {
                 return ResourceManager.GetString("Assert_NotBoolean", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not {1} {2}..
         /// </summary>
-        internal static string Assert_NotComparedTo
-        {
-            get
-            {
+        internal static string Assert_NotComparedTo {
+            get {
                 return ResourceManager.GetString("Assert_NotComparedTo", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain any of {1}..
         /// </summary>
-        internal static string Assert_NotContains
-        {
-            get
-            {
+        internal static string Assert_NotContains {
+            get {
                 return ResourceManager.GetString("Assert_NotContains", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of items is &apos;{0}&apos;..
+        /// </summary>
+        internal static string Assert_NotCount {
+            get {
+                return ResourceManager.GetString("Assert_NotCount", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not a date..
         /// </summary>
-        internal static string Assert_NotDateTime
-        {
-            get
-            {
+        internal static string Assert_NotDateTime {
+            get {
                 return ResourceManager.GetString("Assert_NotDateTime", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not end with any of {1}..
         /// </summary>
-        internal static string Assert_NotEndsWith
-        {
-            get
-            {
+        internal static string Assert_NotEndsWith {
+            get {
                 return ResourceManager.GetString("Assert_NotEndsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exists..
         /// </summary>
@@ -255,615 +243,503 @@ namespace PSRule.Resources
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not in {1}..
         /// </summary>
-        internal static string Assert_NotInSet
-        {
-            get
-            {
+        internal static string Assert_NotInSet {
+            get {
                 return ResourceManager.GetString("Assert_NotInSet", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not an integer..
         /// </summary>
-        internal static string Assert_NotInteger
-        {
-            get
-            {
+        internal static string Assert_NotInteger {
+            get {
                 return ResourceManager.GetString("Assert_NotInteger", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not like &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_NotLike
-        {
-            get
-            {
+        internal static string Assert_NotLike {
+            get {
                 return ResourceManager.GetString("Assert_NotLike", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not numeric..
         /// </summary>
-        internal static string Assert_NotNumeric
-        {
-            get
-            {
+        internal static string Assert_NotNumeric {
+            get {
                 return ResourceManager.GetString("Assert_NotNumeric", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the specified schemas match &apos;{0}&apos;..
         /// </summary>
-        internal static string Assert_NotSpecifiedSchema
-        {
-            get
-            {
+        internal static string Assert_NotSpecifiedSchema {
+            get {
                 return ResourceManager.GetString("Assert_NotSpecifiedSchema", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not start with any of {1}..
         /// </summary>
-        internal static string Assert_NotStartsWith
-        {
-            get
-            {
+        internal static string Assert_NotStartsWith {
+            get {
                 return ResourceManager.GetString("Assert_NotStartsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; is not a string..
         /// </summary>
-        internal static string Assert_NotString
-        {
-            get
-            {
+        internal static string Assert_NotString {
+            get {
                 return ResourceManager.GetString("Assert_NotString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; starts with &apos;{1}&apos;..
         /// </summary>
-        internal static string Assert_StartsWith
-        {
-            get
-            {
+        internal static string Assert_StartsWith {
+            get {
                 return ResourceManager.GetString("Assert_StartsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; can not be compared with &apos;{1}&apos;..
         /// </summary>
-        internal static string Compare
-        {
-            get
-            {
+        internal static string Compare {
+            get {
                 return ResourceManager.GetString("Compare", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not contain &apos;{1}&apos;..
         /// </summary>
-        internal static string Contains
-        {
-            get
-            {
+        internal static string Contains {
+            get {
                 return ResourceManager.GetString("Contains", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; has &apos;{1}&apos; items instead of &apos;{2}&apos;..
         /// </summary>
-        internal static string Count
-        {
-            get
-            {
+        internal static string Count {
+            get {
                 return ResourceManager.GetString("Count", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not end with &apos;{1}&apos;..
         /// </summary>
-        internal static string EndsWith
-        {
-            get
-            {
+        internal static string EndsWith {
+            get {
                 return ResourceManager.GetString("EndsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the field(s) existed: {0}.
         /// </summary>
-        internal static string Exists
-        {
-            get
-            {
+        internal static string Exists {
+            get {
                 return ResourceManager.GetString("Exists", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field(s) existed: {0}.
         /// </summary>
-        internal static string ExistsNot
-        {
-            get
-            {
+        internal static string ExistsNot {
+            get {
                 return ResourceManager.GetString("ExistsNot", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The header was not set..
         /// </summary>
-        internal static string FileHeader
-        {
-            get
-            {
+        internal static string FileHeader {
+            get {
                 return ResourceManager.GetString("FileHeader", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The file &apos;{0}&apos; does not exist..
         /// </summary>
-        internal static string FilePath
-        {
-            get
-            {
+        internal static string FilePath {
+            get {
                 return ResourceManager.GetString("FilePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &gt; &apos;{1}&apos;..
         /// </summary>
-        internal static string Greater
-        {
-            get
-            {
+        internal static string Greater {
+            get {
                 return ResourceManager.GetString("Greater", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &gt;= &apos;{1}&apos;..
         /// </summary>
-        internal static string GreaterOrEqual
-        {
-            get
-            {
+        internal static string GreaterOrEqual {
+            get {
                 return ResourceManager.GetString("GreaterOrEqual", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; is set to &apos;{1}&apos;..
         /// </summary>
-        internal static string HasExpectedFieldValue
-        {
-            get
-            {
+        internal static string HasExpectedFieldValue {
+            get {
                 return ResourceManager.GetString("HasExpectedFieldValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; exists..
         /// </summary>
-        internal static string HasField
-        {
-            get
-            {
+        internal static string HasField {
+            get {
                 return ResourceManager.GetString("HasField", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the specified schemas match &apos;{0}&apos;..
         /// </summary>
-        internal static string HasJsonSchema
-        {
-            get
-            {
+        internal static string HasJsonSchema {
+            get {
                 return ResourceManager.GetString("HasJsonSchema", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; was not included in the set..
         /// </summary>
-        internal static string In
-        {
-            get
-            {
+        internal static string In {
+            get {
                 return ResourceManager.GetString("In", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; does not contain only letters..
         /// </summary>
-        internal static string IsLetter
-        {
-            get
-            {
+        internal static string IsLetter {
+            get {
                 return ResourceManager.GetString("IsLetter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed schema validation on {0}. {1}.
         /// </summary>
-        internal static string JsonSchemaInvalid
-        {
-            get
-            {
+        internal static string JsonSchemaInvalid {
+            get {
                 return ResourceManager.GetString("JsonSchemaInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The JSON schema &apos;{0}&apos; could not be found..
         /// </summary>
-        internal static string JsonSchemaNotFound
-        {
-            get
-            {
+        internal static string JsonSchemaNotFound {
+            get {
                 return ResourceManager.GetString("JsonSchemaNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &lt; &apos;{1}&apos;..
         /// </summary>
-        internal static string Less
-        {
-            get
-            {
+        internal static string Less {
+            get {
                 return ResourceManager.GetString("Less", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was not &lt;= &apos;{1}&apos;..
         /// </summary>
-        internal static string LessOrEqual
-        {
-            get
-            {
+        internal static string LessOrEqual {
+            get {
                 return ResourceManager.GetString("LessOrEqual", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the regex(s) matched: {0}.
         /// </summary>
-        internal static string Match
-        {
-            get
-            {
+        internal static string Match {
+            get {
                 return ResourceManager.GetString("Match", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The regex &apos;{0}&apos; matched..
         /// </summary>
-        internal static string MatchNot
-        {
-            get
-            {
+        internal static string MatchNot {
+            get {
                 return ResourceManager.GetString("MatchNot", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; does not match the pattern &apos;{1}&apos;..
         /// </summary>
-        internal static string MatchPattern
-        {
-            get
-            {
+        internal static string MatchPattern {
+            get {
                 return ResourceManager.GetString("MatchPattern", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; has &apos;{1}&apos; items instead of not &apos;{2}&apos;..
         /// </summary>
-        internal static string NotCount
-        {
-            get
-            {
+        internal static string NotCount {
+            get {
                 return ResourceManager.GetString("NotCount", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; is not enumerable..
         /// </summary>
-        internal static string NotEnumerable
-        {
-            get
-            {
+        internal static string NotEnumerable {
+            get {
                 return ResourceManager.GetString("NotEnumerable", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not exist..
         /// </summary>
-        internal static string NotHasField
-        {
-            get
-            {
+        internal static string NotHasField {
+            get {
                 return ResourceManager.GetString("NotHasField", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value of &apos;{0}&apos; is null or empty..
         /// </summary>
-        internal static string NotHasFieldValue
-        {
-            get
-            {
+        internal static string NotHasFieldValue {
+            get {
                 return ResourceManager.GetString("NotHasFieldValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; was in the set..
         /// </summary>
-        internal static string NotIn
-        {
-            get
-            {
+        internal static string NotIn {
+            get {
                 return ResourceManager.GetString("NotIn", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; matches the pattern &apos;{1}&apos;..
         /// </summary>
-        internal static string NotMatchPattern
-        {
-            get
-            {
+        internal static string NotMatchPattern {
+            get {
                 return ResourceManager.GetString("NotMatchPattern", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not null..
         /// </summary>
-        internal static string NotNull
-        {
-            get
-            {
+        internal static string NotNull {
+            get {
                 return ResourceManager.GetString("NotNull", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The file &apos;{0}&apos; is within the path &apos;{1}&apos;..
         /// </summary>
-        internal static string NotWithinPath
-        {
-            get
-            {
+        internal static string NotWithinPath {
+            get {
                 return ResourceManager.GetString("NotWithinPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is null..
         /// </summary>
-        internal static string Null
-        {
-            get
-            {
+        internal static string Null {
+            get {
                 return ResourceManager.GetString("Null", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; is not empty..
         /// </summary>
-        internal static string NullOrEmpty
-        {
-            get
-            {
+        internal static string NullOrEmpty {
+            get {
                 return ResourceManager.GetString("NullOrEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is null or empty..
         /// </summary>
-        internal static string NullOrEmptyParameter
-        {
-            get
-            {
+        internal static string NullOrEmptyParameter {
+            get {
                 return ResourceManager.GetString("NullOrEmptyParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The parameter &apos;{0}&apos; is null..
         /// </summary>
-        internal static string NullParameter
-        {
-            get
-            {
+        internal static string NullParameter {
+            get {
                 return ResourceManager.GetString("NullParameter", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No results were provided..
         /// </summary>
-        internal static string ResultsNotProvided
-        {
-            get
-            {
+        internal static string ResultsNotProvided {
+            get {
                 return ResourceManager.GetString("ResultsNotProvided", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; does not start with &apos;{1}&apos;..
         /// </summary>
-        internal static string StartsWith
-        {
-            get
-            {
+        internal static string StartsWith {
+            get {
                 return ResourceManager.GetString("StartsWith", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not a string..
         /// </summary>
-        internal static string String
-        {
-            get
-            {
+        internal static string String {
+            get {
                 return ResourceManager.GetString("String", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; did not contain &apos;{1}&apos;..
         /// </summary>
-        internal static string Subset
-        {
-            get
-            {
+        internal static string Subset {
+            get {
                 return ResourceManager.GetString("Subset", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field &apos;{0}&apos; included multiple instances of &apos;{1}&apos;..
         /// </summary>
-        internal static string SubsetDuplicate
-        {
-            get
-            {
+        internal static string SubsetDuplicate {
+            get {
                 return ResourceManager.GetString("SubsetDuplicate", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{2}&apos; of type {1} is not {0}..
         /// </summary>
-        internal static string Type
-        {
-            get
-            {
+        internal static string Type {
+            get {
                 return ResourceManager.GetString("Type", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{1}&apos; of type {0} is not an integer..
         /// </summary>
-        internal static string TypeInteger
-        {
-            get
-            {
+        internal static string TypeInteger {
+            get {
                 return ResourceManager.GetString("TypeInteger", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{1}&apos; of type {0} is not numeric..
         /// </summary>
-        internal static string TypeNumeric
-        {
-            get
-            {
+        internal static string TypeNumeric {
+            get {
                 return ResourceManager.GetString("TypeNumeric", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to None of the type name(s) match: {0}.
         /// </summary>
-        internal static string TypeOf
-        {
-            get
-            {
+        internal static string TypeOf {
+            get {
                 return ResourceManager.GetString("TypeOf", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value &apos;{0}&apos; is not a version string..
         /// </summary>
-        internal static string Version
-        {
-            get
-            {
+        internal static string Version {
+            get {
                 return ResourceManager.GetString("Version", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The version &apos;{0}&apos; does not match the constraint &apos;{1}&apos;..
         /// </summary>
-        internal static string VersionContraint
-        {
-            get
-            {
+        internal static string VersionContraint {
+            get {
                 return ResourceManager.GetString("VersionContraint", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The field value didn&apos;t match the set..
         /// </summary>
-        internal static string Within
-        {
-            get
-            {
+        internal static string Within {
+            get {
                 return ResourceManager.GetString("Within", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value &apos;{0}&apos; was within the set..
         /// </summary>
-        internal static string WithinNot
-        {
-            get
-            {
+        internal static string WithinNot {
+            get {
                 return ResourceManager.GetString("WithinNot", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The file &apos;{0}&apos; is not within the path &apos;{1}&apos;..
         /// </summary>
-        internal static string WithinPath
-        {
-            get
-            {
+        internal static string WithinPath {
+            get {
                 return ResourceManager.GetString("WithinPath", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/ReasonStrings.resx
+++ b/src/PSRule/Resources/ReasonStrings.resx
@@ -345,4 +345,13 @@
   <data name="Assert_NotExists" xml:space="preserve">
     <value>Exists.</value>
   </data>
+  <data name="Assert_Count" xml:space="preserve">
+    <value>The number of items is '{0}' instead of '{1}'.</value>
+  </data>
+  <data name="Assert_IsNull" xml:space="preserve">
+    <value>The value is null.</value>
+  </data>
+  <data name="Assert_NotCount" xml:space="preserve">
+    <value>The number of items is '{0}'.</value>
+  </data>
 </root>

--- a/src/PSRule/Runtime/Configuration.cs
+++ b/src/PSRule/Runtime/Configuration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System.Collections;
@@ -69,23 +69,7 @@ namespace PSRule.Runtime
         private bool TryGetValue(string name, out object value)
         {
             value = null;
-            if (_Context == null)
-                return false;
-
-            // Get from baseline configuration
-            if (_Context.LanguageScope.TryConfigurationValue(name, out var result))
-            {
-                value = result;
-                return true;
-            }
-
-            // Check if value exists in Rule definition defaults
-            if (_Context.RuleBlock == null || _Context.RuleBlock.Configuration == null || !_Context.RuleBlock.Configuration.ContainsKey(name))
-                return false;
-
-            // Get from rule default
-            value = _Context.RuleBlock.Configuration[name];
-            return true;
+            return _Context != null && _Context.TryGetConfigurationValue(name, out value);
         }
 
         private static bool TryBool(object o, out bool value)

--- a/src/PSRule/Runtime/Operand.cs
+++ b/src/PSRule/Runtime/Operand.cs
@@ -38,7 +38,12 @@ namespace PSRule.Runtime
         /// <summary>
         /// The target object itself.
         /// </summary>
-        Target = 5
+        Target = 5,
+
+        /// <summary>
+        /// A literal value or function.
+        /// </summary>
+        Value = 6
     }
 
     /// <summary>
@@ -115,6 +120,11 @@ namespace PSRule.Runtime
         internal static IOperand FromTarget()
         {
             return new Operand(OperandKind.Target, null, null);
+        }
+
+        internal static IOperand FromValue(object value)
+        {
+            return new Operand(OperandKind.Value, null, value);
         }
 
         internal static string JoinPath(string p1, string p2)

--- a/src/PSRule/Runtime/PSRule.cs
+++ b/src/PSRule/Runtime/PSRule.cs
@@ -136,7 +136,7 @@ namespace PSRule.Runtime
         /// <summary>
         /// The current target object.
         /// </summary>
-        public PSObject TargetObject => GetContext().RuleRecord.TargetObject;
+        public PSObject TargetObject => GetContext().TargetObject.Value;
 
         /// <summary>
         /// The bound name of the target object.

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -771,7 +771,6 @@ namespace PSRule.Runtime
         {
             InitLanguageScopes(source);
             Host.HostHelper.ImportResource(source, this);
-
             foreach (var languageScope in _LanguageScopes.Get())
                 Pipeline.Baseline.BuildScope(languageScope);
         }
@@ -840,6 +839,32 @@ namespace PSRule.Runtime
             _WarnOnce.Add(combinedKey);
             return true;
         }
+
+        #region Configuration
+
+        internal bool TryGetConfigurationValue(string name, out object value)
+        {
+            value = null;
+            if (string.IsNullOrEmpty(name))
+                return false;
+
+            // Get from baseline configuration
+            if (LanguageScope.TryConfigurationValue(name, out var result))
+            {
+                value = result;
+                return true;
+            }
+
+            // Check if value exists in Rule definition defaults
+            if (RuleBlock == null || RuleBlock.Configuration == null || !RuleBlock.Configuration.ContainsKey(name))
+                return false;
+
+            // Get from rule default
+            value = RuleBlock.Configuration[name];
+            return true;
+        }
+
+        #endregion Configuration
 
         #region IDisposable
 

--- a/tests/PSRule.Tests/FunctionBuilderTests.cs
+++ b/tests/PSRule.Tests/FunctionBuilderTests.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using PSRule.Configuration;
+using PSRule.Definitions.Selectors;
+using PSRule.Host;
+using PSRule.Pipeline;
+using PSRule.Runtime;
+using Xunit;
+using Assert = Xunit.Assert;
+
+namespace PSRule
+{
+    public sealed class FunctionBuilderTests
+    {
+        private const string FunctionYamlFileName = "Functions.Rule.yaml";
+        private const string FunctionJsonFileName = "Functions.Rule.jsonc";
+
+        [Theory]
+        [InlineData("Yaml", FunctionYamlFileName)]
+        [InlineData("Json", FunctionJsonFileName)]
+        public void Build(string type, string path)
+        {
+            Assert.NotNull(GetSelectorVisitor($"{type}.Fn.Example1", GetSource(path), out _));
+            Assert.NotNull(GetSelectorVisitor($"{type}.Fn.Example2", GetSource(path), out _));
+            Assert.NotNull(GetSelectorVisitor($"{type}.Fn.Example3", GetSource(path), out _));
+            Assert.NotNull(GetSelectorVisitor($"{type}.Fn.Example4", GetSource(path), out _));
+            Assert.NotNull(GetSelectorVisitor($"{type}.Fn.Example5", GetSource(path), out _));
+            Assert.NotNull(GetSelectorVisitor($"{type}.Fn.Example6", GetSource(path), out _));
+        }
+
+        #region Helper methods
+
+        private static PSRuleOption GetOption()
+        {
+            return new PSRuleOption();
+        }
+
+        private static Source[] GetSource(string path)
+        {
+            var builder = new SourcePipelineBuilder(null, null);
+            builder.Directory(GetSourcePath(path));
+            return builder.Build();
+        }
+
+        private static SelectorVisitor GetSelectorVisitor(string name, Source[] source, out RunspaceContext context)
+        {
+            context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, new OptionContext(), null), null);
+            context.Init(source);
+            context.Begin();
+            var selector = HostHelper.GetSelector(source, context).ToArray().FirstOrDefault(s => s.Name == name);
+            return new SelectorVisitor(selector.Id, selector.Source, selector.Spec.If);
+        }
+
+        private static string GetSourcePath(string fileName)
+        {
+            return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Tests/FunctionTests.cs
+++ b/tests/PSRule.Tests/FunctionTests.cs
@@ -1,0 +1,282 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Management.Automation;
+using PSRule.Configuration;
+using PSRule.Definitions.Expressions;
+using PSRule.Pipeline;
+using Xunit;
+
+namespace PSRule
+{
+    /// <summary>
+    /// Define tests for expression functions are working correctly.
+    /// </summary>
+    public sealed class FunctionTests
+    {
+        [Fact]
+        public void Concat()
+        {
+            var context = GetContext();
+            var fn = GetFunction("concat");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "concat", new object[] { "1", "2", "3" } }
+            };
+            Assert.Equal("123", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "concat", new object[] { 1, 2, 3 } }
+            };
+            Assert.Equal("123", fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Configuration()
+        {
+            var context = GetContext();
+            var fn = GetFunction("configuration");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "configuration", "config1" }
+            };
+            Assert.Equal("123", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "configuration", "notconfig" }
+            };
+            Assert.Null(fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Boolean()
+        {
+            var context = GetContext();
+            var fn = GetFunction("boolean");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "boolean", true }
+            };
+            Assert.Equal(true, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "boolean", false }
+            };
+            Assert.Equal(false, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "boolean", "true" }
+            };
+            Assert.Equal(true, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "boolean", "false" }
+            };
+            Assert.Equal(false, fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Integer()
+        {
+            var context = GetContext();
+            var fn = GetFunction("integer");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", 1 }
+            };
+            Assert.Equal(1, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", -1 }
+            };
+            Assert.Equal(-1, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", 0 }
+            };
+            Assert.Equal(0, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", "1" }
+            };
+            Assert.Equal(1, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", "-1" }
+            };
+            Assert.Equal(-1, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", "0" }
+            };
+            Assert.Equal(0, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "integer", "not" }
+            };
+            Assert.Equal(0, fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void String()
+        {
+            var context = GetContext();
+            var fn = GetFunction("string");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "string", 1 }
+            };
+            Assert.Equal("1", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "string", -1 }
+            };
+            Assert.Equal("-1", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "string", "1" }
+            };
+            Assert.Equal("1", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "string", "-1" }
+            };
+            Assert.Equal("-1", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "string", "0" }
+            };
+            Assert.Equal("0", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "string", "abc" }
+            };
+            Assert.Equal("abc", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "string", true }
+            };
+            Assert.Equal("True", fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Substring()
+        {
+            var context = GetContext();
+            var fn = GetFunction("substring");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "substring", "TestObject" },
+                { "length", 7 }
+            };
+            Assert.Equal("TestObj", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "substring", "TestObject" },
+                { "length", "7" }
+            };
+            Assert.Equal("TestObj", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "substring", 10000 },
+                { "length", 2 }
+            };
+            Assert.Null(fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "substring", "Test" },
+                { "length", 100 }
+            };
+            Assert.Equal("Test", fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Path()
+        {
+            var context = GetContext();
+            var fn = GetFunction("path");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "path", "name" }
+            };
+            Assert.Equal("TestObject1", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "path", "notProperty" }
+            };
+            Assert.Null(fn(context, properties)(context));
+        }
+
+        #region Helper methods
+
+        private static ExpressionBuilderFn GetFunction(string name)
+        {
+            return Functions.Builtin.Single(f => f.Name == name).Fn;
+        }
+
+        private static PSRuleOption GetOption()
+        {
+            var option = new PSRuleOption();
+            option.Configuration["config1"] = "123";
+            return option;
+        }
+
+        private static Source[] GetSource()
+        {
+            var builder = new SourcePipelineBuilder(null, null);
+            builder.Directory(GetSourcePath("Selectors.Rule.yaml"));
+            return builder.Build();
+        }
+
+        private static ExpressionContext GetContext()
+        {
+            var targetObject = new PSObject();
+            targetObject.Properties.Add(new PSNoteProperty("name", "TestObject1"));
+            var context = new Runtime.RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, new OptionContextBuilder(GetOption(), null, null, null).Build(), null), null);
+            var s = GetSource();
+            var result = new ExpressionContext(s[0].File[0], Definitions.ResourceKind.Rule, targetObject);
+            context.Init(s);
+            context.Begin();
+            context.PushScope(Runtime.RunspaceScope.Precondition);
+            context.EnterTargetObject(new TargetObject(targetObject));
+            return result;
+        }
+
+        private static string GetSourcePath(string fileName)
+        {
+            return System.IO.Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
+        }
+
+        #endregion Helper methods
+    }
+}

--- a/tests/PSRule.Tests/Functions.Rule.jsonc
+++ b/tests/PSRule.Tests/Functions.Rule.jsonc
@@ -1,0 +1,133 @@
+[
+    {
+        // Synopsis: An expression function example.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Json.Fn.Example1"
+        },
+        "spec": {
+            "if": {
+                "value": {
+                    "$": {
+                        "substring": {
+                            "path": "name"
+                        },
+                        "length": 7
+                    }
+                },
+                "equals": "TestObj"
+            }
+        }
+    },
+    {
+        // Synopsis: An expression function example.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Json.Fn.Example2"
+        },
+        "spec": {
+            "if": {
+                "value": {
+                    "$": {
+                        "configuration": "ConfigArray"
+                    }
+                },
+                "count": 5
+            }
+        }
+    },
+    {
+        // Synopsis: An expression function example.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Json.Fn.Example3"
+        },
+        "spec": {
+            "if": {
+                "value": {
+                    "$": {
+                        "boolean": true
+                    }
+                },
+                "equals": true
+            }
+        }
+    },
+    {
+        // Synopsis: An expression function example.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Json.Fn.Example4"
+        },
+        "spec": {
+            "if": {
+                "value": {
+                    "$": {
+                        "concat": [
+                            {
+                                "path": "name"
+                            },
+                            {
+                                "string": "-"
+                            },
+                            {
+                                "path": "name"
+                            }
+                        ]
+                    }
+                },
+                "equals": "TestObject1-TestObject1"
+            }
+        }
+    },
+    {
+        // Synopsis: An expression function example.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Json.Fn.Example5"
+        },
+        "spec": {
+            "if": {
+                "value": {
+                    "$": {
+                        "integer": 6
+                    }
+                },
+                "greater": 5
+            }
+        }
+    },
+    {
+        // Synopsis: An expression function example.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Selector",
+        "metadata": {
+            "name": "Json.Fn.Example6"
+        },
+        "spec": {
+            "if": {
+                "value": "TestObject1-TestObject1",
+                "equals": {
+                    "$": {
+                        "concat": [
+                            {
+                                "path": "name"
+                            },
+                            {
+                                "string": "-"
+                            },
+                            {
+                                "path": "name"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+]

--- a/tests/PSRule.Tests/Functions.Rule.yaml
+++ b/tests/PSRule.Tests/Functions.Rule.yaml
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example1
+spec:
+  if:
+    value:
+      $:
+        substring:
+          path: name
+        length: 7
+    equals: TestObj
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example2
+spec:
+  if:
+    value:
+      $:
+        configuration: 'ConfigArray'
+    count: 5
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example3
+spec:
+  if:
+    value:
+      $:
+        boolean: true
+    equals: true
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example4
+spec:
+  if:
+    value:
+      $:
+        concat:
+        - path: name
+        - string: '-'
+        - path: name
+    equals: TestObject1-TestObject1
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example5
+spec:
+  if:
+    value:
+      $:
+        integer: 6
+    greater: 5
+
+---
+# Synopsis: An expression function example.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Example6
+spec:
+  if:
+    value: TestObject1-TestObject1
+    equals:
+      $:
+        concat:
+        - path: name
+        - string: '-'
+        - path: name

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -70,6 +70,12 @@
     <None Update="FromFileName.Rule.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Functions.Rule.jsonc">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Functions.Rule.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="ModuleConfig.Rule.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -27,6 +27,8 @@ namespace PSRule
     {
         private const string SelectorYamlFileName = "Selectors.Rule.yaml";
         private const string SelectorJsonFileName = "Selectors.Rule.jsonc";
+        private const string FunctionsYamlFileName = "Functions.Rule.yaml";
+        private const string FunctionsJsonFileName = "Functions.Rule.jsonc";
 
         [Theory]
         [InlineData("Yaml", SelectorYamlFileName)]
@@ -1651,11 +1653,40 @@ namespace PSRule
 
         #endregion Properties
 
+        #region Functions
+
+        [Theory]
+        [InlineData("Yaml", FunctionsYamlFileName)]
+        [InlineData("Json", FunctionsJsonFileName)]
+        public void WithFunction(string type, string path)
+        {
+            var example1 = GetSelectorVisitor($"{type}.Fn.Example1", GetSource(path), out _);
+            var example2 = GetSelectorVisitor($"{type}.Fn.Example2", GetSource(path), out _);
+            var example3 = GetSelectorVisitor($"{type}.Fn.Example3", GetSource(path), out _);
+            var example4 = GetSelectorVisitor($"{type}.Fn.Example4", GetSource(path), out _);
+            var example5 = GetSelectorVisitor($"{type}.Fn.Example5", GetSource(path), out _);
+            var example6 = GetSelectorVisitor($"{type}.Fn.Example6", GetSource(path), out _);
+            var actual1 = GetObject(
+                (name: "Name", value: "TestObject1")
+            );
+
+            Assert.True(example1.Match(actual1));
+            Assert.True(example2.Match(actual1));
+            Assert.True(example3.Match(actual1));
+            Assert.True(example4.Match(actual1));
+            Assert.True(example5.Match(actual1));
+            Assert.True(example6.Match(actual1));
+        }
+
+        #endregion Functions
+
         #region Helper methods
 
         private static PSRuleOption GetOption()
         {
-            return new PSRuleOption();
+            var option = new PSRuleOption();
+            option.Configuration["ConfigArray"] = new string[] { "1", "2", "3", "4", "5" };
+            return option;
         }
 
         private static Source[] GetSource(string path)
@@ -1676,7 +1707,8 @@ namespace PSRule
 
         private static SelectorVisitor GetSelectorVisitor(string name, Source[] source, out RunspaceContext context)
         {
-            context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, new OptionContext(), null), null);
+            var builder = new OptionContextBuilder(GetOption(), null, null, null);
+            context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, builder.Build(), null), null);
             context.Init(source);
             context.Begin();
             var selector = HostHelper.GetSelector(source, context).ToArray().FirstOrDefault(s => s.Name == name);


### PR DESCRIPTION
## PR Summary

- **Experimental**: Added support for functions within YAML and JSON expressions.
  - Added conversion functions `boolean`, `string`, and `integer`.
  - Added lookup functions `configuration`, and `path`.
  - Added string functions `concat`, `substring`.

Progress towards #1227

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
