### PR TITLE
Pre-release v2.4.0-B0091

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -23,6 +23,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.4.0-B0091 (pre-release)
+
 What's changed since pre-release v2.4.0-B0063:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v2.4.0-B0063:

- Engineering:
  - Bump BenchmarkDotNet to v0.13.2.
    [#1241](https://github.com/microsoft/PSRule/pull/1241)
  - Bump BenchmarkDotNet.Diagnostics.Windows to v0.13.2.
    [#1242](https://github.com/microsoft/PSRule/pull/1242)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
