### PR TITLE
Added sub-selectors for YAML and JSON #1024 #1045

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -20,7 +20,7 @@
     "no-reversed-links": true,
     "no-multiple-blanks": true,
     "line-length": {
-        "line_length": 100,
+        "line_length": 120,
         "code_blocks": false,
         "tables": false,
         "headers": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,7 +22,8 @@
         "./schemas/PSRule-language.schema.json": [
             "/tests/PSRule.Tests/**.Rule.yaml",
             "/tests/PSRule.Tests/**/**.Rule.yaml",
-            "/docs/scenarios/*/*.Rule.yaml"
+            "/docs/scenarios/*/*.Rule.yaml",
+            "/docs/expressions/**/*.Rule.yaml"
         ]
     },
     "json.schemas": [
@@ -30,6 +31,7 @@
             "fileMatch": [
                 "/tests/PSRule.Tests/**.Rule.jsonc",
                 "/tests/PSRule.Tests/**/**.Rule.jsonc",
+                "/docs/expressions/**/*.Rule.jsonc"
             ],
             "url": "./schemas/PSRule-resources.schema.json"
         }

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -13,9 +13,25 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 **Experimental features**:
 
-- Functions within YAML expressions can be used to perform manipulation prior to testing a condition.
+- Functions within YAML and JSON expressions can be used to perform manipulation prior to testing a condition.
+  See [functions][3] for more information.
+- Sub-selectors within YAML and JSON expressions can be used to filter rules and list properties.
+  See [sub-selectors][4] for more information.
+
+  [3]: expressions/functions.md
+  [4]: expressions/sub-selectors.md
 
 ## Unreleased
+
+What's changed since pre-release v2.4.0-B0039:
+
+- New features:
+  - **Experimental**: Added support for sub-selectors YAML and JSON expressions by @BernieWhite.
+    [#1024](https://github.com/microsoft/PSRule/issues/1024)
+    [#1045](https://github.com/microsoft/PSRule/issues/1045)
+    - Sub-selector pre-conditions add an additional expression to determine if a rule is executed.
+    - Sub-selector object filters provide an way to filter items from list properties.
+    - See [sub-selectors][4] for more information.
 
 ## v2.4.0-B0039 (pre-release)
 
@@ -27,6 +43,7 @@ What's changed since pre-release v2.4.0-B0022:
     - Added conversion functions `boolean`, `string`, and `integer`.
     - Added lookup functions `configuration`, and `path`.
     - Added string functions `concat`, `substring`.
+    - See [functions][3] for more information.
 - Bug fixes:
   - Fixed reporting of duplicate identifiers which were not generating an error for all cases by @BernieWhite.
     [#1229](https://github.com/microsoft/PSRule/issues/1229)

--- a/docs/expressions/SubSelectors.Rule.jsonc
+++ b/docs/expressions/SubSelectors.Rule.jsonc
@@ -1,0 +1,74 @@
+[
+  {
+    // Synopsis: A rule with a sub-selector precondition.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "Json.Subselector.Precondition"
+    },
+    "spec": {
+      "where": {
+        "field": "kind",
+        "equals": "api"
+      },
+      "condition": {
+        "field": "resources",
+        "count": 10
+      }
+    }
+  },
+  {
+    // Synopsis: A rule with a sub-selector filter.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "Json.Subselector.Filter"
+    },
+    "spec": {
+      "condition": {
+        "field": "resources",
+        "where": {
+          "type": ".",
+          "equals": "Microsoft.Web/sites/config"
+        },
+        "allOf": [
+          {
+            "field": "properties.detailedErrorLoggingEnabled",
+            "equals": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    // Synopsis: A rule with a sub-selector filter.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Rule",
+    "metadata": {
+      "name": "Json.Subselector.FilterOr"
+    },
+    "spec": {
+      "condition": {
+        "anyOf": [
+          {
+            "field": "resources",
+            "where": {
+              "type": ".",
+              "equals": "Microsoft.Web/sites/config"
+            },
+            "allOf": [
+              {
+                "field": "properties.detailedErrorLoggingEnabled",
+                "equals": true
+              }
+            ]
+          },
+          {
+            "field": "resources",
+            "exists": false
+          }
+        ]
+      }
+    }
+  }
+]

--- a/docs/expressions/SubSelectors.Rule.yaml
+++ b/docs/expressions/SubSelectors.Rule.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# YAML-based rules for documentation
+#
+
+---
+# Synopsis: A rule with a sub-selector precondition.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Yaml.Subselector.Precondition
+spec:
+  where:
+    field: 'kind'
+    equals: 'api'
+  condition:
+    field: resources
+    count: 10
+
+---
+# Synopsis: A rule with a sub-selector filter.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Yaml.Subselector.Filter
+spec:
+  condition:
+    field: resources
+    where:
+      type: '.'
+      equals: 'Microsoft.Web/sites/config'
+    allOf:
+    - field: properties.detailedErrorLoggingEnabled
+      equals: true
+
+---
+# Synopsis: A rule with a sub-selector filter.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: Yaml.Subselector.FilterOr
+spec:
+  condition:
+    anyOf:
+
+    - field: resources
+      where:
+        type: '.'
+        equals: 'Microsoft.Web/sites/config'
+      allOf:
+      - field: properties.detailedErrorLoggingEnabled
+        equals: true
+
+    - field: resources
+      exists: false

--- a/docs/expressions/functions.md
+++ b/docs/expressions/functions.md
@@ -1,15 +1,21 @@
-# Expression functions
+# Functions
 
 !!! Abstract
-    Functions are an advanced lanaguage feature specific to YAML and JSON resources.
+    _Functions_ are an advanced lanaguage feature specific to YAML and JSON expressions.
     That extend the language to allow for more complex use cases with expressions.
+    Functions don't apply to script expressions because PowerShell already has rich support for complex manipulation.
 
 !!! Experimental
-    Functions are a work in progress and subject to change.
+    _Functions_ are a work in progress and subject to change.
     We hope to add more functions, broader support, and more detailed documentation in the future.
     [Join or start a disucssion][1] to let us know how we can improve this feature going forward.
 
   [1]: https://github.com/microsoft/PSRule/discussions
+
+Functions cover two (2) main scenarios:
+
+- **Transformation** &mdash; you need to perform minor transformation before a condition.
+- **Configuration** &mdash; you want to configure an input into a condition.
 
 ## Using functions
 

--- a/docs/expressions/sub-selectors.md
+++ b/docs/expressions/sub-selectors.md
@@ -1,0 +1,272 @@
+# Sub-selectors
+
+!!! Abstract
+    This topic covers _sub-selectors_ which are a PSRule language feature specific to YAML and JSON expressions.
+    They are useful for filtering out objects that you do not want to evaluate.
+    Sub-selectors don't apply to script expressions because PowerShell already has rich support for filtering.
+
+!!! Experimental
+    _Sub-selectors_ are a work in progress and subject to change.
+    We hope to add broader support, and more detailed documentation in the future.
+    [Join or start a disucssion][1] to let us know how we can improve this feature going forward.
+
+  [1]: https://github.com/microsoft/PSRule/discussions
+
+Sub-selectors cover two (2) main scenarios:
+
+- **Pre-conditions** &mdash; you want to filtering out objects before a rule is run.
+- **Object filtering** &mdash; you want to limit a condition to specific elements in a list of items.
+
+## Pre-conditions
+
+PSRule can process many different types of objects.
+Rules however, are normally written to test a specific property or type of object.
+So it is important that rules only run on objects that you want to evaluate.
+Pre-condition sub-selectors are one way you can determine if a rule should be run.
+
+To use a sub-selector as a pre-condition, use the `where` property, directly under the `spec`.
+The expressions in the sub-selector follow the same form that you can use in rules.
+
+For example:
+
+=== "YAML"
+
+    ```yaml hl_lines="8-10"
+    ---
+    # Synopsis: A rule with a sub-selector precondition.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: Rule
+    metadata:
+      name: Yaml.Subselector.Precondition
+    spec:
+      where:
+        field: 'kind'
+        equals: 'api'
+      condition:
+        field: resources
+        count: 10
+    ```
+
+=== "JSON"
+
+    ```json hl_lines="9-12"
+    {
+      // Synopsis: A rule with a sub-selector precondition.
+      "apiVersion": "github.com/microsoft/PSRule/v1",
+      "kind": "Rule",
+      "metadata": {
+        "name": "Json.Subselector.Precondition"
+      },
+      "spec": {
+        "where": {
+          "field": "kind",
+          "equals": "api"
+        },
+        "condition": {
+          "field": "resources",
+          "count": 10
+        }
+      }
+    }
+    ```
+
+In the example:
+
+1. The `where` property is the start of a sub-selector.
+2. The sub-selector checks if the `kind` property equals `api`.
+
+The rule does not run if the:
+
+- The object does not have a `kind` property. **OR**
+- The value of the `kind` property is not `api`.
+
+!!! Tip
+    Other types of pre-conditions also exist that allow you to filter based on type or by a shared selector.
+
+## Object filter
+
+When you are evaluating an object, you can use sub-selectors to limit the condition.
+This is helpful when dealing with properties that are a list of items.
+Properties that contain a list of items may contain a sub-set of items that you want to evaluate.
+
+For example, the object may look like this:
+
+=== "YAML"
+
+    ```yaml
+    name: app1
+    type: Microsoft.Web/sites
+    resources:
+    - name: web
+      type: Microsoft.Web/sites/config
+      properties:
+        detailedErrorLoggingEnabled: true
+    ```
+
+=== "JSON"
+
+    ```json
+    {
+      "name": "app1",
+      "type": "Microsoft.Web/sites",
+      "resources": [
+        {
+          "name": "web",
+          "type": "Microsoft.Web/sites/config",
+          "properties": {
+            "detailedErrorLoggingEnabled": true
+          }
+        }
+      ]
+    }
+    ```
+
+A rule to test if any sub-resources with the `detailedErrorLoggingEnabled` set to `true` exist might look like this:
+
+=== "YAML"
+
+    ```yaml hl_lines="10-12"
+    ---
+    # Synopsis: A rule with a sub-selector filter.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: Rule
+    metadata:
+      name: Yaml.Subselector.Filter
+    spec:
+      condition:
+        field: resources
+        where:
+          type: '.'
+          equals: 'Microsoft.Web/sites/config'
+        allOf:
+        - field: properties.detailedErrorLoggingEnabled
+          equals: true
+    ```
+
+=== "JSON"
+
+    ```json
+    {
+      // Synopsis: A rule with a sub-selector filter.
+      "apiVersion": "github.com/microsoft/PSRule/v1",
+      "kind": "Rule",
+      "metadata": {
+        "name": "Json.Subselector.Filter"
+      },
+      "spec": {
+        "condition": {
+          "field": "resources",
+          "where": {
+            "type": ".",
+            "equals": "Microsoft.Web/sites/config"
+          },
+          "allOf": [
+            {
+              "field": "properties.detailedErrorLoggingEnabled",
+              "equals": true
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+In the example:
+
+- If the array property `resources` exists, any items with a type of `Microsoft.Web/sites/config` are evaluated.
+  - Each item must have the `properties.detailedErrorLoggingEnabled` property set to `true` to pass.
+  - Items without the `properties.detailedErrorLoggingEnabled` property fail.
+  - Items with the `properties.detailedErrorLoggingEnabled` property set to a value other then `true` fail.
+- If the `resources` property does not exist, the rule fails.
+- If the `resources` property exists but has 0 items of type `Microsoft.Web/sites/config`, the rule fails.
+- If the `resources` property exists and has any items of type `Microsoft.Web/sites/config` but any fail, the rule fails.
+- If the `resources` property exists and has any items of type `Microsoft.Web/sites/config` and all pass, the rule passes.
+
+### When there are no results
+
+Given the example, is important to understand what happens if:
+
+- The `resources` property doesn't exist.
+- The `resources` property doesn't contain any items that match the sub-selector condition.
+
+In either of these two cases, the sub-selector will return `false` and fail the rule.
+The rule fails because there is no secondary conditions that could be used instead.
+
+If this was not the desired behavior, you could:
+
+- Use a pre-condition to avoid running the rule.
+- Group the sub-selector into a `anyOf`, and provide a secondary condition.
+
+For example:
+
+=== "YAML"
+
+    ```yaml hl_lines="9 11-14 19-20"
+    ---
+    # Synopsis: A rule with a sub-selector filter.
+    apiVersion: github.com/microsoft/PSRule/v1
+    kind: Rule
+    metadata:
+      name: Yaml.Subselector.FilterOr
+    spec:
+      condition:
+        anyOf:
+
+        - field: resources
+          where:
+            type: '.'
+            equals: 'Microsoft.Web/sites/config'
+          allOf:
+          - field: properties.detailedErrorLoggingEnabled
+            equals: true
+
+        - field: resources
+          exists: false
+    ```
+
+=== "JSON"
+
+    ```json hl_lines="10 12-16 25-26"
+    {
+      // Synopsis: A rule with a sub-selector filter.
+      "apiVersion": "github.com/microsoft/PSRule/v1",
+      "kind": "Rule",
+      "metadata": {
+        "name": "Json.Subselector.FilterOr"
+      },
+      "spec": {
+        "condition": {
+          "anyOf": [
+            {
+              "field": "resources",
+              "where": {
+                "type": ".",
+                "equals": "Microsoft.Web/sites/config"
+              },
+              "allOf": [
+                {
+                  "field": "properties.detailedErrorLoggingEnabled",
+                  "equals": true
+                }
+              ]
+            },
+            {
+              "field": "resources",
+              "exists": false
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+In the example:
+
+- If the array property `resources` exists, any items with a type of `Microsoft.Web/sites/config` are evaluated.
+  - Each item must have the `properties.detailedErrorLoggingEnabled` property set to `true` to pass.
+  - Items without the `properties.detailedErrorLoggingEnabled` property fail.
+  - Items with the `properties.detailedErrorLoggingEnabled` property set to a value other then `true` fail.
+- If the `resources` property does not exist, the rule passes.
+- If the `resources` property exists but has 0 items of type `Microsoft.Web/sites/config`, the rule fails.
+- If the `resources` property exists and has any items of type `Microsoft.Web/sites/config` but any fail, the rule fails.
+- If the `resources` property exists and has any items of type `Microsoft.Web/sites/config` and all pass, the rule passes.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,37 @@
+# Changes and versioning
+
+PSRule uses [semantic versioning][1] to declare breaking changes.
+The latest module version can be installed from the PowerShell Gallery.
+For a list of module changes please see the [change log][2].
+
+  [1]: https://semver.org/
+  [2]: https://aka.ms/ps-rule/changelog
+
+## Pre-releases
+
+Pre-release module versions are created on major commits and can be installed from the PowerShell Gallery.
+Module versions and change log details for pre-releases will be removed as stable releases are made available.
+
+!!! Important
+    Pre-release versions should be considered work in progress.
+    These releases should not be used in production.
+    We may introduce breaking changes between a pre-release as we work towards a stable version release.
+
+## Experimental features
+
+From time to time we may ship experimential features.
+These features are generally marked experimential in the change log as these features ship.
+Experimental features may ship in stable releases, however to use them you may need to:
+
+- Enabled or explictly reference them.
+
+!!! Important
+   Experimental features should be considered work in progress.
+   These features may be incomplete and should not be used in production.
+   We may introduce breaking changes for experimental features as we work towards a general release for the feature.
+
+## Reporting bugs
+
+If you experience an issue with an pre-release or experimental feature please let us know by logging an issue as a [bug][3].
+
+  [3]: https://github.com/microsoft/PSRule/issues

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ theme:
       level: 1
   - navigation.tabs
   - content.code.annotate
+  - content.tabs.link
 
 nav:
   - Home: index.md
@@ -55,8 +56,9 @@ nav:
       - Azure resource tagging example: scenarios/azure-tags/azure-tags.md
       - Kubernetes resource validation example: scenarios/kubernetes-resources/kubernetes-resources.md
     - Concepts:
-      - Expressions:
-        - Functions: expressions/functions.md
+      - Functions: expressions/functions.md
+      - Sub-selectors: expressions/sub-selectors.md
+    - Scenarios:
       - Using within continuous integration: scenarios/validation-pipeline/validation-pipeline.md
     # - Troubleshooting: troubleshooting.md
     - License and contributing: license-contributing.md
@@ -68,6 +70,7 @@ nav:
         - v0: 'CHANGELOG-v0.md'
       - Upgrade notes: upgrade-notes.md
       - Deprecations: deprecations.md
+      - Changes and versioning: versioning.md
     - Support: support.md
   # - Setup:
   #   - Configuring options: setup/configuring-options.md

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -458,7 +458,7 @@
                     "title": "If",
                     "description": "A condition is made up of one or more expressions that will determine if an object is selected by the selector.",
                     "markdownDescription": "A condition is made up of one or more [expressions](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/) that will determine if an object is selected by the selector. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Selectors/)",
-                    "$ref": "#/definitions/selectorExpression"
+                    "$ref": "#/definitions/expressions"
                 }
             },
             "required": [
@@ -520,7 +520,7 @@
                 },
                 "if": {
                     "type": "object",
-                    "$ref": "#/definitions/selectorExpression"
+                    "$ref": "#/definitions/expressions"
                 }
             },
             "required": [
@@ -577,8 +577,12 @@
                     "type": "object",
                     "title": "Condition",
                     "description": "A condition is made up of one or more expressions that will determine if the rule passes or fails.",
-                    "markdownDescription": "A condition is made up of one or more [expressions](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/) that will determine if the rule passes or fails. [See help](https://microsoft.github.io/PSRule/v2/authoring/writing-rules/)",
-                    "$ref": "#/definitions/selectorExpression"
+                    "markdownDescription": "A condition is made up of one or more [expressions](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/) that will determine if the rule passes or fails.\n\n[See help](https://microsoft.github.io/PSRule/v2/authoring/writing-rules/)",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/expressions"
+                        }
+                    ]
                 },
                 "level": {
                     "type": "string",
@@ -597,7 +601,8 @@
                     "title": "Type pre-condition",
                     "description": "This rule only applies to objects that match the specifies types.",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "default": ""
                     },
                     "uniqueItems": true
                 },
@@ -606,15 +611,30 @@
                     "title": "Selector pre-condition",
                     "description": "This rule only applies to objects that match the specified selectors.",
                     "items": {
-                        "type": "string"
+                        "type": "string",
+                        "default": ""
                     },
                     "uniqueItems": true
+                },
+                "where": {
+                    "type": "object",
+                    "title": "Sub-selector pre-condition",
+                    "description": "The rule only applies to objects that match the sub-selector condition.",
+                    "markdownDescription": "The rule only applies to objects that match the sub-selector condition.\n\n[See help](https://microsoft.github.io/PSRule/v2/expressions/sub-selectors/)",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/expressions"
+                        }
+                    ]
                 }
             },
             "required": [
                 "condition"
             ],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "default": {
+                "condition": {}
+            }
         },
         "ruleMetadata": {
             "type": "object",
@@ -666,1286 +686,6 @@
                 "name"
             ]
         },
-        "selectorExpression": {
-            "type": "object",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorOperator"
-                },
-                {
-                    "$ref": "#/definitions/selectorCondition"
-                }
-            ]
-        },
-        "selectorOperator": {
-            "type": "object",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorOperatorAllOf"
-                },
-                {
-                    "$ref": "#/definitions/selectorOperatorAnyOf"
-                },
-                {
-                    "$ref": "#/definitions/selectorOperatorNot"
-                }
-            ]
-        },
-        "selectorCondition": {
-            "type": "object",
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorConditionExists"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionEquals"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotEquals"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionHasValue"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionMatch"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotMatch"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIn"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotIn"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionSetOf"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionSubset"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionCount"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotCount"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionLess"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionLessOrEquals"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionGreater"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionGreaterOrEquals"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionStartsWith"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotStartsWith"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionEndsWith"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotEndsWith"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionContains"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotContains"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsString"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsLower"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsArray"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsBoolean"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsDateTime"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsInteger"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsNumeric"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionIsUpper"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionHasSchema"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionVersion"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionHasDefault"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionWithinPath"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotWithinPath"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionLike"
-                },
-                {
-                    "$ref": "#/definitions/selectorConditionNotLike"
-                }
-            ]
-        },
-        "selectorProperties": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertyField"
-                },
-                {
-                    "$ref": "#/definitions/selectorPropertyValue"
-                }
-            ]
-        },
-        "selectorPropertiesString": {
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertyField"
-                },
-                {
-                    "$ref": "#/definitions/selectorPropertyValue"
-                },
-                {
-                    "$ref": "#/definitions/selectorPropertyType"
-                },
-                {
-                    "$ref": "#/definitions/selectorPropertyName"
-                },
-                {
-                    "$ref": "#/definitions/selectorPropertySource"
-                }
-            ]
-        },
-        "selectorPropertyField": {
-            "properties": {
-                "field": {
-                    "type": "string",
-                    "title": "Field",
-                    "description": "The object path of a field to compare.",
-                    "markdownDescription": "The object path of a field to compare. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#field)",
-                    "default": "."
-                }
-            },
-            "required": [
-                "field"
-            ]
-        },
-        "selectorPropertyValue": {
-            "properties": {
-                "value": {
-                    "$ref": "#/definitions/selectorExpressionValue"
-                }
-            },
-            "required": [
-                "value"
-            ]
-        },
-        "selectorPropertyType": {
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "title": "Type",
-                    "description": "The target type of the object.",
-                    "markdownDescription": "The target type of the object. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#type)",
-                    "default": "."
-                }
-            },
-            "required": [
-                "type"
-            ]
-        },
-        "selectorPropertyName": {
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "title": "Name",
-                    "description": "The target name of the object.",
-                    "markdownDescription": "The target name of the object. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#name)",
-                    "default": "."
-                }
-            },
-            "required": [
-                "name"
-            ]
-        },
-        "selectorPropertySource": {
-            "properties": {
-                "source": {
-                    "type": "string",
-                    "title": "Source",
-                    "description": "The source of the object currently being processed by the pipeline.",
-                    "markdownDescription": "The source of the object currently being processed by the pipeline. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#source)"
-                }
-            },
-            "required": [
-                "source"
-            ]
-        },
-        "selectorOperatorAllOf": {
-            "type": "object",
-            "properties": {
-                "allOf": {
-                    "type": "array",
-                    "title": "All Of",
-                    "description": "All of the expressions must be true.",
-                    "markdownDescription": "All of the expressions must be true. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#allof)",
-                    "items": {
-                        "$ref": "#/definitions/selectorExpression"
-                    }
-                }
-            },
-            "required": [
-                "allOf"
-            ],
-            "additionalProperties": false
-        },
-        "selectorOperatorAnyOf": {
-            "type": "object",
-            "properties": {
-                "anyOf": {
-                    "type": "array",
-                    "title": "Any Of",
-                    "description": "One of the expressions must be true.",
-                    "markdownDescription": "All of the expressions must be true. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#anyof)",
-                    "items": {
-                        "$ref": "#/definitions/selectorExpression"
-                    }
-                }
-            },
-            "required": [
-                "anyOf"
-            ],
-            "additionalProperties": false
-        },
-        "selectorOperatorNot": {
-            "type": "object",
-            "properties": {
-                "not": {
-                    "type": "object",
-                    "title": "Not",
-                    "description": "The nested expression must not be true.",
-                    "markdownDescription": "The nested expression must not be true. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#not)",
-                    "$ref": "#/definitions/selectorExpression"
-                }
-            },
-            "required": [
-                "not"
-            ]
-        },
-        "selectorConditionExists": {
-            "type": "object",
-            "properties": {
-                "exists": {
-                    "type": "boolean",
-                    "title": "Exists",
-                    "description": "Must have the named field.",
-                    "markdownDescription": "Must have the named field. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#exists)"
-                },
-                "field": {
-                    "type": "string",
-                    "title": "Field",
-                    "description": "The path of the field.",
-                    "markdownDescription": "The path of the field. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#field)"
-                }
-            },
-            "required": [
-                "exists",
-                "field"
-            ]
-        },
-        "selectorConditionEquals": {
-            "type": "object",
-            "properties": {
-                "equals": {
-                    "title": "Equals",
-                    "description": "Must have the specified value.",
-                    "markdownDescription": "Must have the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
-                    "$ref": "#/definitions/selectorExpressionValue"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type of compared operand.",
-                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive. Only applies to string values.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. Only applies to string values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
-                    "default": false
-                }
-            },
-            "required": [
-                "equals"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotEquals": {
-            "type": "object",
-            "properties": {
-                "notEquals": {
-                    "title": "Not Equals",
-                    "description": "Must not have the specified value.",
-                    "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
-                    "$ref": "#/definitions/selectorExpressionValue"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type of compared operand.",
-                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive. Only applies to string values.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. Only applies to string values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
-                    "default": false
-                }
-            },
-            "required": [
-                "notEquals"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionHasValue": {
-            "type": "object",
-            "properties": {
-                "hasValue": {
-                    "type": "boolean",
-                    "title": "Has Value",
-                    "description": "Must have a non-empty value.",
-                    "markdownDescription": "Must have a non-empty value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasvalue)"
-                }
-            },
-            "required": [
-                "hasValue"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionMatch": {
-            "type": "object",
-            "properties": {
-                "match": {
-                    "type": "string",
-                    "title": "Match",
-                    "description": "Must match the regular expression.",
-                    "markdownDescription": "Must match the regular expression. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#match)"
-                }
-            },
-            "required": [
-                "match"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotMatch": {
-            "type": "object",
-            "properties": {
-                "notMatch": {
-                    "type": "string",
-                    "title": "Not Match",
-                    "description": "Must not match the regular expression.",
-                    "markdownDescription": "Must not match the regular expression. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notmatch)"
-                }
-            },
-            "required": [
-                "notMatch"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIn": {
-            "type": "object",
-            "properties": {
-                "in": {
-                    "type": "array",
-                    "title": "In",
-                    "description": "Must equal one of the specified values.",
-                    "markdownDescription": "Must equal one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#in)"
-                }
-            },
-            "required": [
-                "in"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotIn": {
-            "type": "object",
-            "properties": {
-                "notIn": {
-                    "type": "array",
-                    "title": "Not In",
-                    "description": "Must not equal any of the specified values.",
-                    "markdownDescription": "Must not equal any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notin)"
-                }
-            },
-            "required": [
-                "notIn"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionSetOf": {
-            "type": "object",
-            "properties": {
-                "setOf": {
-                    "type": "array",
-                    "title": "SetOf",
-                    "description": "Must include all of but only specified values.",
-                    "markdownDescription": "Must include all of but only values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#setof)"
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#setof)",
-                    "default": false
-                }
-            },
-            "required": [
-                "setOf"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionSubset": {
-            "type": "object",
-            "properties": {
-                "subset": {
-                    "type": "array",
-                    "title": "Subset",
-                    "description": "Must include all of the specified values.",
-                    "markdownDescription": "Must include all of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#subset)"
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#subset)",
-                    "default": false
-                },
-                "unique": {
-                    "type": "boolean",
-                    "title": "Unique",
-                    "description": "Determines if each of the field values must be unique.",
-                    "markdownDescription": "Determines if each of the field values must be unique. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#subset)",
-                    "default": false
-                }
-            },
-            "required": [
-                "subset"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionCount": {
-            "type": "object",
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "title": "Count",
-                    "description": "Must include all of the specified values.",
-                    "markdownDescription": "Must include all of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#count)",
-                    "minimum": 0
-                }
-            },
-            "required": [
-                "count"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionNotCount": {
-            "type": "object",
-            "properties": {
-                "notCount": {
-                    "type": "integer",
-                    "title": "NotCount",
-                    "description": "Determines if operand does not have number of items.",
-                    "markdownDescription": "Determines if operand does not have number of items. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcount)",
-                    "minimum": 0
-                }
-            },
-            "required": [
-                "notCount"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionLess": {
-            "type": "object",
-            "properties": {
-                "less": {
-                    "type": "integer",
-                    "title": "Less",
-                    "description": "Must be less then the specified value.",
-                    "markdownDescription": "Must be less then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type of compared operand.",
-                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
-                    "default": false
-                }
-            },
-            "required": [
-                "less"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionLessOrEquals": {
-            "type": "object",
-            "properties": {
-                "lessOrEquals": {
-                    "type": "integer",
-                    "title": "Less or Equal to",
-                    "description": "Must be less or equal to the specified value.",
-                    "markdownDescription": "Must be less or equal to the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#lessorequals)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type of compared operand.",
-                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
-                    "default": false
-                }
-            },
-            "required": [
-                "lessOrEquals"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionGreater": {
-            "type": "object",
-            "properties": {
-                "greater": {
-                    "title": "Greater",
-                    "description": "Must be greater then the specified value.",
-                    "markdownDescription": "Must be greater then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greater)",
-                    "oneOf": [
-                        {
-                            "type": "integer"
-                        },
-                        {
-                            "type": "object",
-                            "$ref": "#/definitions/fn"
-                        }
-                    ]
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type of compared operand.",
-                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
-                    "default": false
-                }
-            },
-            "required": [
-                "greater"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionGreaterOrEquals": {
-            "type": "object",
-            "properties": {
-                "greaterOrEquals": {
-                    "type": "integer",
-                    "title": "Greater or Equal to",
-                    "description": "Must be greater or equal to the specified value.",
-                    "markdownDescription": "Must be greater or equal to the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greaterorequals)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type of compared operand.",
-                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
-                    "default": false
-                }
-            },
-            "required": [
-                "greaterOrEquals"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionStartsWith": {
-            "type": "object",
-            "properties": {
-                "startsWith": {
-                    "title": "Starts with",
-                    "description": "Must start with one of the specified values.",
-                    "markdownDescription": "Must start with one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
-                    "default": false
-                }
-            },
-            "required": [
-                "startsWith"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotStartsWith": {
-            "type": "object",
-            "properties": {
-                "notStartsWith": {
-                    "title": "Not starts with",
-                    "description": "Must not start with any of the specified values.",
-                    "markdownDescription": "Must not start with any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notstartswith)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notstartswith)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notstartswith)",
-                    "default": false
-                }
-            },
-            "required": [
-                "notStartsWith"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionEndsWith": {
-            "type": "object",
-            "properties": {
-                "endsWith": {
-                    "title": "Ends with",
-                    "description": "Must end with one of the specified values.",
-                    "markdownDescription": "Must end with one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
-                    "default": false
-                }
-            },
-            "required": [
-                "endsWith"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotEndsWith": {
-            "type": "object",
-            "properties": {
-                "notEndsWith": {
-                    "title": "Not Ends with",
-                    "description": "Must not end with any of the specified values.",
-                    "markdownDescription": "Must not end with any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notendswith)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notendswith)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notendswith)",
-                    "default": false
-                }
-            },
-            "required": [
-                "notEndsWith"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionContains": {
-            "type": "object",
-            "properties": {
-                "contains": {
-                    "title": "Contains",
-                    "description": "Must contain one of the specified values.",
-                    "markdownDescription": "Must contain one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
-                    "default": false
-                }
-            },
-            "required": [
-                "contains"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotContains": {
-            "type": "object",
-            "properties": {
-                "notContains": {
-                    "title": "Not Contains",
-                    "description": "Must not contain any of the specified values.",
-                    "markdownDescription": "Must not contain any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcontains)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcontains)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcontains)",
-                    "default": false
-                }
-            },
-            "required": [
-                "notContains"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsString": {
-            "type": "object",
-            "properties": {
-                "isString": {
-                    "type": "boolean",
-                    "title": "Is string",
-                    "description": "Must be a string type.",
-                    "markdownDescription": "Must be a string type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isstring)"
-                }
-            },
-            "required": [
-                "isString"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsArray": {
-            "type": "object",
-            "properties": {
-                "isArray": {
-                    "type": "boolean",
-                    "title": "Is array",
-                    "description": "Must be an array type.",
-                    "markdownDescription": "Must be an array type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isarray)"
-                }
-            },
-            "required": [
-                "isArray"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsBoolean": {
-            "type": "object",
-            "properties": {
-                "isBoolean": {
-                    "type": "boolean",
-                    "title": "Is boolean",
-                    "description": "Must be a boolean type.",
-                    "markdownDescription": "Must be a boolean type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isboolean)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to boolean.",
-                    "markdownDescription": "Convert type to boolean. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isboolean)",
-                    "default": false
-                }
-            },
-            "required": [
-                "isBoolean"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsDateTime": {
-            "type": "object",
-            "properties": {
-                "isDateTime": {
-                    "type": "boolean",
-                    "title": "Is datetime",
-                    "description": "Must be a datetime type.",
-                    "markdownDescription": "Must be a datetime type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isdatetime)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to datetime.",
-                    "markdownDescription": "Convert type to datetime. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isdatetime)",
-                    "default": false
-                }
-            },
-            "required": [
-                "isDateTime"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsInteger": {
-            "type": "object",
-            "properties": {
-                "isInteger": {
-                    "type": "boolean",
-                    "title": "Is integer",
-                    "description": "Must be an integer type.",
-                    "markdownDescription": "Must be an integer type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isinteger)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to integer.",
-                    "markdownDescription": "Convert type to integer. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isinteger)",
-                    "default": false
-                }
-            },
-            "required": [
-                "isInteger"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsNumeric": {
-            "type": "object",
-            "properties": {
-                "isNumeric": {
-                    "type": "boolean",
-                    "title": "Is numeric",
-                    "description": "Must be a numeric type.",
-                    "markdownDescription": "Must be a numeric type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isnumeric)"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to numeric.",
-                    "markdownDescription": "Convert type to numeric. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isnumeric)",
-                    "default": false
-                }
-            },
-            "required": [
-                "isNumeric"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsLower": {
-            "type": "object",
-            "properties": {
-                "isLower": {
-                    "type": "boolean",
-                    "title": "Is Lowercase",
-                    "description": "Must be a lowercase string.",
-                    "markdownDescription": "Must be a lowercase string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#islower)"
-                }
-            },
-            "required": [
-                "isLower"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionIsUpper": {
-            "type": "object",
-            "properties": {
-                "isUpper": {
-                    "type": "boolean",
-                    "title": "Is Uppercase",
-                    "description": "Must be an uppercase string.",
-                    "markdownDescription": "Must be an uppercase string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isupper)"
-                }
-            },
-            "required": [
-                "isUpper"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionHasSchema": {
-            "type": "object",
-            "properties": {
-                "hasSchema": {
-                    "type": "array",
-                    "title": "Has schema",
-                    "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
-                    "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
-                    "default": [],
-                    "items": {
-                        "type": "string",
-                        "title": "Has schema",
-                        "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
-                        "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
-                        "minLength": 1
-                    },
-                    "uniqueItems": true
-                },
-                "ignoreScheme": {
-                    "type": "boolean",
-                    "title": "Ignore scheme",
-                    "description": "Determines comparing values is case-sensitive.",
-                    "markdownDescription": "Determines comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing schemas is case-sensitive.",
-                    "markdownDescription": "Determines if comparing schemas is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
-                    "default": false
-                }
-            },
-            "required": [
-                "hasSchema"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionVersion": {
-            "type": "object",
-            "properties": {
-                "version": {
-                    "type": "string",
-                    "title": "Version",
-                    "description": "Must be a valid semantic version. A constraint can optionally be provided to require the semantic version to be within a range.",
-                    "markdownDescription": "Must be a valid semantic version. A constraint can optionally be provided to require the semantic version to be within a range. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#version)",
-                    "default": ""
-                },
-                "includePrerelease": {
-                    "type": "boolean",
-                    "title": "Include pre-release",
-                    "description": "Determines if pre-release versions are included. By default, pre-release versions are not included.",
-                    "markdownDescription": "Determines if pre-release versions are included. By default, pre-release versions are not included. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#version)",
-                    "default": false
-                }
-            },
-            "required": [
-                "version"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionHasDefault": {
-            "type": "object",
-            "properties": {
-                "hasDefault": {
-                    "title": "Has Default",
-                    "description": "The field must either not exist or be set to the configured value.",
-                    "markdownDescription": "The field must either not exist or be set to the configured value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasdefault)",
-                    "$ref": "#/definitions/selectorExpressionValue"
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasdefault)",
-                    "default": false
-                }
-            },
-            "required": [
-                "hasDefault"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorProperties"
-                }
-            ]
-        },
-        "selectorConditionWithinPath": {
-            "type": "object",
-            "properties": {
-                "withinPath": {
-                    "type": "array",
-                    "title": "Within Path",
-                    "description": "The file path must exist within the required paths.",
-                    "markdownDescription": "The file path must exist within the required paths. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#withinpath)",
-                    "default": [],
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#withinpath)",
-                    "default": false
-                }
-            },
-            "required": [
-                "withinPath"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotWithinPath": {
-            "type": "object",
-            "properties": {
-                "notWithinPath": {
-                    "type": "array",
-                    "title": "Not Within Path",
-                    "description": "The file path must not exist within the required paths.",
-                    "markdownDescription": "The file path must not exist within the required paths. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notwithinpath)",
-                    "default": [],
-                    "items": {
-                        "type": "string"
-                    },
-                    "uniqueItems": true
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notwithinpath)",
-                    "default": false
-                }
-            },
-            "required": [
-                "notWithinPath"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionLike": {
-            "type": "object",
-            "properties": {
-                "like": {
-                    "title": "Like",
-                    "description": "Must match any of the specified wildcard patterns.",
-                    "markdownDescription": "Must match any of the specified wildcard patterns. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#like)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#like)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#like)",
-                    "default": false
-                }
-            },
-            "required": [
-                "like"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
-        "selectorConditionNotLike": {
-            "type": "object",
-            "properties": {
-                "notLike": {
-                    "title": "Not like",
-                    "description": "Must not match any of the specified wildcard patterns.",
-                    "markdownDescription": "Must not match any of the specified wildcard patterns. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notlike)",
-                    "$ref": "#/definitions/selectorExpressionValueMultiString"
-                },
-                "convert": {
-                    "type": "boolean",
-                    "title": "Type conversion",
-                    "description": "Convert type to string.",
-                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notlike)",
-                    "default": false
-                },
-                "caseSensitive": {
-                    "type": "boolean",
-                    "title": "Case sensitive",
-                    "description": "Determines if comparing values is case-sensitive.",
-                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notlike)",
-                    "default": false
-                }
-            },
-            "required": [
-                "notLike"
-            ],
-            "oneOf": [
-                {
-                    "$ref": "#/definitions/selectorPropertiesString"
-                }
-            ]
-        },
         "selectorExpressionValueMultiString": {
             "oneOf": [
                 {
@@ -1964,23 +704,26 @@
             "oneOf": [
                 {
                     "type": "string",
-                    "title": "Value from string",
-                    "description": "A value to compare."
+                    "ztitle": "Value from string",
+                    "zdescription": "A value to compare.",
+                    "default": ""
                 },
                 {
                     "type": "boolean",
-                    "title": "Value from boolean",
-                    "description": "A value to compare."
+                    "ztitle": "Value from boolean",
+                    "zdescription": "A value to compare.",
+                    "default": true
                 },
                 {
                     "type": "integer",
-                    "title": "Value from integer",
-                    "description": "A value to compare."
+                    "ztitle": "Value from integer",
+                    "zdescription": "A value to compare.",
+                    "default": 0
                 },
                 {
                     "type": "object",
-                    "title": "Value for object",
-                    "description": "A value to compare.",
+                    "ztitle": "Value for object",
+                    "zdescription": "A value to compare.",
                     "not": {
                         "propertyNames": {
                             "enum": [
@@ -1994,10 +737,2071 @@
                 }
             ]
         },
+        "expressions": {
+            "type": "object",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/expressions/definitions/operators/definitions/allOf"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/operators/definitions/anyOf"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/operators/definitions/not"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/exists"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/equals"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notEquals"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasValue"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/match"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notMatch"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/in"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notIn"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/setOf"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/subset"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/count"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notCount"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/less"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/lessOrEquals"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/greater"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/greaterOrEquals"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/startsWith"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notStartsWith"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/endsWith"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notEndsWith"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/contains"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notContains"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isString"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isLower"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isArray"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isBoolean"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isDateTime"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isInteger"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isNumeric"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/isUpper"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasSchema"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/version"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasDefault"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/withinPath"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notWithinPath"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/like"
+                },
+                {
+                    "$ref": "#/definitions/expressions/definitions/conditions/definitions/notLike"
+                }
+            ],
+            "defaultSnippets": [
+                {
+                    "label": "field",
+                    "description": "The object path of a field to compare.",
+                    "markdownDescription": "The object path of a field to compare.",
+                    "body": {
+                        "field": "${1}"
+                    }
+                },
+                {
+                    "label": "value",
+                    "body": {
+                        "value": "${1}"
+                    }
+                },
+                {
+                    "label": "name",
+                    "body": {
+                        "name": "."
+                    }
+                },
+                {
+                    "label": "type",
+                    "body": {
+                        "type": "."
+                    }
+                },
+                {
+                    "label": "source",
+                    "body": {
+                        "source": "${1}"
+                    }
+                },
+                {
+                    "label": "allOf",
+                    "body": {
+                        "allOf": [
+                            "${1}"
+                        ]
+                    }
+                },
+                {
+                    "label": "anyOf",
+                    "body": {
+                        "anyOf": [
+                            "${1}"
+                        ]
+                    }
+                },
+                {
+                    "label": "not",
+                    "body": {
+                        "not": {}
+                    }
+                }
+            ],
+            "definitions": {
+                "operands": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/field"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/value"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/type"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/name"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/source"
+                        }
+                    ],
+                    "definitions": {
+                        "string-only": {
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands/definitions/field"
+                                },
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands/definitions/value"
+                                },
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands/definitions/type"
+                                },
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands/definitions/name"
+                                },
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands/definitions/source"
+                                }
+                            ]
+                        },
+                        "field": {
+                            "type": "object",
+                            "properties": {
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "where": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/where"
+                                }
+                            },
+                            "required": [
+                                "field"
+                            ]
+                        },
+                        "value": {
+                            "type": "object",
+                            "properties": {
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "value"
+                            ]
+                        },
+                        "type": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        },
+                        "name": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ]
+                        },
+                        "source": {
+                            "type": "object",
+                            "properties": {
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "source"
+                            ]
+                        }
+                    }
+                },
+                "properties": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/field"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/value"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/name"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/type"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operands/definitions/source"
+                        }
+                    ],
+                    "definitions": {
+                        "field": {
+                            "type": "string",
+                            "title": "Field",
+                            "description": "The object path of a field to compare.",
+                            "markdownDescription": "The object path of a field to compare.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#field)",
+                            "minLength": 1
+                        },
+                        "where": {
+                            "type": "object",
+                            "title": "Sub-selector filter",
+                            "description": "Limits the condition to matching items.",
+                            "markdownDescription": "Limits the condition to matching items.\n\n[See help](https://microsoft.github.io/PSRule/v2/expressions/sub-selectors/)",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/expressions"
+                                }
+                            ]
+                        },
+                        "value": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/selectorExpressionValue"
+                                }
+                            ]
+                        },
+                        "name": {
+                            "type": "string",
+                            "title": "Name",
+                            "description": "The target name of the object.",
+                            "markdownDescription": "The target name of the object. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#name)",
+                            "default": ".",
+                            "enum": [
+                                "."
+                            ]
+                        },
+                        "type": {
+                            "type": "string",
+                            "title": "Type",
+                            "description": "The target type of the object.",
+                            "markdownDescription": "The target type of the object. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#type)",
+                            "default": ".",
+                            "enum": [
+                                "."
+                            ]
+                        },
+                        "source": {
+                            "type": "string",
+                            "title": "Source",
+                            "description": "The source of the object currently being processed by the pipeline.",
+                            "markdownDescription": "The source of the object currently being processed by the pipeline. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#source)",
+                            "default": ""
+                        }
+                    }
+                },
+                "conditions": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/exists"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/equals"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notEquals"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasValue"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/match"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notMatch"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/in"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notIn"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/setOf"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/subset"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/count"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notCount"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/less"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/lessOrEquals"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/greater"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/greaterOrEquals"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/startsWith"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notStartsWith"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/endsWith"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notEndsWith"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/contains"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notContains"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isString"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isLower"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isArray"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isBoolean"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isDateTime"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isInteger"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isNumeric"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/isUpper"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasSchema"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/version"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasDefault"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/withinPath"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notWithinPath"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/like"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/conditions/definitions/notLike"
+                        }
+                    ],
+                    "definitions": {
+                        "equals": {
+                            "type": "object",
+                            "title": "equals",
+                            "description": "Must have the specified value.",
+                            "markdownDescription": "Must have the specified value.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
+                            "properties": {
+                                "equals": {
+                                    "title": "Equals",
+                                    "description": "Must have the specified value.",
+                                    "markdownDescription": "Must have the specified value.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
+                                    "default": "",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/selectorExpressionValue"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type of compared operand.",
+                                    "markdownDescription": "Convert type of compared operand.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive. Only applies to string values.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. Only applies to string values.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#equals)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "equals"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "count": {
+                            "type": "object",
+                            "properties": {
+                                "count": {
+                                    "type": "integer",
+                                    "title": "Count",
+                                    "description": "Must include the specified number of values.",
+                                    "markdownDescription": "Must include the specified number of values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#count)",
+                                    "minimum": 0
+                                }
+                            },
+                            "required": [
+                                "count"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "exists": {
+                            "type": "object",
+                            "properties": {
+                                "exists": {
+                                    "type": "boolean",
+                                    "title": "Exists",
+                                    "description": "Must have the named field.",
+                                    "markdownDescription": "Must have the named field. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#exists)",
+                                    "default": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                }
+                            },
+                            "required": [
+                                "exists",
+                                "field"
+                            ]
+                        },
+                        "notEquals": {
+                            "type": "object",
+                            "properties": {
+                                "notEquals": {
+                                    "title": "Not Equals",
+                                    "description": "Must not have the specified value.",
+                                    "markdownDescription": "Must not have the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
+                                    "default": "",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/selectorExpressionValue"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type of compared operand.",
+                                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive. Only applies to string values.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. Only applies to string values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notequals)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "notEquals"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "hasValue": {
+                            "type": "object",
+                            "properties": {
+                                "hasValue": {
+                                    "type": "boolean",
+                                    "title": "Has Value",
+                                    "description": "Must have a non-empty value.",
+                                    "markdownDescription": "Must have a non-empty value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasvalue)",
+                                    "default": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                }
+                            },
+                            "required": [
+                                "hasValue"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "match": {
+                            "type": "object",
+                            "properties": {
+                                "match": {
+                                    "type": "string",
+                                    "title": "Match",
+                                    "description": "Must match the regular expression.",
+                                    "markdownDescription": "Must match the regular expression. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#match)",
+                                    "default": ""
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "match"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "notMatch": {
+                            "type": "object",
+                            "properties": {
+                                "notMatch": {
+                                    "type": "string",
+                                    "title": "Not Match",
+                                    "description": "Must not match the regular expression.",
+                                    "markdownDescription": "Must not match the regular expression. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notmatch)",
+                                    "default": ""
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "notMatch"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "in": {
+                            "type": "object",
+                            "properties": {
+                                "in": {
+                                    "type": "array",
+                                    "title": "In",
+                                    "description": "Must equal one of the specified values.",
+                                    "markdownDescription": "Must equal one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#in)",
+                                    "default": [
+                                        ""
+                                    ],
+                                    "uniqueItems": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "in"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "notIn": {
+                            "type": "object",
+                            "properties": {
+                                "notIn": {
+                                    "type": "array",
+                                    "title": "Not In",
+                                    "description": "Must not equal any of the specified values.",
+                                    "markdownDescription": "Must not equal any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notin)",
+                                    "default": [
+                                        ""
+                                    ],
+                                    "uniqueItems": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "notIn"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ]
+                        },
+                        "setOf": {
+                            "type": "object",
+                            "properties": {
+                                "setOf": {
+                                    "type": "array",
+                                    "title": "SetOf",
+                                    "description": "Must include all of but only specified values.",
+                                    "markdownDescription": "Must include all of but only values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#setof)",
+                                    "default": [
+                                        ""
+                                    ],
+                                    "uniqueItems": true
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#setof)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "setOf"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/properties"
+                                }
+                            ]
+                        },
+                        "subset": {
+                            "type": "object",
+                            "properties": {
+                                "subset": {
+                                    "type": "array",
+                                    "title": "Subset",
+                                    "description": "Must include all of the specified values.",
+                                    "markdownDescription": "Must include all of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#subset)",
+                                    "default": [
+                                        ""
+                                    ],
+                                    "uniqueItems": true
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#subset)",
+                                    "default": false
+                                },
+                                "unique": {
+                                    "type": "boolean",
+                                    "title": "Unique",
+                                    "description": "Determines if each of the field values must be unique.",
+                                    "markdownDescription": "Determines if each of the field values must be unique. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#subset)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "subset"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/properties"
+                                }
+                            ]
+                        },
+                        "notCount": {
+                            "type": "object",
+                            "properties": {
+                                "notCount": {
+                                    "type": "integer",
+                                    "title": "NotCount",
+                                    "description": "Determines if operand does not have number of items.",
+                                    "markdownDescription": "Determines if operand does not have number of items. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcount)",
+                                    "minimum": 0,
+                                    "default": 0
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "notCount"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/properties"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "less": {
+                            "type": "object",
+                            "properties": {
+                                "less": {
+                                    "title": "Less",
+                                    "description": "Must be less then the specified value.",
+                                    "markdownDescription": "Must be less then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                                    "default": 0,
+                                    "oneOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type of compared operand.",
+                                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "less"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "lessOrEquals": {
+                            "type": "object",
+                            "properties": {
+                                "lessOrEquals": {
+                                    "title": "Less or Equal to",
+                                    "description": "Must be less or equal to the specified value.",
+                                    "markdownDescription": "Must be less or equal to the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#lessorequals)",
+                                    "default": 0,
+                                    "oneOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type of compared operand.",
+                                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "lessOrEquals"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "greater": {
+                            "type": "object",
+                            "properties": {
+                                "greater": {
+                                    "title": "Greater",
+                                    "description": "Must be greater then the specified value.",
+                                    "markdownDescription": "Must be greater then the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greater)",
+                                    "default": 0,
+                                    "oneOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type of compared operand.",
+                                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "greater"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "greaterOrEquals": {
+                            "type": "object",
+                            "properties": {
+                                "greaterOrEquals": {
+                                    "title": "Greater or Equal to",
+                                    "description": "Must be greater or equal to the specified value.",
+                                    "markdownDescription": "Must be greater or equal to the specified value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#greaterorequals)",
+                                    "default": 0,
+                                    "oneOf": [
+                                        {
+                                            "type": "integer"
+                                        },
+                                        {
+                                            "type": "object",
+                                            "$ref": "#/definitions/fn"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type of compared operand.",
+                                    "markdownDescription": "Convert type of compared operand. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#less)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "greaterOrEquals"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "startsWith": {
+                            "type": "object",
+                            "properties": {
+                                "startsWith": {
+                                    "title": "Starts with",
+                                    "description": "Must start with one of the specified values.",
+                                    "markdownDescription": "Must start with one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString",
+                                    "default": ""
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#startswith)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "startsWith"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "notStartsWith": {
+                            "type": "object",
+                            "properties": {
+                                "notStartsWith": {
+                                    "title": "Not starts with",
+                                    "description": "Must not start with any of the specified values.",
+                                    "markdownDescription": "Must not start with any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notstartswith)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notstartswith)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notstartswith)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "notStartsWith"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "endsWith": {
+                            "type": "object",
+                            "properties": {
+                                "endsWith": {
+                                    "title": "Ends with",
+                                    "description": "Must end with one of the specified values.",
+                                    "markdownDescription": "Must end with one of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString",
+                                    "default": ""
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "endsWith"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "notEndsWith": {
+                            "type": "object",
+                            "properties": {
+                                "notEndsWith": {
+                                    "title": "Not Ends with",
+                                    "description": "Must not end with any of the specified values.",
+                                    "markdownDescription": "Must not end with any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notendswith)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notendswith)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notendswith)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "notEndsWith"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "contains": {
+                            "type": "object",
+                            "title": "contains",
+                            "description": "Must contain one of the specified values.",
+                            "markdownDescription": "Must contain one of the specified values.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
+                            "properties": {
+                                "contains": {
+                                    "title": "Contains",
+                                    "description": "Must contain one of the specified values.",
+                                    "markdownDescription": "Must contain one of the specified values.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
+                                    "default": "",
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/definitions/selectorExpressionValueMultiString"
+                                        }
+                                    ]
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "contains"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "notContains": {
+                            "type": "object",
+                            "properties": {
+                                "notContains": {
+                                    "title": "Not Contains",
+                                    "description": "Must not contain any of the specified values.",
+                                    "markdownDescription": "Must not contain any of the specified values. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcontains)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcontains)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notcontains)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                },
+                                "type": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/type"
+                                },
+                                "name": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/name"
+                                },
+                                "source": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/source"
+                                }
+                            },
+                            "required": [
+                                "notContains"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "isString": {
+                            "type": "object",
+                            "properties": {
+                                "isString": {
+                                    "type": "boolean",
+                                    "title": "Is string",
+                                    "description": "Must be a string type.",
+                                    "markdownDescription": "Must be a string type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isstring)",
+                                    "default": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isString"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "isArray": {
+                            "type": "object",
+                            "properties": {
+                                "isArray": {
+                                    "type": "boolean",
+                                    "title": "Is array",
+                                    "description": "Must be an array type.",
+                                    "markdownDescription": "Must be an array type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isarray)",
+                                    "default": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isArray"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "isBoolean": {
+                            "type": "object",
+                            "properties": {
+                                "isBoolean": {
+                                    "type": "boolean",
+                                    "title": "Is boolean",
+                                    "description": "Must be a boolean type.",
+                                    "markdownDescription": "Must be a boolean type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isboolean)",
+                                    "default": true
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to boolean.",
+                                    "markdownDescription": "Convert type to boolean. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isboolean)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isBoolean"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "isDateTime": {
+                            "type": "object",
+                            "properties": {
+                                "isDateTime": {
+                                    "type": "boolean",
+                                    "title": "Is datetime",
+                                    "description": "Must be a datetime type.",
+                                    "markdownDescription": "Must be a datetime type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isdatetime)",
+                                    "default": true
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to datetime.",
+                                    "markdownDescription": "Convert type to datetime. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isdatetime)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isDateTime"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "isInteger": {
+                            "type": "object",
+                            "properties": {
+                                "isInteger": {
+                                    "type": "boolean",
+                                    "title": "Is integer",
+                                    "description": "Must be an integer type.",
+                                    "markdownDescription": "Must be an integer type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isinteger)",
+                                    "default": true
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to integer.",
+                                    "markdownDescription": "Convert type to integer. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isinteger)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isInteger"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "isNumeric": {
+                            "type": "object",
+                            "properties": {
+                                "isNumeric": {
+                                    "type": "boolean",
+                                    "title": "Is numeric",
+                                    "description": "Must be a numeric type.",
+                                    "markdownDescription": "Must be a numeric type. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isnumeric)",
+                                    "default": true
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to numeric.",
+                                    "markdownDescription": "Convert type to numeric. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isnumeric)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isNumeric"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "isLower": {
+                            "type": "object",
+                            "properties": {
+                                "isLower": {
+                                    "type": "boolean",
+                                    "title": "Is Lowercase",
+                                    "description": "Must be a lowercase string.",
+                                    "markdownDescription": "Must be a lowercase string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#islower)",
+                                    "default": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isLower"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "isUpper": {
+                            "type": "object",
+                            "properties": {
+                                "isUpper": {
+                                    "type": "boolean",
+                                    "title": "Is Uppercase",
+                                    "description": "Must be an uppercase string.",
+                                    "markdownDescription": "Must be an uppercase string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#isupper)",
+                                    "default": true
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "isUpper"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "hasSchema": {
+                            "type": "object",
+                            "properties": {
+                                "hasSchema": {
+                                    "type": "array",
+                                    "title": "Has schema",
+                                    "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
+                                    "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
+                                    "default": [],
+                                    "items": {
+                                        "type": "string",
+                                        "title": "Has schema",
+                                        "description": "Must use one of the specified schemas of the value of $schema. If an empty array is specified any non-empty $schema can be specified.",
+                                        "markdownDescription": "Must use one of the specified schemas of the value of `$schema`. If an empty array is specified any non-empty `$schema` can be specified [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
+                                        "minLength": 1
+                                    },
+                                    "uniqueItems": true
+                                },
+                                "ignoreScheme": {
+                                    "type": "boolean",
+                                    "title": "Ignore scheme",
+                                    "description": "Determines comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing schemas is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing schemas is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasschema)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "hasSchema"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/properties"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "version": {
+                            "type": "object",
+                            "properties": {
+                                "version": {
+                                    "type": "string",
+                                    "title": "Version",
+                                    "description": "Must be a valid semantic version. A constraint can optionally be provided to require the semantic version to be within a range.",
+                                    "markdownDescription": "Must be a valid semantic version. A constraint can optionally be provided to require the semantic version to be within a range. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#version)",
+                                    "default": ""
+                                },
+                                "includePrerelease": {
+                                    "type": "boolean",
+                                    "title": "Include pre-release",
+                                    "description": "Determines if pre-release versions are included. By default, pre-release versions are not included.",
+                                    "markdownDescription": "Determines if pre-release versions are included. By default, pre-release versions are not included. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#version)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "version"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/properties"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "hasDefault": {
+                            "type": "object",
+                            "properties": {
+                                "hasDefault": {
+                                    "title": "Has Default",
+                                    "description": "The field must either not exist or be set to the configured value.",
+                                    "markdownDescription": "The field must either not exist or be set to the configured value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasdefault)",
+                                    "default": "",
+                                    "oneOf": [
+                                        {
+                                            "$ref": "#/definitions/selectorExpressionValue"
+                                        }
+                                    ]
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasdefault)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "hasDefault"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/properties"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "withinPath": {
+                            "type": "object",
+                            "properties": {
+                                "withinPath": {
+                                    "type": "array",
+                                    "title": "Within Path",
+                                    "description": "The file path must exist within the required paths.",
+                                    "markdownDescription": "The file path must exist within the required paths. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#withinpath)",
+                                    "default": [],
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "uniqueItems": true
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#withinpath)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "withinPath"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "maxProperties": 2
+                        },
+                        "notWithinPath": {
+                            "type": "object",
+                            "properties": {
+                                "notWithinPath": {
+                                    "type": "array",
+                                    "title": "Not Within Path",
+                                    "description": "The file path must not exist within the required paths.",
+                                    "markdownDescription": "The file path must not exist within the required paths. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notwithinpath)",
+                                    "default": [],
+                                    "items": {
+                                        "type": "string"
+                                    },
+                                    "uniqueItems": true
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notwithinpath)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "notWithinPath"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "like": {
+                            "type": "object",
+                            "properties": {
+                                "like": {
+                                    "title": "Like",
+                                    "description": "Must match any of the specified wildcard patterns.",
+                                    "markdownDescription": "Must match any of the specified wildcard patterns. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#like)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#like)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#like)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "like"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        },
+                        "notLike": {
+                            "type": "object",
+                            "properties": {
+                                "notLike": {
+                                    "title": "Not like",
+                                    "description": "Must not match any of the specified wildcard patterns.",
+                                    "markdownDescription": "Must not match any of the specified wildcard patterns. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notlike)",
+                                    "$ref": "#/definitions/selectorExpressionValueMultiString"
+                                },
+                                "convert": {
+                                    "type": "boolean",
+                                    "title": "Type conversion",
+                                    "description": "Convert type to string.",
+                                    "markdownDescription": "Convert type to string. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notlike)",
+                                    "default": false
+                                },
+                                "caseSensitive": {
+                                    "type": "boolean",
+                                    "title": "Case sensitive",
+                                    "description": "Determines if comparing values is case-sensitive.",
+                                    "markdownDescription": "Determines if comparing values is case-sensitive. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notlike)",
+                                    "default": false
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "value": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                                }
+                            },
+                            "required": [
+                                "notLike"
+                            ],
+                            "oneOf": [
+                                {
+                                    "$ref": "#/definitions/expressions/definitions/operands"
+                                }
+                            ],
+                            "additionalProperties": false,
+                            "minProperties": 2
+                        }
+                    }
+                },
+                "operators": {
+                    "type": "object",
+                    "oneOf": [
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operators/definitions/allOf"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operators/definitions/anyOf"
+                        },
+                        {
+                            "$ref": "#/definitions/expressions/definitions/operators/definitions/not"
+                        }
+                    ],
+                    "definitions": {
+                        "allOf": {
+                            "type": "object",
+                            "title": "allOf",
+                            "description": "All of the expressions must be true.",
+                            "markdownDescription": "All of the expressions must be true.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#allof)",
+                            "properties": {
+                                "allOf": {
+                                    "type": "array",
+                                    "title": "AllOf",
+                                    "description": "All of the expressions must be true.",
+                                    "markdownDescription": "All of the expressions must be true.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#allof)",
+                                    "items": {
+                                        "$ref": "#/definitions/expressions"
+                                    }
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "where": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/where"
+                                }
+                            },
+                            "required": [
+                                "allOf"
+                            ],
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "field": {
+                                            "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                        },
+                                        "where": {
+                                            "$ref": "#/definitions/expressions/definitions/properties/definitions/where"
+                                        }
+                                    }
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "anyOf": {
+                            "type": "object",
+                            "properties": {
+                                "anyOf": {
+                                    "type": "array",
+                                    "title": "AnyOf",
+                                    "description": "One of the expressions must be true.",
+                                    "markdownDescription": "All of the expressions must be true.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#anyof)",
+                                    "items": {
+                                        "$ref": "#/definitions/expressions"
+                                    }
+                                },
+                                "field": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                },
+                                "where": {
+                                    "$ref": "#/definitions/expressions/definitions/properties/definitions/where"
+                                }
+                            },
+                            "required": [
+                                "anyOf"
+                            ],
+                            "oneOf": [
+                                {
+                                    "properties": {
+                                        "field": {
+                                            "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                                        },
+                                        "where": {
+                                            "$ref": "#/definitions/expressions/definitions/properties/definitions/where"
+                                        }
+                                    }
+                                }
+                            ],
+                            "additionalProperties": false
+                        },
+                        "not": {
+                            "type": "object",
+                            "properties": {
+                                "not": {
+                                    "type": "object",
+                                    "title": "Not",
+                                    "description": "The nested expression must not be true.",
+                                    "markdownDescription": "The nested expression must not be true.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#not)",
+                                    "$ref": "#/definitions/expressions"
+                                }
+                            },
+                            "required": [
+                                "not"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                }
+            }
+        },
         "fn": {
-            "title": "Value from function",
-            "description": "A function expression that once evaluated specifies the value.",
-            "markdownDescription": "A function expression that once evaluated specifies the value.",
+            "ztitle": "Value from function",
+            "zdescription": "A function expression that once evaluated specifies the value.",
+            "zmarkdownDescription": "A function expression that once evaluated specifies the value.",
             "properties": {
                 "$": {
                     "type": "object",

--- a/src/PSRule/Common/ConditionResultExtensions.cs
+++ b/src/PSRule/Common/ConditionResultExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using PSRule.Definitions;
@@ -9,12 +9,17 @@ namespace PSRule
     {
         public static bool AllOf(this IConditionResult result)
         {
-            return result.Count > 0 && result.Pass == result.Count;
+            return result != null && result.Count > 0 && result.Pass == result.Count;
         }
 
         public static bool AnyOf(this IConditionResult result)
         {
-            return result.Pass > 0;
+            return result != null && result.Pass > 0;
+        }
+
+        public static bool Skipped(this IConditionResult result)
+        {
+            return result == null;
         }
     }
 }

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -34,11 +34,6 @@ namespace PSRule
                 : PSObject.AsPSObject(o.Properties[propertyName].Value);
         }
 
-        public static string ValueAsString(this PSObject o, string propertyName, bool caseSensitive)
-        {
-            return ObjectHelper.GetPath(o, propertyName, caseSensitive, out var value) && value != null ? value.ToString() : null;
-        }
-
         public static bool HasProperty(this PSObject o, string propertyName)
         {
             return o.Properties[propertyName] != null;

--- a/src/PSRule/Configuration/PipelineHook.cs
+++ b/src/PSRule/Configuration/PipelineHook.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Management.Automation;
 
 namespace PSRule.Configuration
 {
     /// <summary>
     /// Used by custom binding functions.
     /// </summary>
-    public delegate string BindTargetName(PSObject targetObject);
+    public delegate string BindTargetName(object targetObject);
 
-    internal delegate string BindTargetMethod(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, out string path);
-    internal delegate string BindTargetFunc(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, BindTargetMethod next, out string path);
+    internal delegate string BindTargetMethod(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, out string path);
+    internal delegate string BindTargetFunc(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, BindTargetMethod next, out string path);
 
     /// <summary>
     /// Hooks that provide customize pipeline execution.

--- a/src/PSRule/Definitions/Expressions/ExpressionContext.cs
+++ b/src/PSRule/Definitions/Expressions/ExpressionContext.cs
@@ -18,7 +18,7 @@ namespace PSRule.Definitions.Expressions
 
         object Current { get; }
 
-        RunspaceContext GetContext();
+        RunspaceContext Context { get; }
     }
 
     internal sealed class ExpressionContext : IExpressionContext, IBindingContext
@@ -27,8 +27,9 @@ namespace PSRule.Definitions.Expressions
 
         private List<ResultReason> _Reason;
 
-        internal ExpressionContext(SourceFile source, ResourceKind kind, object current)
+        internal ExpressionContext(RunspaceContext context, SourceFile source, ResourceKind kind, object current)
         {
+            Context = context;
             Source = source;
             LanguageScope = source.Module;
             Kind = kind;
@@ -43,6 +44,8 @@ namespace PSRule.Definitions.Expressions
         public ResourceKind Kind { get; }
 
         public object Current { get; }
+
+        public RunspaceContext Context { get; }
 
         [DebuggerStepThrough]
         void IBindingContext.CachePathExpression(string path, PathExpression expression)
@@ -81,7 +84,7 @@ namespace PSRule.Definitions.Expressions
                 return;
 
             _Reason ??= new List<ResultReason>();
-            _Reason.Add(new ResultReason(RunspaceContext.CurrentThread?.TargetObject?.Path, operand, text, args));
+            _Reason.Add(new ResultReason(Context.TargetObject?.Path, operand, text, args));
         }
 
         public void Reason(string text, params object[] args)
@@ -90,17 +93,12 @@ namespace PSRule.Definitions.Expressions
                 return;
 
             _Reason ??= new List<ResultReason>();
-            _Reason.Add(new ResultReason(RunspaceContext.CurrentThread?.TargetObject?.Path, null, text, args));
+            _Reason.Add(new ResultReason(Context.TargetObject?.Path, null, text, args));
         }
 
         internal ResultReason[] GetReasons()
         {
             return _Reason == null || _Reason.Count == 0 ? Array.Empty<ResultReason>() : _Reason.ToArray();
-        }
-
-        public RunspaceContext GetContext()
-        {
-            return RunspaceContext.CurrentThread;
         }
     }
 }

--- a/src/PSRule/Definitions/Expressions/Functions.cs
+++ b/src/PSRule/Definitions/Expressions/Functions.cs
@@ -91,7 +91,7 @@ namespace PSRule.Definitions.Expressions
             // Lookup a configuration value.
             return (context) =>
             {
-                return context.GetContext().TryGetConfigurationValue(name, out var value) ? value : null;
+                return context.Context.TryGetConfigurationValue(name, out var value) ? value : null;
             };
         }
 

--- a/src/PSRule/Definitions/Expressions/Primitives.cs
+++ b/src/PSRule/Definitions/Expressions/Primitives.cs
@@ -34,7 +34,7 @@ namespace PSRule.Definitions.Expressions
         public LanguageExpression CreateInstance(SourceFile source, LanguageExpression.PropertyBag properties)
         {
             if (Type == LanguageExpressionType.Operator)
-                return new LanguageOperator(this);
+                return new LanguageOperator(this, properties);
 
             if (Type == LanguageExpressionType.Condition)
                 return new LanguageCondition(this, properties);
@@ -74,11 +74,16 @@ namespace PSRule.Definitions.Expressions
     [DebuggerDisplay("Selector {Descriptor.Name}")]
     internal sealed class LanguageOperator : LanguageExpression
     {
-        internal LanguageOperator(LanguageExpresssionDescriptor descriptor)
+        internal LanguageOperator(LanguageExpresssionDescriptor descriptor, PropertyBag properties)
             : base(descriptor)
         {
+            Property = properties ?? new PropertyBag();
             Children = new List<LanguageExpression>();
         }
+
+        public LanguageExpression Subselector { get; set; }
+
+        public PropertyBag Property { get; }
 
         public List<LanguageExpression> Children { get; }
 
@@ -109,9 +114,6 @@ namespace PSRule.Definitions.Expressions
     internal sealed class LanguageFunction : LanguageExpression
     {
         internal LanguageFunction(LanguageExpresssionDescriptor descriptor)
-            : base(descriptor)
-        {
-
-        }
+            : base(descriptor) { }
     }
 }

--- a/src/PSRule/Definitions/ILanguageBlock.cs
+++ b/src/PSRule/Definitions/ILanguageBlock.cs
@@ -6,16 +6,33 @@ using PSRule.Pipeline;
 
 namespace PSRule.Definitions
 {
+    /// <summary>
+    /// A language block.
+    /// </summary>
     public interface ILanguageBlock
     {
+        /// <summary>
+        /// The unique identifier for the block.
+        /// </summary>
         ResourceId Id { get; }
 
+        /// <summary>
+        /// Obsolete. The source file path.
+        /// Replaced by <see cref="Source"/>.
+        /// </summary>
         [Obsolete("Use Source property instead.")]
         string SourcePath { get; }
 
+        /// <summary>
+        /// Obsolete. The source module.
+        /// Replaced by <see cref="Source"/>.
+        /// </summary>
         [Obsolete("Use Source property instead.")]
         string Module { get; }
 
+        /// <summary>
+        /// The source location for the block.
+        /// </summary>
         SourceFile Source { get; }
     }
 }

--- a/src/PSRule/Definitions/Resource.cs
+++ b/src/PSRule/Definitions/Resource.cs
@@ -18,8 +18,14 @@ using YamlDotNet.Serialization.NodeDeserializers;
 
 namespace PSRule.Definitions
 {
+    /// <summary>
+    /// The type of resource.
+    /// </summary>
     public enum ResourceKind
     {
+        /// <summary>
+        /// Unknown or empty.
+        /// </summary>
         None = 0,
 
         /// <summary>
@@ -53,14 +59,26 @@ namespace PSRule.Definitions
         SuppressionGroup = 6
     }
 
+    /// <summary>
+    /// Additional flags that indicate the status of the resource.
+    /// </summary>
     [Flags]
     public enum ResourceFlags
     {
+        /// <summary>
+        /// No flags are set.
+        /// </summary>
         None = 0,
 
+        /// <summary>
+        /// The resource is obsolete.
+        /// </summary>
         Obsolete = 1
     }
 
+    /// <summary>
+    /// A resource langange block.
+    /// </summary>
     public interface IResource : ILanguageBlock
     {
         /// <summary>
@@ -142,6 +160,9 @@ namespace PSRule.Definitions
 
     }
 
+    /// <summary>
+    /// A resource object.
+    /// </summary>
     public sealed class ResourceObject
     {
         internal ResourceObject(IResource block)
@@ -196,15 +217,24 @@ namespace PSRule.Definitions
         }
     }
 
+    /// <summary>
+    /// Additional resource annotations.
+    /// </summary>
     public sealed class ResourceAnnotations : Dictionary<string, object>
     {
 
     }
 
+    /// <summary>
+    /// Additional resource tags.
+    /// </summary>
     public sealed class ResourceTags : Dictionary<string, string>
     {
         private Hashtable _Hashtable;
 
+        /// <summary>
+        /// Create an empty set of resource tags.
+        /// </summary>
         public ResourceTags() : base(StringComparer.OrdinalIgnoreCase) { }
 
         /// <summary>
@@ -287,6 +317,10 @@ namespace PSRule.Definitions
             return false;
         }
 
+        /// <summary>
+        /// Convert the resourecs tags to a display string for PowerShell views.
+        /// </summary>
+        /// <returns></returns>
         public string ToViewString()
         {
             var sb = new StringBuilder();
@@ -308,8 +342,14 @@ namespace PSRule.Definitions
         }
     }
 
+    /// <summary>
+    /// Additional resource metadata.
+    /// </summary>
     public sealed class ResourceMetadata
     {
+        /// <summary>
+        /// Create an empty set of metadata.
+        /// </summary>
         public ResourceMetadata()
         {
             Annotations = new ResourceAnnotations();
@@ -321,8 +361,14 @@ namespace PSRule.Definitions
         /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// A opaque reference for the resource.
+        /// </summary>
         public string Ref { get; set; }
 
+        /// <summary>
+        /// Additional aliases for the resource.
+        /// </summary>
         public string[] Alias { get; set; }
 
         /// <summary>
@@ -338,16 +384,32 @@ namespace PSRule.Definitions
         public ResourceTags Tags { get; set; }
     }
 
+    /// <summary>
+    /// The source location of the resource.
+    /// </summary>
     public sealed class ResourceExtent
     {
+        /// <summary>
+        /// The file where the resource is located.
+        /// </summary>
         public string File { get; set; }
 
+        /// <summary>
+        /// The name of the module if the resource is contained within a module.
+        /// </summary>
         public string Module { get; set; }
     }
 
+    /// <summary>
+    /// A base class for resources.
+    /// </summary>
+    /// <typeparam name="TSpec">The type for the resource specification.</typeparam>
     [DebuggerDisplay("Kind = {Kind}, Id = {Id}")]
     public abstract class Resource<TSpec> where TSpec : Spec, new()
     {
+        /// <summary>
+        /// Create a resource.
+        /// </summary>
         internal protected Resource(ResourceKind kind, string apiVersion, SourceFile source, ResourceMetadata metadata, IResourceHelpInfo info, ISourceExtent extent, TSpec spec)
         {
             Kind = kind;
@@ -361,6 +423,9 @@ namespace PSRule.Definitions
             Id = new ResourceId(source.Module, Name, ResourceIdKind.Id);
         }
 
+        /// <summary>
+        /// The resource identifier for the resource.
+        /// </summary>
         [YamlIgnore()]
         public ResourceId Id { get; }
 
@@ -376,6 +441,9 @@ namespace PSRule.Definitions
         [YamlIgnore()]
         public SourceFile Source { get; }
 
+        /// <summary>
+        /// Information about the resource.
+        /// </summary>
         [YamlIgnore()]
         public IResourceHelpInfo Info { get; }
 

--- a/src/PSRule/Definitions/Rules/Rule.cs
+++ b/src/PSRule/Definitions/Rules/Rule.cs
@@ -14,17 +14,36 @@ namespace PSRule.Definitions.Rules
     /// </summary>
     public enum SeverityLevel
     {
+        /// <summary>
+        /// Severity is unset.
+        /// </summary>
         None = 0,
 
+        /// <summary>
+        /// A failure generates an error.
+        /// </summary>
         Error = 1,
 
+        /// <summary>
+        /// A fiailure generates a warning.
+        /// </summary>
         Warning = 2,
 
+        /// <summary>
+        /// A failure generate an informational message.
+        /// </summary>
         Information = 3
     }
 
+    /// <summary>
+    /// A rule resource V1.
+    /// </summary>
     public interface IRuleV1 : IResource, IDependencyTarget
     {
+        /// <summary>
+        /// Obsolete. The name of the rule.
+        /// Replaced by <see cref="IResource.Name"/>.
+        /// </summary>
         [Obsolete("Use Name instead.")]
         string RuleName { get; }
 
@@ -33,16 +52,32 @@ namespace PSRule.Definitions.Rules
         /// </summary>
         SeverityLevel Level { get; }
 
+        /// <summary>
+        /// A short description of the rule.
+        /// </summary>
         string Synopsis { get; }
 
+        /// <summary>
+        /// Obsolete. A short description of the rule.
+        /// Replaced by <see cref="Synopsis"/>.
+        /// </summary>
         [Obsolete("Use Synopsis instead.")]
         string Description { get; }
 
+        /// <summary>
+        /// Any additional tags assigned to the rule.
+        /// </summary>
         ResourceTags Tag { get; }
     }
 
+    /// <summary>
+    /// A specification for a rule resource.
+    /// </summary>
     internal interface IRuleSpec
     {
+        /// <summary>
+        /// The of the rule condition that will be evaluated.
+        /// </summary>
         LanguageIf Condition { get; }
 
         /// <summary>
@@ -50,9 +85,20 @@ namespace PSRule.Definitions.Rules
         /// </summary>
         SeverityLevel? Level { get; }
 
+        /// <summary>
+        /// An optional type pre-condition before the rule is evaluated.
+        /// </summary>
         string[] Type { get; }
 
+        /// <summary>
+        /// An optional selector pre-condition before the rule is evaluated.
+        /// </summary>
         string[] With { get; }
+
+        /// <summary>
+        /// An optional sub-selector pre-condition before the rule is evaluated.
+        /// </summary>
+        LanguageIf Where { get; }
     }
 
     [Spec(Specs.V1, Specs.Rule)]
@@ -68,10 +114,12 @@ namespace PSRule.Definitions.Rules
             Level = ResourceHelper.GetLevel(spec.Level);
         }
 
+        /// <inheritdoc/>
         [JsonIgnore]
         [YamlIgnore]
         public ResourceId? Ref { get; }
 
+        /// <inheritdoc/>
         [JsonIgnore]
         [YamlIgnore]
         public ResourceId[] Alias { get; }
@@ -90,43 +138,52 @@ namespace PSRule.Definitions.Rules
         [YamlIgnore]
         public string Synopsis => Info.Synopsis.Text;
 
+        /// <inheritdoc/>
         ResourceId? IDependencyTarget.Ref => Ref;
 
+        /// <inheritdoc/>
         ResourceId[] IDependencyTarget.Alias => Alias;
 
         // Not supported with resource rules.
         ResourceId[] IDependencyTarget.DependsOn => Array.Empty<ResourceId>();
 
+        /// <inheritdoc/>
         bool IDependencyTarget.Dependency => Source.IsDependency();
 
+        /// <inheritdoc/>
         ResourceId? IResource.Ref => Ref;
 
+        /// <inheritdoc/>
         ResourceId[] IResource.Alias => Alias;
 
+        /// <inheritdoc/>
         string IRuleV1.RuleName => Name;
 
+        /// <inheritdoc/>
         ResourceTags IRuleV1.Tag => Metadata.Tags;
 
+        /// <inheritdoc/>
         string IRuleV1.Description => Info.Synopsis.Text;
     }
 
+    /// <summary>
+    /// A specification for a V1 rule resource.
+    /// </summary>
     internal sealed class RuleV1Spec : Spec, IRuleSpec
     {
+        /// <inheritdoc/>
         public LanguageIf Condition { get; set; }
 
-        /// <summary>
-        /// If the rule fails, how serious is the result.
-        /// </summary>
+        /// <inheritdoc/>
         public SeverityLevel? Level { get; set; }
 
-        /// <summary>
-        /// An optional type precondition before the rule is evaluated.
-        /// </summary>
+        /// <inheritdoc/>
         public string[] Type { get; set; }
 
-        /// <summary>
-        /// An optional selector precondition before the rule is evaluated.
-        /// </summary>
+        /// <inheritdoc/>
         public string[] With { get; set; }
+
+        /// <inheritdoc/>
+        public LanguageIf Where { get; set; }
     }
 }

--- a/src/PSRule/Definitions/Selectors/SelectorVisitor.cs
+++ b/src/PSRule/Definitions/Selectors/SelectorVisitor.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using PSRule.Definitions.Expressions;
 using PSRule.Pipeline;
 using PSRule.Resources;
+using PSRule.Runtime;
 
 namespace PSRule.Definitions.Selectors
 {
@@ -18,9 +19,11 @@ namespace PSRule.Definitions.Selectors
     internal sealed class SelectorVisitor : ISelector
     {
         private readonly LanguageExpressionOuterFn _Fn;
+        private readonly RunspaceContext _Context;
 
-        public SelectorVisitor(ResourceId id, SourceFile source, LanguageIf expression)
+        public SelectorVisitor(RunspaceContext context, ResourceId id, SourceFile source, LanguageIf expression)
         {
+            _Context = context;
             Id = id;
             Source = source;
             InstanceId = Guid.NewGuid();
@@ -42,7 +45,7 @@ namespace PSRule.Definitions.Selectors
 
         public bool Match(object o)
         {
-            var context = new ExpressionContext(Source, ResourceKind.Selector, o);
+            var context = new ExpressionContext(_Context, Source, ResourceKind.Selector, o);
             context.Debug(PSRuleResources.SelectorMatchTrace, Id);
             return _Fn(context, o).GetValueOrDefault(false);
         }

--- a/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
+++ b/src/PSRule/Definitions/SuppressionGroups/SuppressionGroupVisitor.cs
@@ -5,6 +5,7 @@ using System;
 using PSRule.Definitions.Expressions;
 using PSRule.Pipeline;
 using PSRule.Resources;
+using PSRule.Runtime;
 
 namespace PSRule.Definitions.SuppressionGroups
 {
@@ -12,9 +13,11 @@ namespace PSRule.Definitions.SuppressionGroups
     {
         private readonly LanguageExpressionOuterFn _Fn;
         private readonly SuppressionInfo _Info;
+        private readonly RunspaceContext _Context;
 
-        public SuppressionGroupVisitor(ResourceId id, SourceFile source, ISuppressionGroupSpec spec, IResourceHelpInfo info)
+        public SuppressionGroupVisitor(RunspaceContext context, ResourceId id, SourceFile source, ISuppressionGroupSpec spec, IResourceHelpInfo info)
         {
+            _Context = context;
             Id = id;
             Source = source;
             InstanceId = Guid.NewGuid();
@@ -77,7 +80,7 @@ namespace PSRule.Definitions.SuppressionGroups
         public bool TryMatch(object o, out ISuppressionInfo suppression)
         {
             suppression = null;
-            var context = new ExpressionContext(Source, ResourceKind.SuppressionGroup, o);
+            var context = new ExpressionContext(_Context, Source, ResourceKind.SuppressionGroup, o);
             context.Debug(PSRuleResources.SelectorMatchTrace, Id);
             if (_Fn(context, o).GetValueOrDefault(false))
             {

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -56,11 +56,6 @@ namespace PSRule.Host
             return builder.Build();
         }
 
-        internal static IEnumerable<RuleBlock> GetRuleYamlBlocks(Source[] source, RunspaceContext context)
-        {
-            return ToRuleBlockV1(GetYamlLanguageBlocks(source, context), context, skipDuplicateName: true).GetAll();
-        }
-
         private static IEnumerable<ILanguageBlock> GetYamlJsonLanguageBlocks(Source[] source, RunspaceContext context)
         {
             var results = new List<ILanguageBlock>();
@@ -530,7 +525,7 @@ namespace PSRule.Host
                         @ref: block.Ref,
                         level: block.Level,
                         info: info,
-                        condition: new RuleVisitor(block.Id, block.Source, block.Spec),
+                        condition: new RuleVisitor(context, block.Id, block.Source, block.Spec),
                         alias: block.Alias,
                         tag: block.Metadata.Tags,
                         dependsOn: null,  // TODO: No support for DependsOn yet
@@ -706,11 +701,11 @@ namespace PSRule.Host
 
             // Process module configurations first
             foreach (var resource in resources.Where(r => r.Kind == ResourceKind.ModuleConfig).ToArray())
-                context.Pipeline.Import(resource);
+                context.Pipeline.Import(context, resource);
 
             // Process other resources
             foreach (var resource in resources.Where(r => r.Kind != ResourceKind.ModuleConfig).ToArray())
-                context.Pipeline.Import(resource);
+                context.Pipeline.Import(context, resource);
         }
 
         private static void Import(IConvention[] blocks, RunspaceContext context)

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -476,7 +476,7 @@ namespace PSRule.Pipeline
         {
             // Nest the previous write action in the new supplied action
             // Execution chain will be: action -> previous -> previous..n
-            return (string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, out string path) =>
+            return (string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, out string path) =>
             {
                 return action(propertyNames, caseSensitive, preferTargetInfo, targetObject, previous, out path);
             };
@@ -484,7 +484,7 @@ namespace PSRule.Pipeline
 
         private static BindTargetMethod AddBindTargetAction(BindTargetName action, BindTargetMethod previous)
         {
-            return AddBindTargetAction((string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, BindTargetMethod next, out string path) =>
+            return AddBindTargetAction((string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, BindTargetMethod next, out string path) =>
             {
                 path = null;
                 var targetType = action(targetObject);

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -161,7 +161,7 @@ namespace PSRule.Pipeline
             return _Runspace;
         }
 
-        internal void Import(IResource resource)
+        internal void Import(RunspaceContext context, IResource resource)
         {
             TrackIssue(resource);
             if (TryBaseline(resource, out var baseline) && TryBaselineRef(resource.Id, out var baselineRef))
@@ -170,7 +170,7 @@ namespace PSRule.Pipeline
                 Baseline.Add(new OptionContext.BaselineScope(baselineRef.Type, baseline.BaselineId, resource.Source.Module, baseline.Spec, baseline.Obsolete));
             }
             else if (resource.Kind == ResourceKind.Selector && resource is SelectorV1 selector)
-                Selector[selector.Id.Value] = new SelectorVisitor(selector.Id, selector.Source, selector.Spec.If);
+                Selector[selector.Id.Value] = new SelectorVisitor(context, selector.Id, selector.Source, selector.Spec.If);
             else if (TryModuleConfig(resource, out var moduleConfig))
             {
                 if (!string.IsNullOrEmpty(moduleConfig?.Spec?.Rule?.Baseline))
@@ -184,6 +184,7 @@ namespace PSRule.Pipeline
             else if (resource.Kind == ResourceKind.SuppressionGroup && resource is SuppressionGroupV1 suppressionGroup)
             {
                 SuppressionGroup.Add(new SuppressionGroupVisitor(
+                    context: context,
                     id: suppressionGroup.Id,
                     source: suppressionGroup.Source,
                     spec: suppressionGroup.Spec,

--- a/src/PSRule/Pipeline/PipelineHookActions.cs
+++ b/src/PSRule/Pipeline/PipelineHookActions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
@@ -19,9 +20,12 @@ namespace PSRule.Pipeline
         private const string Property_TargetName = "TargetName";
         private const string Property_Name = "Name";
 
-        public static string BindTargetName(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, out string path)
+        public static string BindTargetName(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, out string path)
         {
             path = null;
+            if (targetObject == null)
+                return null;
+
             if (preferTargetInfo && TryGetInfoTargetName(targetObject, out var targetName))
                 return targetName;
 
@@ -33,9 +37,12 @@ namespace PSRule.Pipeline
             return DefaultTargetNameBinding(targetObject);
         }
 
-        public static string BindTargetType(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, out string path)
+        public static string BindTargetType(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, out string path)
         {
             path = null;
+            if (targetObject == null)
+                return null;
+
             if (preferTargetInfo && TryGetInfoTargetType(targetObject, out var targetType))
                 return targetType;
 
@@ -47,9 +54,12 @@ namespace PSRule.Pipeline
             return DefaultTargetTypeBinding(targetObject);
         }
 
-        public static string BindField(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, PSObject targetObject, out string path)
+        public static string BindField(string[] propertyNames, bool caseSensitive, bool preferTargetInfo, object targetObject, out string path)
         {
             path = null;
+            if (targetObject == null)
+                return null;
+
             if (propertyNames != null)
                 return propertyNames.Any(n => n.Contains('.'))
                     ? NestedTargetPropertyBinding(propertyNames, caseSensitive, targetObject, DefaultFieldBinding, out path)
@@ -63,7 +73,7 @@ namespace PSRule.Pipeline
         /// </summary>
         /// <param name="targetObject">A PSObject to bind.</param>
         /// <returns>The TargetName of the object.</returns>
-        private static string DefaultTargetNameBinding(PSObject targetObject)
+        private static string DefaultTargetNameBinding(object targetObject)
         {
             return TryGetInfoTargetName(targetObject, out var targetName) ||
                 TryGetTargetName(targetObject, propertyName: Property_TargetName, targetName: out targetName) ||
@@ -76,16 +86,17 @@ namespace PSRule.Pipeline
         /// Get the TargetName of the object by using any of the specified property names.
         /// </summary>
         /// <param name="propertyNames">One or more property names to use to bind TargetName.</param>
+        /// <param name="caseSensitive">Determines if binding properties are case-sensitive.</param>
         /// <param name="targetObject">A PSObject to bind.</param>
         /// <param name="next">The next delegate function to check if all of the property names can not be found.</param>
         /// <returns>The TargetName of the object.</returns>
-        private static string CustomTargetPropertyBinding(string[] propertyNames, bool caseSensitive, PSObject targetObject, BindTargetName next, out string path)
+        private static string CustomTargetPropertyBinding(string[] propertyNames, bool caseSensitive, object targetObject, BindTargetName next, out string path)
         {
             path = null;
             string targetName = null;
             for (var i = 0; i < propertyNames.Length && targetName == null; i++)
             {
-                targetName = targetObject.ValueAsString(propertyName: propertyNames[i], caseSensitive: caseSensitive);
+                targetName = ValueAsString(targetObject, propertyName: propertyNames[i], caseSensitive: caseSensitive);
                 if (targetName != null)
                     path = propertyNames[i];
             }
@@ -97,10 +108,11 @@ namespace PSRule.Pipeline
         /// Get the TargetName of the object by using any of the specified property names.
         /// </summary>
         /// <param name="propertyNames">One or more property names to use to bind TargetName.</param>
+        /// <param name="caseSensitive">Determines if binding properties are case-sensitive.</param>
         /// <param name="targetObject">A PSObject to bind.</param>
         /// <param name="next">The next delegate function to check if all of the property names can not be found.</param>
         /// <returns>The TargetName of the object.</returns>
-        private static string NestedTargetPropertyBinding(string[] propertyNames, bool caseSensitive, PSObject targetObject, BindTargetName next, out string path)
+        private static string NestedTargetPropertyBinding(string[] propertyNames, bool caseSensitive, object targetObject, BindTargetName next, out string path)
         {
             path = null;
             string targetName = null;
@@ -128,7 +140,7 @@ namespace PSRule.Pipeline
         /// </summary>
         /// <param name="targetObject">A PSObject to hash.</param>
         /// <returns>The TargetName of the object.</returns>
-        private static string GetUnboundObjectTargetName(PSObject targetObject)
+        private static string GetUnboundObjectTargetName(object targetObject)
         {
             var settings = new JsonSerializerSettings
             {
@@ -146,9 +158,9 @@ namespace PSRule.Pipeline
         /// <summary>
         /// Try to get TargetName from specified property.
         /// </summary>
-        private static bool TryGetTargetName(PSObject targetObject, string propertyName, out string targetName)
+        private static bool TryGetTargetName(object targetObject, string propertyName, out string targetName)
         {
-            targetName = targetObject.ValueAsString(propertyName, false);
+            targetName = ValueAsString(targetObject, propertyName, false);
             return targetName != null;
         }
 
@@ -157,34 +169,49 @@ namespace PSRule.Pipeline
         /// </summary>
         /// <param name="targetObject">A PSObject to bind.</param>
         /// <returns>The TargetObject of the object.</returns>
-        private static string DefaultTargetTypeBinding(PSObject targetObject)
+        private static string DefaultTargetTypeBinding(object targetObject)
         {
-            return TryGetInfoTargetType(targetObject, out var targetType) ? targetType : targetObject.TypeNames[0];
+            return TryGetInfoTargetType(targetObject, out var targetType) ? targetType : GetTypeNames(targetObject);
         }
 
-        private static string DefaultFieldBinding(PSObject targetObject)
+        private static string GetTypeNames(object targetObject)
+        {
+            if (targetObject == null)
+                return null;
+
+            return targetObject is PSObject pso ? pso.TypeNames[0] : targetObject.GetType().FullName;
+        }
+
+        private static string DefaultFieldBinding(object targetObject)
         {
             return null;
         }
 
-        private static bool TryGetInfoTargetName(PSObject targetObject, out string targetName)
+        private static bool TryGetInfoTargetName(object targetObject, out string targetName)
         {
             targetName = null;
-            if (!(targetObject.BaseObject is ITargetInfo info))
+            var baseObject = ExpressionHelpers.GetBaseObject(targetObject);
+            if (baseObject is not ITargetInfo info)
                 return false;
 
             targetName = info.TargetName;
             return true;
         }
 
-        private static bool TryGetInfoTargetType(PSObject targetObject, out string targetType)
+        private static bool TryGetInfoTargetType(object targetObject, out string targetType)
         {
             targetType = null;
-            if (!(targetObject.BaseObject is ITargetInfo info))
+            var baseObject = ExpressionHelpers.GetBaseObject(targetObject);
+            if (baseObject is not ITargetInfo info)
                 return false;
 
             targetType = info.TargetType;
             return true;
+        }
+
+        private static string ValueAsString(object o, string propertyName, bool caseSensitive)
+        {
+            return ObjectHelper.GetPath(bindingContext: null, targetObject: o, path: propertyName, caseSensitive: caseSensitive, value: out object value) && value != null ? value.ToString() : null;
         }
     }
 }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -8,11 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace PSRule.Resources
-{
+namespace PSRule.Resources {
     using System;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -23,980 +22,805 @@ namespace PSRule.Resources
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class PSRuleResources
-    {
-
+    internal class PSRuleResources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal PSRuleResources()
-        {
+        internal PSRuleResources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("PSRule.Resources.PSRuleResources", typeof(PSRuleResources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to The arguments for &apos;{0}&apos; are not in the expected format or type..
+        ///   Looks up a localized string similar to The {0} resource &apos;{1}&apos; is currently referencing &apos;{2}&apos; using the alias &apos;{3}&apos;. Consider updating the reference to use name or id directly..
         /// </summary>
-        internal static string ArgumentFormatInvalid
-        {
-            get
-            {
-                return ResourceManager.GetString("ArgumentFormatInvalid", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid boolean..
-        /// </summary>
-        internal static string ArgumentInvalidBoolean
-        {
-            get
-            {
-                return ResourceManager.GetString("ArgumentInvalidBoolean", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid integer..
-        /// </summary>
-        internal static string ArgumentInvalidInteger
-        {
-            get
-            {
-                return ResourceManager.GetString("ArgumentInvalidInteger", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid string..
-        /// </summary>
-        internal static string ArgumentInvalidString
-        {
-            get
-            {
-                return ResourceManager.GetString("ArgumentInvalidString", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The number of arguments &apos;{1}&apos; is not within the allowed range for &apos;{0}&apos;..
-        /// </summary>
-        internal static string ArgumentsOutOfRange
-        {
-            get
-            {
-                return ResourceManager.GetString("ArgumentsOutOfRange", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to The baseline &apos;{0}&apos; is obsolete. Consider switching to an alternative baseline..
-        /// </summary>
-        internal static string AliasReference
-        {
-            get
-            {
+        internal static string AliasReference {
+            get {
                 return ResourceManager.GetString("AliasReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Suppression for the rule &apos;{0}&apos; was configured using the alias &apos;{1}&apos;. Consider updating the suppression to use the name or id directly..
         /// </summary>
-        internal static string AliasSuppression
-        {
-            get
-            {
+        internal static string AliasSuppression {
+            get {
                 return ResourceManager.GetString("AliasSuppression", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The arguments for &apos;{0}&apos; are not in the expected format or type..
+        /// </summary>
+        internal static string ArgumentFormatInvalid {
+            get {
+                return ResourceManager.GetString("ArgumentFormatInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid boolean..
+        /// </summary>
+        internal static string ArgumentInvalidBoolean {
+            get {
+                return ResourceManager.GetString("ArgumentInvalidBoolean", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid integer..
+        /// </summary>
+        internal static string ArgumentInvalidInteger {
+            get {
+                return ResourceManager.GetString("ArgumentInvalidInteger", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; for &apos;{1}&apos; is not a valid string..
+        /// </summary>
+        internal static string ArgumentInvalidString {
+            get {
+                return ResourceManager.GetString("ArgumentInvalidString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of arguments &apos;{1}&apos; is not within the allowed range for &apos;{0}&apos;..
+        /// </summary>
+        internal static string ArgumentsOutOfRange {
+            get {
+                return ResourceManager.GetString("ArgumentsOutOfRange", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The baseline &apos;{0}&apos; is obsolete. Consider switching to an alternative baseline..
+        /// </summary>
+        internal static string BaselineObsolete {
+            get {
+                return ResourceManager.GetString("BaselineObsolete", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Binding functions are not supported in this language mode..
         /// </summary>
-        internal static string ConstrainedTargetBinding
-        {
-            get
-            {
+        internal static string ConstrainedTargetBinding {
+            get {
                 return ResourceManager.GetString("ConstrainedTargetBinding", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0}: The property &apos;${1}.{2}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string DebugPropertyObsolete
-        {
-            get
-            {
+        internal static string DebugPropertyObsolete {
+            get {
                 return ResourceManager.GetString("DebugPropertyObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target failed If precondition.
         /// </summary>
-        internal static string DebugTargetIfMismatch
-        {
-            get
-            {
+        internal static string DebugTargetIfMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetIfMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target failed Rule precondition.
         /// </summary>
-        internal static string DebugTargetRuleMismatch
-        {
-            get
-            {
+        internal static string DebugTargetRuleMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetRuleMismatch", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Target failed sub-selector pre-condition..
+        /// </summary>
+        internal static string DebugTargetSubselectorMismatch {
+            get {
+                return ResourceManager.GetString("DebugTargetSubselectorMismatch", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to Target failed Type precondition.
         /// </summary>
-        internal static string DebugTargetTypeMismatch
-        {
-            get
-            {
+        internal static string DebugTargetTypeMismatch {
+            get {
                 return ResourceManager.GetString("DebugTargetTypeMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A circular rule dependency was detected. The rule &apos;{0}&apos; depends on &apos;{1}&apos; which also depend on &apos;{0}&apos;..
         /// </summary>
-        internal static string DependencyCircularReference
-        {
-            get
-            {
+        internal static string DependencyCircularReference {
+            get {
                 return ResourceManager.GetString("DependencyCircularReference", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The dependency &apos;{0}&apos; for &apos;{1}&apos; could not be found. Check that the rule is defined in a .Rule.ps1 file within the search path..
         /// </summary>
-        internal static string DependencyNotFound
-        {
-            get
-            {
+        internal static string DependencyNotFound {
+            get {
                 return ResourceManager.GetString("DependencyNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The resource &apos;{0}&apos; is using a duplicate resource identifier. A resource with the identifier &apos;{1}&apos; already exists. Each resource must have a unique name, ref, and aliases. See https://aka.ms/ps-rule/naming for guidance on naming within PSRule..
         /// </summary>
-        internal static string DuplicateResourceId
-        {
-            get
-            {
+        internal static string DuplicateResourceId {
+            get {
                 return ResourceManager.GetString("DuplicateResourceId", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A rule with the same name &apos;{0}&apos; already exists..
         /// </summary>
-        internal static string DuplicateRuleName
-        {
-            get
-            {
+        internal static string DuplicateRuleName {
+            get {
                 return ResourceManager.GetString("DuplicateRuleName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} : Reported &apos;{1}&apos;. At {2}:{3} char:{4}.
         /// </summary>
-        internal static string ErrorDetailMessage
-        {
-            get
-            {
+        internal static string ErrorDetailMessage {
+            get {
                 return ResourceManager.GetString("ErrorDetailMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more errors occured..
         /// </summary>
-        internal static string ErrorPipelineException
-        {
-            get
-            {
+        internal static string ErrorPipelineException {
+            get {
                 return ResourceManager.GetString("ErrorPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Exists: {0}.
         /// </summary>
-        internal static string ExistsTrue
-        {
-            get
-            {
+        internal static string ExistsTrue {
+            get {
                 return ResourceManager.GetString("ExistsTrue", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to File.
-        /// </summary>
-        internal static string FileSourceType
-        {
-            get
-            {
-                return ResourceManager.GetString("FileSourceType", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to parse expression. The expression may not be valid. Expression: &quot;{0}&quot;.
         /// </summary>
-        internal static string ExpressionInvalid
-        {
-            get
-            {
+        internal static string ExpressionInvalid {
+            get {
                 return ResourceManager.GetString("ExpressionInvalid", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File.
+        /// </summary>
+        internal static string FileSourceType {
+            get {
+                return ResourceManager.GetString("FileSourceType", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Found {0} PSRule module(s).
         /// </summary>
-        internal static string FoundModules
-        {
-            get
-            {
+        internal static string FoundModules {
+            get {
                 return ResourceManager.GetString("FoundModules", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The function &quot;{0}&quot; was not found..
         /// </summary>
-        internal static string FunctionNotFound
-        {
-            get
-            {
+        internal static string FunctionNotFound {
+            get {
                 return ResourceManager.GetString("FunctionNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The language expression index &apos;{0}&apos; is not valid for the object..
         /// </summary>
-        internal static string IndexInvalid
-        {
-            get
-            {
+        internal static string IndexInvalid {
+            get {
                 return ResourceManager.GetString("IndexInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Output written to the following file: &apos;{0}&apos;.
         /// </summary>
-        internal static string InfoOutputPath
-        {
-            get
-            {
+        internal static string InfoOutputPath {
+            get {
                 return ResourceManager.GetString("InfoOutputPath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An invalid ErrorAction ({0}) was specified for rule at {1}. Ignore | Stop are supported..
         /// </summary>
-        internal static string InvalidErrorAction
-        {
-            get
-            {
+        internal static string InvalidErrorAction {
+            get {
                 return ResourceManager.GetString("InvalidErrorAction", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The resource name &apos;{0}&apos; is not valid at {1}. Each resource name must be between 3-128 characters in length, must start and end with a letter or number, and only contain letters, numbers, hyphens, dots, or underscores. See https://aka.ms/ps-rule/naming for more information..
         /// </summary>
-        internal static string InvalidResourceName
-        {
-            get
-            {
+        internal static string InvalidResourceName {
+            get {
                 return ResourceManager.GetString("InvalidResourceName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule nesting was detected for rule at {0}. Rules must not be nested..
         /// </summary>
-        internal static string InvalidRuleNesting
-        {
-            get
-            {
+        internal static string InvalidRuleNesting {
+            get {
                 return ResourceManager.GetString("InvalidRuleNesting", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to An invalid rule result was returned for {0}. Conditions must return boolean $True or $False..
         /// </summary>
-        internal static string InvalidRuleResult
-        {
-            get
-            {
+        internal static string InvalidRuleResult {
+            get {
                 return ResourceManager.GetString("InvalidRuleResult", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string KeywordConditionScope
-        {
-            get
-            {
+        internal static string KeywordConditionScope {
+            get {
                 return ResourceManager.GetString("KeywordConditionScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can only be used within a Rule block or script precondition..
         /// </summary>
-        internal static string KeywordRuleScope
-        {
-            get
-            {
+        internal static string KeywordRuleScope {
+            get {
                 return ResourceManager.GetString("KeywordRuleScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The keyword &apos;{0}&apos; can not be nested in a Rule block..
         /// </summary>
-        internal static string KeywordSourceScope
-        {
-            get
-            {
+        internal static string KeywordSourceScope {
+            get {
                 return ResourceManager.GetString("KeywordSourceScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][{0}][Trace] -- {1}: {2}.
         /// </summary>
-        internal static string LanguageExpressionTraceP2
-        {
-            get
-            {
+        internal static string LanguageExpressionTraceP2 {
+            get {
                 return ResourceManager.GetString("LanguageExpressionTraceP2", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][{0}][Trace] -- {1}: {2} {1} {3}.
         /// </summary>
-        internal static string LanguageExpressionTraceP3
-        {
-            get
-            {
+        internal static string LanguageExpressionTraceP3 {
+            get {
                 return ResourceManager.GetString("LanguageExpressionTraceP3", resourceCulture);
             }
         }
-
-        internal static string LanguageExpressionTrace
-        {
-            get
-            {
-                return ResourceManager.GetString("LanguageExpressionTrace", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Please open your browser to the following location: {0}.
         /// </summary>
-        internal static string LaunchBrowser
-        {
-            get
-            {
+        internal static string LaunchBrowser {
+            get {
                 return ResourceManager.GetString("LaunchBrowser", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Wildcard match requires exactly one name..
         /// </summary>
-        internal static string MatchSingleName
-        {
-            get
-            {
+        internal static string MatchSingleName {
+            get {
                 return ResourceManager.GetString("MatchSingleName", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Matches: {0}.
         /// </summary>
-        internal static string MatchTrue
-        {
-            get
-            {
+        internal static string MatchTrue {
+            get {
                 return ResourceManager.GetString("MatchTrue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Update module &apos;{0}&apos; to set the default baseline using a module configuration resource instead. Configuring the default baseline via manifest will be removed in the next major version. See https://aka.ms/ps-rule/module-config..
         /// </summary>
-        internal static string ModuleManifestBaseline
-        {
-            get
-            {
+        internal static string ModuleManifestBaseline {
+            get {
                 return ResourceManager.GetString("ModuleManifestBaseline", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No valid module can be found with that name..
         /// </summary>
-        internal static string ModuleNotFound
-        {
-            get
-            {
+        internal static string ModuleNotFound {
+            get {
                 return ResourceManager.GetString("ModuleNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Target object &apos;{0}&apos; has not been processed because no matching rules were found..
         /// </summary>
-        internal static string ObjectNotProcessed
-        {
-            get
-            {
+        internal static string ObjectNotProcessed {
+            get {
                 return ResourceManager.GetString("ObjectNotProcessed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Object path not found..
         /// </summary>
-        internal static string ObjectPathNotFound
-        {
-            get
-            {
+        internal static string ObjectPathNotFound {
+            get {
                 return ResourceManager.GetString("ObjectPathNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Options file does not exist..
         /// </summary>
-        internal static string OptionsNotFound
-        {
-            get
-            {
+        internal static string OptionsNotFound {
+            get {
                 return ResourceManager.GetString("OptionsNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to # Source: {0}.
         /// </summary>
-        internal static string OptionsSourceComment
-        {
-            get
-            {
+        internal static string OptionsSourceComment {
+            get {
                 return ResourceManager.GetString("OptionsSourceComment", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Error.
         /// </summary>
-        internal static string OutcomeError
-        {
-            get
-            {
+        internal static string OutcomeError {
+            get {
                 return ResourceManager.GetString("OutcomeError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Fail.
         /// </summary>
-        internal static string OutcomeFail
-        {
-            get
-            {
+        internal static string OutcomeFail {
+            get {
                 return ResourceManager.GetString("OutcomeFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Pass.
         /// </summary>
-        internal static string OutcomePass
-        {
-            get
-            {
+        internal static string OutcomePass {
+            get {
                 return ResourceManager.GetString("OutcomePass", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [FAIL] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRuleFail
-        {
-            get
-            {
+        internal static string OutcomeRuleFail {
+            get {
                 return ResourceManager.GetString("OutcomeRuleFail", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PASS] -- {0}:: Reported for &apos;{1}&apos;.
         /// </summary>
-        internal static string OutcomeRulePass
-        {
-            get
-            {
+        internal static string OutcomeRulePass {
+            get {
                 return ResourceManager.GetString("OutcomeRulePass", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Unknown.
         /// </summary>
-        internal static string OutcomeUnknown
-        {
-            get
-            {
+        internal static string OutcomeUnknown {
+            get {
                 return ResourceManager.GetString("OutcomeUnknown", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The language expression property &apos;{0}&apos; doesn&apos;t exist..
         /// </summary>
-        internal static string PropertyNotFound
-        {
-            get
-            {
+        internal static string PropertyNotFound {
+            get {
                 return ResourceManager.GetString("PropertyNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The property &apos;${0}.{1}&apos; is obsolete and will be removed in the next major version..
         /// </summary>
-        internal static string PropertyObsolete
-        {
-            get
-            {
+        internal static string PropertyObsolete {
+            get {
                 return ResourceManager.GetString("PropertyObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize the file &apos;{0}&apos;: {1}.
         /// </summary>
-        internal static string ReadFileFailed
-        {
-            get
-            {
+        internal static string ReadFileFailed {
+            get {
                 return ResourceManager.GetString("ReadFileFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed..
         /// </summary>
-        internal static string ReadJsonFailed
-        {
-            get
-            {
+        internal static string ReadJsonFailed {
+            get {
                 return ResourceManager.GetString("ReadJsonFailed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Read JSON failed because the token ({0}) was not expected..
         /// </summary>
-        internal static string ReadJsonFailedExpectedToken
-        {
-            get
-            {
+        internal static string ReadJsonFailedExpectedToken {
+            get {
                 return ResourceManager.GetString("ReadJsonFailedExpectedToken", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The module version &apos;{1}&apos; for &apos;{0}&apos; does not match the required version &apos;{2}&apos;. To continue, first update the module to match the version requirement..
         /// </summary>
-        internal static string RequiredVersionMismatch
-        {
-            get
-            {
+        internal static string RequiredVersionMismatch {
+            get {
                 return ResourceManager.GetString("RequiredVersionMismatch", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The {0} &apos;{1}&apos; is obsolete. Consider switching to an alternative {0}..
         /// </summary>
-        internal static string ResourceObsolete
-        {
-            get
-            {
+        internal static string ResourceObsolete {
+            get {
                 return ResourceManager.GetString("ResourceObsolete", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleCountSuppressed
-        {
-            get
-            {
+        internal static string RuleCountSuppressed {
+            get {
                 return ResourceManager.GetString("RuleCountSuppressed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported errors..
         /// </summary>
-        internal static string RuleErrorPipelineException
-        {
-            get
-            {
+        internal static string RuleErrorPipelineException {
+            get {
                 return ResourceManager.GetString("RuleErrorPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to One or more rules reported failure..
         /// </summary>
-        internal static string RuleFailPipelineException
-        {
-            get
-            {
+        internal static string RuleFailPipelineException {
+            get {
                 return ResourceManager.GetString("RuleFailPipelineException", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Inconclusive result reported for &apos;{1}&apos; @{0}..
         /// </summary>
-        internal static string RuleInconclusive
-        {
-            get
-            {
+        internal static string RuleInconclusive {
+            get {
                 return ResourceManager.GetString("RuleInconclusive", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][R][Trace] -- {0}.
         /// </summary>
-        internal static string RuleMatchTrace
-        {
-            get
-            {
+        internal static string RuleMatchTrace {
+            get {
                 return ResourceManager.GetString("RuleMatchTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find a matching rule. Please check that Path, Name and Tag parameters are correct..
         /// </summary>
-        internal static string RuleNotFound
-        {
-            get
-            {
+        internal static string RuleNotFound {
+            get {
                 return ResourceManager.GetString("RuleNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Could not find required rule definition parameter &apos;{0}&apos; on rule at {1}..
         /// </summary>
-        internal static string RuleParameterNotFound
-        {
-            get
-            {
+        internal static string RuleParameterNotFound {
+            get {
                 return ResourceManager.GetString("RuleParameterNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to No matching .Rule.ps1 files were found. Rule definitions should be saved into script files with the .Rule.ps1 extension..
         /// </summary>
-        internal static string RulePathNotFound
-        {
-            get
-            {
+        internal static string RulePathNotFound {
+            get {
                 return ResourceManager.GetString("RulePathNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to at Rule &apos;{0}&apos;, {1}: line {2}.
         /// </summary>
-        internal static string RuleStackTrace
-        {
-            get
-            {
+        internal static string RuleStackTrace {
+            get {
                 return ResourceManager.GetString("RuleStackTrace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed for &apos;{1}&apos;..
         /// </summary>
-        internal static string RuleSuppressed
-        {
-            get
-            {
+        internal static string RuleSuppressed {
+            get {
                 return ResourceManager.GetString("RuleSuppressed", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;..
         /// </summary>
-        internal static string RuleSuppressionGroup
-        {
-            get
-            {
+        internal static string RuleSuppressionGroup {
+            get {
                 return ResourceManager.GetString("RuleSuppressionGroup", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;..
         /// </summary>
-        internal static string RuleSuppressionGroupCount
-        {
-            get
-            {
+        internal static string RuleSuppressionGroupCount {
+            get {
                 return ResourceManager.GetString("RuleSuppressionGroupCount", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Rule &apos;{0}&apos; was suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;. {3}.
         /// </summary>
-        internal static string RuleSuppressionGroupExtended
-        {
-            get
-            {
+        internal static string RuleSuppressionGroupExtended {
+            get {
                 return ResourceManager.GetString("RuleSuppressionGroupExtended", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} rule/s were suppressed by suppression group &apos;{1}&apos; for &apos;{2}&apos;. {3}.
         /// </summary>
-        internal static string RuleSuppressionGroupExtendedCount
-        {
-            get
-            {
+        internal static string RuleSuppressionGroupExtendedCount {
+            get {
                 return ResourceManager.GetString("RuleSuppressionGroupExtendedCount", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files in module: {0}.
         /// </summary>
-        internal static string ScanModule
-        {
-            get
-            {
+        internal static string ScanModule {
+            get {
                 return ResourceManager.GetString("ScanModule", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][D] -- Scanning for source files: {0}.
         /// </summary>
-        internal static string ScanSource
-        {
-            get
-            {
+        internal static string ScanSource {
+            get {
                 return ResourceManager.GetString("ScanSource", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The script was not found..
         /// </summary>
-        internal static string ScriptNotFound
-        {
-            get
-            {
+        internal static string ScriptNotFound {
+            get {
                 return ResourceManager.GetString("ScriptNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}.
         /// </summary>
-        internal static string SelectorMatchTrace
-        {
-            get
-            {
+        internal static string SelectorMatchTrace {
+            get {
                 return ResourceManager.GetString("SelectorMatchTrace", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to [PSRule][S][Trace] -- {0}: {1}.
-        /// </summary>
-        internal static string SelectorTrace
-        {
-            get
-            {
-                return ResourceManager.GetString("SelectorTrace", resourceCulture);
-            }
-        }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Can not serialize a null PSObject..
         /// </summary>
-        internal static string SerializeNullPSObject
-        {
-            get
-            {
+        internal static string SerializeNullPSObject {
+            get {
                 return ResourceManager.GetString("SerializeNullPSObject", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Create path.
         /// </summary>
-        internal static string ShouldCreatePath
-        {
-            get
-            {
+        internal static string ShouldCreatePath {
+            get {
                 return ResourceManager.GetString("ShouldCreatePath", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Write file.
         /// </summary>
-        internal static string ShouldWriteFile
-        {
-            get
-            {
+        internal static string ShouldWriteFile {
+            get {
                 return ResourceManager.GetString("ShouldWriteFile", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The source was not found..
         /// </summary>
-        internal static string SourceNotFound
-        {
-            get
-            {
+        internal static string SourceNotFound {
+            get {
                 return ResourceManager.GetString("SourceNotFound", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Using invariant culture may cause rule infomation to be displayed incorrectly. Consider using -Culture or set the Output.Culture option..
         /// </summary>
-        internal static string UsingInvariantCulture
-        {
-            get
-            {
+        internal static string UsingInvariantCulture {
+            get {
                 return ResourceManager.GetString("UsingInvariantCulture", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The variable &apos;${0}&apos; can only be used within a Rule block..
         /// </summary>
-        internal static string VariableConditionScope
-        {
-            get
-            {
+        internal static string VariableConditionScope {
+            get {
                 return ResourceManager.GetString("VariableConditionScope", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The version constraint &apos;{0}&apos; is not valid..
         /// </summary>
-        internal static string VersionConstraintInvalid
-        {
-            get
-            {
+        internal static string VersionConstraintInvalid {
+            get {
                 return ResourceManager.GetString("VersionConstraintInvalid", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The Within parameter Value must be a string when the Like parameter is used..
         /// </summary>
-        internal static string WithinLikeNotString
-        {
-            get
-            {
+        internal static string WithinLikeNotString {
+            get {
                 return ResourceManager.GetString("WithinLikeNotString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Within: {0}.
         /// </summary>
-        internal static string WithinTrue
-        {
-            get
-            {
+        internal static string WithinTrue {
+            get {
                 return ResourceManager.GetString("WithinTrue", resourceCulture);
             }
         }

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -382,4 +382,7 @@
   <data name="ReadJsonFailedExpectedToken" xml:space="preserve">
     <value>Read JSON failed because the token ({0}) was not expected.</value>
   </data>
+  <data name="DebugTargetSubselectorMismatch" xml:space="preserve">
+    <value>Target failed sub-selector pre-condition.</value>
+  </data>
 </root>

--- a/src/PSRule/Runtime/ObjectPath/PathExpression.cs
+++ b/src/PSRule/Runtime/ObjectPath/PathExpression.cs
@@ -10,7 +10,7 @@ namespace PSRule.Runtime.ObjectPath
     /// <summary>
     /// An expression function that returns one or more values when successful.
     /// </summary>
-    internal delegate bool PathExpressionFn(IPathExpressionContext context, object input, out IEnumerable<object> value);
+    internal delegate bool PathExpressionFn(IPathExpressionContext context, object input, out IEnumerable<object> value, out bool enumerable);
 
     /// <summary>
     /// A function for filter objects that simply returns true or false.
@@ -92,7 +92,7 @@ namespace PSRule.Runtime.ObjectPath
         public bool TryGet(object o, bool caseSensitive, out object[] value)
         {
             value = null;
-            if (!TryGet(o, caseSensitive, out IEnumerable<object> result))
+            if (!TryGet(o, caseSensitive, out var result, out var enumerable))
                 return false;
 
             value = result.ToArray();
@@ -106,10 +106,11 @@ namespace PSRule.Runtime.ObjectPath
         public bool TryGet(object o, bool caseSensitive, out object value)
         {
             value = null;
-            if (!TryGet(o, caseSensitive, out object[] result))
+            if (!TryGet(o, caseSensitive, out var result, out var enumerable))
                 return false;
 
-            value = IsArray ? result : result[0];
+            var items = result.ToArray();
+            value = IsArray || enumerable ? items : items[0];
             return true;
         }
 
@@ -120,10 +121,10 @@ namespace PSRule.Runtime.ObjectPath
         /// <param name="caseSensitive">Determines if member name matching is case-sensitive.</param>
         /// <param name="value">The values selected from the object.</param>
         /// <returns>Returns true when the path exists within the object. Returns false if the path does not exist.</returns>
-        private bool TryGet(object o, bool caseSensitive, out IEnumerable<object> value)
+        private bool TryGet(object o, bool caseSensitive, out IEnumerable<object> value, out bool enumerable)
         {
             var context = new PathExpressionContext(o, caseSensitive);
-            return _Expression.Invoke(context, o, out value);
+            return _Expression.Invoke(context, o, out value, out enumerable);
         }
     }
 }

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -70,7 +70,7 @@ namespace PSRule.Runtime
         // Fields exposed to engine
         internal RuleRecord RuleRecord;
         internal RuleBlock RuleBlock;
-        internal ITargetBindingContext Binding;
+        internal ITargetBindingResult Binding;
 
         private readonly bool _InconclusiveWarning;
         private readonly bool _NotProcessedWarning;
@@ -118,7 +118,7 @@ namespace PSRule.Runtime
             _RuleTimer = new Stopwatch();
             _Reason = new List<ResultReason>();
             _Conventions = new List<IConvention>();
-            _LanguageScopes = new LanguageScopeSet();
+            _LanguageScopes = new LanguageScopeSet(this);
             _Scope = new Stack<RunspaceScope>();
         }
 
@@ -643,7 +643,7 @@ namespace PSRule.Runtime
         /// </summary>
         public RuleRecord EnterRuleBlock(RuleBlock ruleBlock)
         {
-            Binding = TargetBinder.Using(ruleBlock.Info.ModuleName);
+            Binding = TargetBinder.Result(ruleBlock.Info.ModuleName);
 
             _RuleErrors = 0;
             RuleBlock = ruleBlock;
@@ -791,10 +791,14 @@ namespace PSRule.Runtime
                 Pipeline.BindField,
                 Pipeline.Option.Input.TargetType);
 
+            HashSet<string> _TypeFilter = null;
+            if (Pipeline.Option.Input.TargetType != null && Pipeline.Option.Input.TargetType.Length > 0)
+                _TypeFilter = new HashSet<string>(Pipeline.Option.Input.TargetType, StringComparer.OrdinalIgnoreCase);
+
             foreach (var languageScope in _LanguageScopes.Get())
             {
                 var targetBinding = Pipeline.Baseline.GetTargetBinding();
-                builder.With(new TargetBinder.TargetBindingContext(languageScope.Name, targetBinding));
+                builder.With(new TargetBinder.TargetBindingContext(languageScope.Name, targetBinding, Pipeline.BindTargetName, Pipeline.BindTargetType, Pipeline.BindField, _TypeFilter));
             }
             TargetBinder = builder.Build();
             RunConventionInitialize();

--- a/tests/PSRule.Tests/FromFileSubSelector.Rule.jsonc
+++ b/tests/PSRule.Tests/FromFileSubSelector.Rule.jsonc
@@ -1,0 +1,66 @@
+[
+    {
+        // Synopsis: A rule with sub-selector pre-condition.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRuleWithPrecondition"
+        },
+        "spec": {
+            "where": {
+                "field": "kind",
+                "equals": "test"
+            },
+            "condition": {
+                "field": "resources",
+                "count": 2
+            }
+        }
+    },
+    {
+        // Synopsis: A rule with sub-selector filter.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRuleWithSubselector"
+        },
+        "spec": {
+            "condition": {
+                "field": "resources",
+                "where": {
+                    "field": ".",
+                    "isString": true
+                },
+                "allOf": [
+                    {
+                        "field": ".",
+                        "equals": "abc"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        // Synopsis: A rule with sub-selector filter.
+        "apiVersion": "github.com/microsoft/PSRule/v1",
+        "kind": "Rule",
+        "metadata": {
+            "name": "JsonRuleWithSubselectorReordered"
+        },
+        "spec": {
+            "condition": {
+                "allOf": [
+                    {
+                        "field": ".",
+                        "equals": "abc"
+                    }
+                ],
+                "field": "resources",
+                "where": {
+                    "field": ".",
+                    "equals": "abc"
+                }
+            }
+        }
+    }
+]

--- a/tests/PSRule.Tests/FromFileSubSelector.Rule.yaml
+++ b/tests/PSRule.Tests/FromFileSubSelector.Rule.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+#
+# YAML-based rules for unit testing
+#
+
+---
+# Synopsis: A rule with sub-selector pre-condition.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: YamlRuleWithPrecondition
+spec:
+  where:
+    field: 'kind'
+    equals: 'test'
+  condition:
+    field: resources
+    count: 2
+
+---
+# Synopsis: A rule with sub-selector filter.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: YamlRuleWithSubselector
+spec:
+  condition:
+    field: resources
+    where:
+      field: '.'
+      isString: true
+    allOf:
+    - field: '.'
+      equals: abc
+
+---
+# Synopsis: A rule with sub-selector filter.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: YamlRuleWithSubselectorReordered
+spec:
+  condition:
+    allOf:
+    - field: '.'
+      equals: abc
+    field: resources
+    where:
+      field: '.'
+      equals: 'abc'

--- a/tests/PSRule.Tests/FunctionBuilderTests.cs
+++ b/tests/PSRule.Tests/FunctionBuilderTests.cs
@@ -52,7 +52,7 @@ namespace PSRule
             context.Init(source);
             context.Begin();
             var selector = HostHelper.GetSelector(source, context).ToArray().FirstOrDefault(s => s.Name == name);
-            return new SelectorVisitor(selector.Id, selector.Source, selector.Spec.If);
+            return new SelectorVisitor(context, selector.Id, selector.Source, selector.Spec.If);
         }
 
         private static string GetSourcePath(string fileName)

--- a/tests/PSRule.Tests/FunctionTests.cs
+++ b/tests/PSRule.Tests/FunctionTests.cs
@@ -264,7 +264,7 @@ namespace PSRule
             targetObject.Properties.Add(new PSNoteProperty("name", "TestObject1"));
             var context = new Runtime.RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, new OptionContextBuilder(GetOption(), null, null, null).Build(), null), null);
             var s = GetSource();
-            var result = new ExpressionContext(s[0].File[0], Definitions.ResourceKind.Rule, targetObject);
+            var result = new ExpressionContext(context, s[0].File[0], Definitions.ResourceKind.Rule, targetObject);
             context.Init(s);
             context.Begin();
             context.PushScope(Runtime.RunspaceScope.Precondition);

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -70,6 +70,12 @@
     <None Update="FromFileName.Rule.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="FromFileSubSelector.Rule.jsonc">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="FromFileSubSelector.Rule.yaml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Functions.Rule.jsonc">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Tests/RulesTests.cs
+++ b/tests/PSRule.Tests/RulesTests.cs
@@ -20,6 +20,9 @@ namespace PSRule
     {
         #region Yaml rules
 
+        /// <summary>
+        /// Test that a YAML-based rule can be parsed.
+        /// </summary>
         [Fact]
         public void ReadYamlRule()
         {
@@ -42,6 +45,61 @@ namespace PSRule
 
             var hashtable = rule[0].Tag.ToHashtable();
             Assert.Equal("tag", hashtable["feature"]);
+        }
+
+        /// <summary>
+        /// Test that a YAML-based rule with sub-selectors can be parsed.
+        /// </summary>
+        [Fact]
+        public void ReadYamlSubSelectorRule()
+        {
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, new OptionContext(), null), new TestWriter(GetOption()));
+            context.Init(GetSource("FromFileSubSelector.Rule.yaml"));
+            context.Begin();
+
+            // From current path
+            var rule = HostHelper.GetRule(GetSource("FromFileSubSelector.Rule.yaml"), context, includeDependencies: false);
+            Assert.NotNull(rule);
+            Assert.Equal("YamlRuleWithPrecondition", rule[0].Name);
+            Assert.Equal("YamlRuleWithSubselector", rule[1].Name);
+            Assert.Equal("YamlRuleWithSubselectorReordered", rule[2].Name);
+
+            context.Init(GetSource("FromFileSubSelector.Rule.yaml"));
+            context.Begin();
+            var subselector1 = GetRuleVisitor(context, "YamlRuleWithPrecondition", GetSource("FromFileSubSelector.Rule.yaml"));
+            var subselector2 = GetRuleVisitor(context, "YamlRuleWithSubselector", GetSource("FromFileSubSelector.Rule.yaml"));
+            var subselector3 = GetRuleVisitor(context, "YamlRuleWithSubselectorReordered", GetSource("FromFileSubSelector.Rule.yaml"));
+            context.EnterSourceScope(subselector1.Source);
+
+            var actual1 = GetObject((name: "kind", value: "test"), (name: "resources", value: new string[] { "abc", "abc" }));
+            var actual2 = GetObject((name: "resources", value: new string[] { "abc", "123", "abc" }));
+
+            // YamlRuleWithPrecondition
+            context.EnterTargetObject(actual1);
+            context.EnterRuleBlock(subselector1);
+            Assert.True(subselector1.Condition.If().AllOf());
+
+            context.EnterTargetObject(actual2);
+            context.EnterRuleBlock(subselector1);
+            Assert.True(subselector1.Condition.If().Skipped());
+
+            // YamlRuleWithSubselector
+            context.EnterTargetObject(actual1);
+            context.EnterRuleBlock(subselector2);
+            Assert.True(subselector2.Condition.If().AllOf());
+
+            context.EnterTargetObject(actual2);
+            context.EnterRuleBlock(subselector2);
+            Assert.False(subselector2.Condition.If().AllOf());
+
+            // YamlRuleWithSubselectorReordered
+            context.EnterTargetObject(actual1);
+            context.EnterRuleBlock(subselector3);
+            Assert.True(subselector3.Condition.If().AllOf());
+
+            context.EnterTargetObject(actual2);
+            context.EnterRuleBlock(subselector3);
+            Assert.True(subselector3.Condition.If().AllOf());
         }
 
         [Fact]
@@ -136,6 +194,9 @@ namespace PSRule
 
         #region Json rules
 
+        /// <summary>
+        /// Test that a JSON-based rule can be parsed.
+        /// </summary>
         [Fact]
         public void ReadJsonRule()
         {
@@ -158,6 +219,61 @@ namespace PSRule
 
             var hashtable = rule[0].Tag.ToHashtable();
             Assert.Equal("tag", hashtable["feature"]);
+        }
+
+        /// <summary>
+        /// Test that a JSON-based rule with sub-selectors can be parsed.
+        /// </summary>
+        [Fact]
+        public void ReadJsonSubSelectorRule()
+        {
+            var context = new RunspaceContext(PipelineContext.New(GetOption(), null, null, PipelineHookActions.BindTargetName, PipelineHookActions.BindTargetType, PipelineHookActions.BindField, new OptionContext(), null), new TestWriter(GetOption()));
+            context.Init(GetSource("FromFileSubSelector.Rule.jsonc"));
+            context.Begin();
+
+            // From current path
+            var rule = HostHelper.GetRule(GetSource("FromFileSubSelector.Rule.jsonc"), context, includeDependencies: false);
+            Assert.NotNull(rule);
+            Assert.Equal("JsonRuleWithPrecondition", rule[0].Name);
+            Assert.Equal("JsonRuleWithSubselector", rule[1].Name);
+            Assert.Equal("JsonRuleWithSubselectorReordered", rule[2].Name);
+
+            context.Init(GetSource("FromFileSubSelector.Rule.yaml"));
+            context.Begin();
+            var subselector1 = GetRuleVisitor(context, "JsonRuleWithPrecondition", GetSource("FromFileSubSelector.Rule.jsonc"));
+            var subselector2 = GetRuleVisitor(context, "JsonRuleWithSubselector", GetSource("FromFileSubSelector.Rule.jsonc"));
+            var subselector3 = GetRuleVisitor(context, "JsonRuleWithSubselectorReordered", GetSource("FromFileSubSelector.Rule.jsonc"));
+            context.EnterSourceScope(subselector1.Source);
+
+            var actual1 = GetObject((name: "kind", value: "test"), (name: "resources", value: new string[] { "abc", "abc" }));
+            var actual2 = GetObject((name: "resources", value: new string[] { "abc", "123", "abc" }));
+
+            // JsonRuleWithPrecondition
+            context.EnterTargetObject(actual1);
+            context.EnterRuleBlock(subselector1);
+            Assert.True(subselector1.Condition.If().AllOf());
+
+            context.EnterTargetObject(actual2);
+            context.EnterRuleBlock(subselector1);
+            Assert.True(subselector1.Condition.If().Skipped());
+
+            // JsonRuleWithSubselector
+            context.EnterTargetObject(actual1);
+            context.EnterRuleBlock(subselector2);
+            Assert.True(subselector2.Condition.If().AllOf());
+
+            context.EnterTargetObject(actual2);
+            context.EnterRuleBlock(subselector2);
+            Assert.False(subselector2.Condition.If().AllOf());
+
+            // JsonRuleWithSubselectorReordered
+            context.EnterTargetObject(actual1);
+            context.EnterRuleBlock(subselector3);
+            Assert.True(subselector3.Condition.If().AllOf());
+
+            context.EnterTargetObject(actual2);
+            context.EnterRuleBlock(subselector3);
+            Assert.True(subselector3.Condition.If().AllOf());
         }
 
         #endregion Json rules
@@ -190,17 +306,17 @@ namespace PSRule
             return JsonConvert.DeserializeObject<object[]>(File.ReadAllText(path));
         }
 
-        private static RuleBlock GetRuleVisitor(RunspaceContext context, string name)
+        private static RuleBlock GetRuleVisitor(RunspaceContext context, string name, Source[] source = null)
         {
-            var block = HostHelper.GetRuleYamlBlocks(GetSource(), context);
+            var block = HostHelper.GetRuleBlockGraph(source ?? GetSource(), context).GetAll();
             return block.FirstOrDefault(s => s.Name == name);
         }
 
-        private static void ImportSelectors(RunspaceContext context)
+        private static void ImportSelectors(RunspaceContext context, Source[] source = null)
         {
-            var selectors = HostHelper.GetSelector(GetSource(), context).ToArray();
+            var selectors = HostHelper.GetSelector(source ?? GetSource(), context).ToArray();
             foreach (var selector in selectors)
-                context.Pipeline.Import(selector);
+                context.Pipeline.Import(context, selector);
         }
 
         private static string GetSourcePath(string path)

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -1712,7 +1712,7 @@ namespace PSRule
             context.Init(source);
             context.Begin();
             var selector = HostHelper.GetSelector(source, context).ToArray().FirstOrDefault(s => s.Name == name);
-            return new SelectorVisitor(selector.Id, selector.Source, selector.Spec.If);
+            return new SelectorVisitor(context, selector.Id, selector.Source, selector.Spec.If);
         }
 
         private static string GetSourcePath(string fileName)

--- a/tests/PSRule.Tests/TargetBinderTests.cs
+++ b/tests/PSRule.Tests/TargetBinderTests.cs
@@ -7,7 +7,6 @@ using PSRule.Configuration;
 using PSRule.Definitions.Baselines;
 using PSRule.Pipeline;
 using Xunit;
-using static PSRule.Pipeline.TargetBinder;
 
 namespace PSRule
 {
@@ -20,15 +19,15 @@ namespace PSRule
             var targetObject = GetTargetObject();
             binder.Bind(targetObject);
 
-            var m1 = binder.Using("Module1");
+            var m1 = binder.Result("Module1");
             Assert.Equal("Name1", m1.TargetName);
             Assert.Equal("Type1", m1.TargetType);
 
-            var m2 = binder.Using("Module2");
+            var m2 = binder.Result("Module2");
             Assert.Equal("Name2", m2.TargetName);
             Assert.Equal("Type1", m2.TargetType);
 
-            var m0 = binder.Using(".");
+            var m0 = binder.Result(".");
             Assert.Equal("Name1", m0.TargetName);
             Assert.Equal("System.Management.Automation.PSCustomObject", m0.TargetType);
         }
@@ -40,15 +39,15 @@ namespace PSRule
             var targetObject = new TargetObject(PSObject.AsPSObject(JToken.Parse("{ \"name\": \"Name1\", \"type\": \"Type1\", \"AlternativeName\": \"Name2\", \"AlternativeType\": \"Type2\" }")));
             binder.Bind(targetObject);
 
-            var m1 = binder.Using("Module1");
+            var m1 = binder.Result("Module1");
             Assert.Equal("Name1", m1.TargetName);
             Assert.Equal("Type1", m1.TargetType);
 
-            var m2 = binder.Using("Module2");
+            var m2 = binder.Result("Module2");
             Assert.Equal("Name2", m2.TargetName);
             Assert.Equal("Type1", m2.TargetType);
 
-            var m0 = binder.Using(".");
+            var m0 = binder.Result(".");
             Assert.Equal("Name1", m0.TargetName);
             Assert.Equal("System.Management.Automation.PSCustomObject", m0.TargetType);
         }
@@ -93,13 +92,13 @@ namespace PSRule
             ));
 
             option.UseScope("Module1");
-            builder.With(new TargetBindingContext("Module1", option.GetTargetBinding()));
+            builder.With("Module1", option.GetTargetBinding());
 
             option.UseScope("Module2");
-            builder.With(new TargetBindingContext("Module2", option.GetTargetBinding()));
+            builder.With("Module2", option.GetTargetBinding());
 
             option.UseScope(null);
-            builder.With(new TargetBindingContext(".", option.GetTargetBinding()));
+            builder.With(".", option.GetTargetBinding());
             return builder.Build();
         }
 


### PR DESCRIPTION
## PR Summary

- **Experimental**: Added support for sub-selectors YAML and JSON expressions.
  - Sub-selector pre-conditions add an additional expression to determine if a rule is executed.
  - Sub-selector object filters provide an way to filter items from list properties.

Fixes #1024 
Related to #1045 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
