### PR TITLE
Fixes could not load Microsoft.Management.Infrastructure #1249

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Execution.NotProcessedWarning](https://aka.ms/ps-rule/options#executionnotprocessedwarning)
   - [Execution.SuppressedRuleWarning](https://aka.ms/ps-rule/options#executionsuppressedrulewarning)
   - [Execution.InvariantCultureWarning](https://aka.ms/ps-rule/options#executioninvariantculturewarning)
+  - [Execution.InitialSessionState](https://aka.ms/ps-rule/options#executioninitialsessionstate)
   - [Include.Module](https://aka.ms/ps-rule/options#includemodule)
   - [Include.Path](https://aka.ms/ps-rule/options#includepath)
   - [Input.Format](https://aka.ms/ps-rule/options#inputformat)

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -28,6 +28,10 @@ What's changed since v2.4.0:
 - Engineering:
   - Bump Microsoft.NET.Test.Sdk to v17.3.1.
     [#1248](https://github.com/microsoft/PSRule/pull/1248)
+- Bug fixes:
+  - Fixed could not load Microsoft.Management.Infrastructure by @BernieWhite.
+    [#1249](https://github.com/microsoft/PSRule/issues/1249)
+    - To use minimal initial session state set `Execution.InitialSessionState` to `Minimal`.
 
 ## v2.4.0
 

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -21,16 +21,18 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
+ [-AliasReferenceWarning <Boolean>] [-DuplicateResourceId <ExecutionActionPreference>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-AliasReferenceWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-IncludeModule <String[]>]
+ [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-IncludeModule <String[]>]
  [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>]
+ [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>]
+ [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -41,16 +43,18 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
+ [-AliasReferenceWarning <Boolean>] [-DuplicateResourceId <ExecutionActionPreference>]
  [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-AliasReferenceWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-IncludeModule <String[]>]
+ [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-IncludeModule <String[]>]
  [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>]
+ [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>]
+ [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -60,16 +64,18 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-BindTargetName <BindTargetName[]>] [-BindTargetType <BindTargetName[]>] [-BindingIgnoreCase <Boolean>]
  [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>]
  [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
- [-Convention <String[]>] [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>]
- [-SuppressedRuleWarning <Boolean>] [-AliasReferenceWarning <Boolean>] [-InvariantCultureWarning <Boolean>]
- [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-Convention <String[]>] [-AliasReferenceWarning <Boolean>] [-DuplicateResourceId <ExecutionActionPreference>]
+ [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
+ [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
+ [-OutputOutcome <RuleOutcome>] [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>]
+ [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>]
+ [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -588,6 +594,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -InputIgnoreObjectSource
+
+Sets the option `Input.IgnoreObjectSource`.
+The `Input.IgnoreObjectSource` option determines if objects will be skipped if the source path has been ignored.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -LoggingLimitDebug
 
 Sets the `Logging.LimitDebug` option to limit debug messages to a list of named debug scopes.
@@ -912,12 +935,46 @@ Accept wildcard characters: False
 ### -InvariantCultureWarning
 
 Sets the option `Execution.InvariantCultureWarning`.
-The `Execution.InvariantCultureWarning` option set if a warning is logged when invarient culture is detected.
+The `Execution.InvariantCultureWarning` option sets if a warning is logged when invarient culture is detected.
 
 ```yaml
 Type: Boolean
 Parameter Sets: (All)
 Aliases: ExecutionInvariantCultureWarning
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DuplicateResourceId
+
+Sets the option `Execution.DuplicateResourceId`.
+The `Execution.DuplicateResourceId` option determines how to handle duplicate resources identifiers during execution.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases: ExecutionDuplicateResourceId
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InitialSessionState
+
+Sets the option `Execution.InitialSessionState`.
+The `Execution.InitialSessionState` option determines how the initial session state for executing PowerShell code is created.
+
+```yaml
+Type: SessionState
+Parameter Sets: (All)
+Aliases: ExecutionInitialSessionState
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -17,17 +17,19 @@ Sets options that configure PSRule execution.
 Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force] [-AllowClobber]
  [-BindingIgnoreCase <Boolean>] [-BindingField <Hashtable>] [-BindingNameSeparator <String>]
  [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
- [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-InconclusiveWarning <Boolean>]
- [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>] [-AliasReferenceWarning <Boolean>]
- [-InvariantCultureWarning <Boolean>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
- [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
- [-ObjectPath <String>] [-InputPathIgnore <String[]>] [-InputTargetType <String[]>]
- [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>]
- [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>]
- [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>]
- [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-OutputJsonIndent <Int32>]
- [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-AliasReferenceWarning <Boolean>]
+ [-DuplicateResourceId <ExecutionActionPreference>] [-InconclusiveWarning <Boolean>]
+ [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>] [-InvariantCultureWarning <Boolean>]
+ [-InitialSessionState <SessionState>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
+ [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreObjectSource <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
+ [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-OutputJsonIndent <Int32>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -482,6 +484,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -InputIgnoreObjectSource
+
+Sets the option `Input.IgnoreObjectSource`.
+The `Input.IgnoreObjectSource` option determines if objects will be skipped if the source path has been ignored.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -LoggingLimitDebug
 
 Sets the `Logging.LimitDebug` option to limit debug messages to a list of named debug scopes.
@@ -841,6 +860,40 @@ The `Execution.InvariantCultureWarning` option set if a warning is logged when i
 Type: Boolean
 Parameter Sets: (All)
 Aliases: ExecutionInvariantCultureWarning
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DuplicateResourceId
+
+Sets the option `Execution.DuplicateResourceId`.
+The `Execution.DuplicateResourceId` option determines how to handle duplicate resources identifiers during execution.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases: ExecutionDuplicateResourceId
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InitialSessionState
+
+Sets the option `Execution.InitialSessionState`.
+The `Execution.InitialSessionState` option determines how the initial session state for executing PowerShell code is created.
+
+```yaml
+Type: SessionState
+Parameter Sets: (All)
+Aliases: ExecutionInitialSessionState
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -21,6 +21,7 @@ The following workspace options are available for use:
 - [Execution.NotProcessedWarning](#executionnotprocessedwarning)
 - [Execution.SuppressedRuleWarning](#executionsuppressedrulewarning)
 - [Execution.InvariantCultureWarning](#executioninvariantculturewarning)
+- [Execution.InitialSessionState](#executioninitialsessionstate)
 - [Include.Module](#includemodule)
 - [Include.Path](#includepath)
 - [Input.Format](#inputformat)
@@ -1022,6 +1023,55 @@ env:
 variables:
 - name: PSRULE_EXECUTION_INVARIANTCULTUREWARNING
   value: false
+```
+
+### Execution.InitialSessionState
+
+Determines how the initial session state for executing PowerShell code is created.
+
+The following preferences are available:
+
+- `BuiltIn` (0) - Create the initial session state with all built-in cmdlets loaded.
+  This is the default.
+- `Minimal` (1) - Create the initial session state with only a minimum set of cmdlets loaded.
+
+```powershell
+# PowerShell: Using the InitialSessionState parameter
+$option = New-PSRuleOption -InitialSessionState 'Minimal';
+```
+
+```powershell
+# PowerShell: Using the Execution.InitialSessionState hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.InitialSessionState' = 'Minimal' };
+```
+
+```powershell
+# PowerShell: Using the InitialSessionState parameter to set YAML
+Set-PSRuleOption -InitialSessionState 'Minimal';
+```
+
+```yaml
+# YAML: Using the execution/initialSessionState property
+execution:
+  initialSessionState: Minimal
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_INITIALSESSIONSTATE=Minimal
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_INITIALSESSIONSTATE: Minimal
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_INITIALSESSIONSTATE
+  value: Minimal
 ```
 
 ### Include.Module

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -307,16 +307,27 @@
                 "suppressedRuleWarning": {
                     "type": "boolean",
                     "title": "Warn on suppressed rules",
-                    "description": "Enable or disable warnings for suppressed rules. The default is `true`.",
+                    "description": "Enable or disable warnings for suppressed rules. The default is true.",
                     "markdownDescription": "Enable or disable warnings for suppressed rules. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionsuppressedrulewarning)",
                     "default": true
                 },
                 "invariantCultureWarning": {
                     "type": "boolean",
                     "title": "Warn on invariant culture",
-                    "description": "Enable or disable warning when invariant culture is used. The default is `true`.",
+                    "description": "Enable or disable warning when invariant culture is used. The default is true.",
                     "markdownDescription": "Enable or disable warning when invariant culture is used. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executioninvariantculturewarning)",
                     "default": true
+                },
+                "initialSessionState": {
+                    "type": "string",
+                    "title": "Initial Session State",
+                    "description": "Determines how the initial session state for executing PowerShell code is created. The default is BuiltIn.",
+                    "markdownDescription": "Determines how the initial session state for executing PowerShell code is created. The default is `BuiltIn`.\n- When set to `BuiltIn` all built-in cmdlets are loaded.\n- When set to `Minimal` only cmdlets for hosting PowerShell will be loaded.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executioninitialsessionstate)",
+                    "enum": [
+                        "BuiltIn",
+                        "Minimal"
+                    ],
+                    "default": "BuiltIn"
                 }
             },
             "additionalProperties": false

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -22,6 +22,7 @@ namespace PSRule.Configuration
         private const bool DEFAULT_ALIASREFERENCEWARNING = true;
         private const bool DEFAULT_INVARIANTCULTUREWARNING = true;
         private const ExecutionActionPreference DEFAULT_DUPLICATERESOURCEID = ExecutionActionPreference.Error;
+        private const SessionState DEFAULT_INITIALSESSIONSTATE = SessionState.BuiltIn;
 
         internal static readonly ExecutionOption Default = new()
         {
@@ -32,6 +33,7 @@ namespace PSRule.Configuration
             NotProcessedWarning = DEFAULT_NOTPROCESSEDWARNING,
             SuppressedRuleWarning = DEFAULT_SUPPRESSEDRULEWARNING,
             InvariantCultureWarning = DEFAULT_INVARIANTCULTUREWARNING,
+            InitialSessionState = DEFAULT_INITIALSESSIONSTATE,
         };
 
         /// <summary>
@@ -46,6 +48,7 @@ namespace PSRule.Configuration
             NotProcessedWarning = null;
             SuppressedRuleWarning = null;
             InvariantCultureWarning = null;
+            InitialSessionState = null;
         }
 
         /// <summary>
@@ -64,6 +67,7 @@ namespace PSRule.Configuration
             NotProcessedWarning = option.NotProcessedWarning;
             SuppressedRuleWarning = option.SuppressedRuleWarning;
             InvariantCultureWarning = option.InvariantCultureWarning;
+            InitialSessionState = option.InitialSessionState;
         }
 
         /// <inheritdoc/>
@@ -82,7 +86,8 @@ namespace PSRule.Configuration
                 InconclusiveWarning == other.InconclusiveWarning &&
                 NotProcessedWarning == other.NotProcessedWarning &&
                 SuppressedRuleWarning == other.NotProcessedWarning &&
-                InvariantCultureWarning == other.InvariantCultureWarning;
+                InvariantCultureWarning == other.InvariantCultureWarning &&
+                InitialSessionState == other.InitialSessionState;
         }
 
         /// <inheritdoc/>
@@ -98,6 +103,7 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (NotProcessedWarning.HasValue ? NotProcessedWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (SuppressedRuleWarning.HasValue ? SuppressedRuleWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (InvariantCultureWarning.HasValue ? InvariantCultureWarning.Value.GetHashCode() : 0);
+                hash = hash * 23 + (InitialSessionState.HasValue ? InitialSessionState.Value.GetHashCode() : 0);
                 return hash;
             }
         }
@@ -116,7 +122,8 @@ namespace PSRule.Configuration
                 InconclusiveWarning = o1.InconclusiveWarning ?? o2.InconclusiveWarning,
                 NotProcessedWarning = o1.NotProcessedWarning ?? o2.NotProcessedWarning,
                 SuppressedRuleWarning = o1.SuppressedRuleWarning ?? o2.SuppressedRuleWarning,
-                InvariantCultureWarning = o1.InvariantCultureWarning ?? o2.InvariantCultureWarning
+                InvariantCultureWarning = o1.InvariantCultureWarning ?? o2.InvariantCultureWarning,
+                InitialSessionState = o1.InitialSessionState ?? o2.InitialSessionState,
             };
             return result;
         }
@@ -167,6 +174,13 @@ namespace PSRule.Configuration
         [DefaultValue(null)]
         public bool? InvariantCultureWarning { get; set; }
 
+        /// <summary>
+        /// Determines how the initial session state for executing PowerShell code is created.
+        /// The default is <see cref="SessionState.BuiltIn"/>.
+        /// </summary>
+        [DefaultValue(null)]
+        public SessionState? InitialSessionState { get; set; }
+
         internal void Load(EnvironmentHelper env)
         {
             if (env.TryBool("PSRULE_EXECUTION_ALIASREFERENCEWARNING", out var bvalue))
@@ -189,6 +203,9 @@ namespace PSRule.Configuration
 
             if (env.TryBool("PSRULE_EXECUTION_INVARIANTCULTUREWARNING", out bvalue))
                 InvariantCultureWarning = bvalue;
+
+            if (env.TryEnum("PSRULE_EXECUTION_INITIALSESSIONSTATE", out SessionState initialSessionState))
+                InitialSessionState = initialSessionState;
         }
 
         internal void Load(Dictionary<string, object> index)
@@ -213,6 +230,9 @@ namespace PSRule.Configuration
 
             if (index.TryPopBool("Execution.InvariantCultureWarning", out bvalue))
                 InvariantCultureWarning = bvalue;
+
+            if (index.TryPopEnum("Execution.InitialSessionState", out SessionState initialSessionState))
+                InitialSessionState = initialSessionState;
         }
     }
 }

--- a/src/PSRule/Configuration/SessionState.cs
+++ b/src/PSRule/Configuration/SessionState.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Configuration
+{
+    /// <summary>
+    /// Configures how the initial PowerShell sandbox for executing rules is created.
+    /// </summary>
+    public enum SessionState
+    {
+        /// <summary>
+        /// Create the initial session state with all built-in cmdlets loaded.
+        /// See <seealso href="https://docs.microsoft.com/en-us/powershell/scripting/developer/hosting/creating-an-initialsessionstate?view=powershell-7.2">CreateDefault</seealso>.
+        /// </summary>
+        BuiltIn = 0,
+
+        /// <summary>
+        /// Create the initial session state with only cmdlets loaded for hosting PowerShell.
+        /// See <seealso href="https://docs.microsoft.com/en-us/powershell/scripting/developer/hosting/creating-an-initialsessionstate?view=powershell-7.2">CreateDefault2</seealso>.
+        /// </summary>
+        Minimal = 1
+    }
+}

--- a/src/PSRule/Host/Host.cs
+++ b/src/PSRule/Host/Host.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -34,12 +34,12 @@ namespace PSRule.Host
     {
         private const string VARIABLE_NAME = "Rule";
 
-        private readonly Runtime.Rule _Value;
+        private readonly Rule _Value;
 
         public RuleVariable()
             : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
-            _Value = new Runtime.Rule();
+            _Value = new Rule();
         }
 
         public override object Value => _Value;
@@ -52,12 +52,12 @@ namespace PSRule.Host
     {
         private const string VARIABLE_NAME = "LocalizedData";
 
-        private readonly Runtime.LocalizedData _Value;
+        private readonly LocalizedData _Value;
 
         public LocalizedDataVariable()
             : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
-            _Value = new Runtime.LocalizedData();
+            _Value = new LocalizedData();
         }
 
         public override object Value => _Value;
@@ -69,12 +69,12 @@ namespace PSRule.Host
     internal sealed class AssertVariable : PSVariable
     {
         private const string VARIABLE_NAME = "Assert";
-        private readonly Runtime.Assert _Value;
+        private readonly Assert _Value;
 
         public AssertVariable()
             : base(VARIABLE_NAME, null, ScopedItemOptions.ReadOnly)
         {
-            _Value = new Runtime.Assert();
+            _Value = new Assert();
         }
 
         public override object Value => _Value;
@@ -148,10 +148,10 @@ namespace PSRule.Host
         /// <summary>
         /// Create a default session state.
         /// </summary>
-        /// <returns></returns>
-        public static InitialSessionState CreateSessionState()
+        public static InitialSessionState CreateSessionState(Configuration.SessionState initialSessionState)
         {
-            var state = InitialSessionState.CreateDefault();
+            var state = initialSessionState == Configuration.SessionState.Minimal ?
+                InitialSessionState.CreateDefault2() : InitialSessionState.CreateDefault();
 
             // Add in language elements
             state.Commands.Add(BuiltInCmdlets);
@@ -161,7 +161,7 @@ namespace PSRule.Host
             state.ThreadOptions = PSThreadOptions.UseCurrentThread;
 
             // Set execution policy
-            SetExecutionPolicy(state: state, executionPolicy: Microsoft.PowerShell.ExecutionPolicy.RemoteSigned);
+            SetExecutionPolicy(state, executionPolicy: Microsoft.PowerShell.ExecutionPolicy.RemoteSigned);
 
             return state;
         }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1195,6 +1195,11 @@ function New-PSRuleOption {
         [Alias('ExecutionInvariantCultureWarning')]
         [System.Boolean]$InvariantCultureWarning = $True,
 
+        # Sets the Execution.InitialSessionState option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInitialSessionState')]
+        [PSRule.Configuration.SessionState]$InitialSessionState = [PSRule.Configuration.SessionState]::BuiltIn,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -1473,6 +1478,11 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionInvariantCultureWarning')]
         [System.Boolean]$InvariantCultureWarning = $True,
+
+        # Sets the Execution.InitialSessionState option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInitialSessionState')]
+        [PSRule.Configuration.SessionState]$InitialSessionState = [PSRule.Configuration.SessionState]::BuiltIn,
 
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
@@ -2196,6 +2206,11 @@ function SetOptions {
         [Alias('ExecutionInvariantCultureWarning')]
         [System.Boolean]$InvariantCultureWarning = $True,
 
+        # Sets the Execution.InitialSessionState option
+        [Parameter(Mandatory = $False)]
+        [Alias('ExecutionInitialSessionState')]
+        [PSRule.Configuration.SessionState]$InitialSessionState = [PSRule.Configuration.SessionState]::BuiltIn,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -2384,6 +2399,11 @@ function SetOptions {
         # Sets option Execution.InvariantCultureWarning
         if ($PSBoundParameters.ContainsKey('InvariantCultureWarning')) {
             $Option.Execution.InvariantCultureWarning = $InvariantCultureWarning;
+        }
+
+        # Sets option Execution.InitialSessionState
+        if ($PSBoundParameters.ContainsKey('InitialSessionState')) {
+            $Option.Execution.InitialSessionState = $InitialSessionState;
         }
 
         # Sets option Include.Module

--- a/src/PSRule/Pipeline/PipelineBuilder.cs
+++ b/src/PSRule/Pipeline/PipelineBuilder.cs
@@ -25,6 +25,7 @@ namespace PSRule.Pipeline
     {
         /// <summary>
         /// Create a builder for an Assert pipeline.
+        /// Used by Assert-PSRule.
         /// </summary>
         /// <remarks>
         /// Assert pipelines process objects with rules and produce text-based output suitable for output to a CI pipeline.
@@ -42,6 +43,7 @@ namespace PSRule.Pipeline
 
         /// <summary>
         /// Create a builder for an Invoke pipeline.
+        /// Used by Invoke-PSRule.
         /// </summary>
         /// <remarks>
         /// Invoke piplines process objects and produce records indicating the outcome of each rule.
@@ -57,6 +59,17 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
+        /// <summary>
+        /// Create a builder for a Test pipeline.
+        /// Used by Test-PSRule.
+        /// </summary>
+        /// <remarks>
+        /// Test piplines process objects and true or false the outcome of each rule.
+        /// </remarks>
+        /// <param name="source">An array of sources.</param>
+        /// <param name="option">Options that configure PSRule.</param>
+        /// <param name="hostContext">An implementation of a host context that will recieve output and results.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IInvokePipelineBuilder Test(Source[] source, PSRuleOption option, IHostContext hostContext)
         {
             var pipeline = new TestPipelineBuilder(source, hostContext);
@@ -64,6 +77,17 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
+        /// <summary>
+        /// Create a builder for a Get pipeline.
+        /// Used by Get-PSRule.
+        /// </summary>
+        /// <remarks>
+        /// Get pipelines list rules that are discovered by PSRule either in modules or as standalone rules.
+        /// </remarks>
+        /// <param name="source">An array of sources.</param>
+        /// <param name="option">Options that configure PSRule.</param>
+        /// <param name="hostContext">An implementation of a host context that will recieve output and results.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IGetPipelineBuilder Get(Source[] source, PSRuleOption option, IHostContext hostContext)
         {
             var pipeline = new GetRulePipelineBuilder(source, hostContext);
@@ -71,6 +95,17 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
+        /// <summary>
+        /// Create a builder for a help pipeline.
+        /// Used by Get-PSRuleHelp.
+        /// </summary>
+        /// <remarks>
+        /// Gets command lines help content for all or specific rules.
+        /// </remarks>
+        /// <param name="source">An array of sources.</param>
+        /// <param name="option">Options that configure PSRule.</param>
+        /// <param name="hostContext">An implementation of a host context that will recieve output and results.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IHelpPipelineBuilder GetHelp(Source[] source, PSRuleOption option, IHostContext hostContext)
         {
             var pipeline = new GetRuleHelpPipelineBuilder(source, hostContext);
@@ -90,6 +125,14 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
+        /// <summary>
+        /// Create a builder for a get baseline pipeline.
+        /// Used by Get-PSRuleBaseline.
+        /// </summary>
+        /// <param name="source">An array of sources.</param>
+        /// <param name="option">Options that configure PSRule.</param>
+        /// <param name="hostContext">An implementation of a host context that will recieve output and results.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IPipelineBuilder GetBaseline(Source[] source, PSRuleOption option, IHostContext hostContext)
         {
             var pipeline = new GetBaselinePipelineBuilder(source, hostContext);
@@ -97,6 +140,14 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
+        /// <summary>
+        /// Create a builder for an export baseline pipeline.
+        /// Used by Export-PSRuleBaseline.
+        /// </summary>
+        /// <param name="source">An array of sources.</param>
+        /// <param name="option">Options that configure PSRule.</param>
+        /// <param name="hostContext">An implementation of a host context that will recieve output and results.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IPipelineBuilder ExportBaseline(Source[] source, PSRuleOption option, IHostContext hostContext)
         {
             var pipeline = new ExportBaselinePipelineBuilder(source, hostContext);
@@ -104,6 +155,13 @@ namespace PSRule.Pipeline
             return pipeline;
         }
 
+        /// <summary>
+        /// Create a builder for a target pipeline.
+        /// Used by Get-PSRuleTarget.
+        /// </summary>
+        /// <param name="option">Options that configure PSRule.</param>
+        /// <param name="hostContext">An implementation of a host context that will recieve output and results.</param>
+        /// <returns>A builder object to configure the pipeline.</returns>
         public static IGetTargetPipelineBuilder GetTarget(PSRuleOption option, IHostContext hostContext)
         {
             var pipeline = new GetTargetPipelineBuilder(null, hostContext);
@@ -420,10 +478,6 @@ namespace PSRule.Pipeline
         protected static ExecutionOption GetExecutionOption(ExecutionOption option)
         {
             var result = ExecutionOption.Combine(option, ExecutionOption.Default);
-            //result.InconclusiveWarning ??= ExecutionOption.Default.InconclusiveWarning;
-            //result.NotProcessedWarning ??= ExecutionOption.Default.NotProcessedWarning;
-            //result.SuppressedRuleWarning ??= ExecutionOption.Default.SuppressedRuleWarning;
-            //result.InvariantCultureWarning ??= ExecutionOption.Default.InvariantCultureWarning;
             result.DuplicateResourceId = result.DuplicateResourceId == ExecutionActionPreference.None ? ExecutionOption.Default.DuplicateResourceId.Value : result.DuplicateResourceId;
             return result;
         }

--- a/src/PSRule/Pipeline/PipelineContext.cs
+++ b/src/PSRule/Pipeline/PipelineContext.cs
@@ -138,7 +138,8 @@ namespace PSRule.Pipeline
         {
             if (_Runspace == null)
             {
-                var state = HostState.CreateSessionState();
+                var initialSessionState = Option.Execution.InitialSessionState.GetValueOrDefault(ExecutionOption.Default.InitialSessionState.Value);
+                var state = HostState.CreateSessionState(initialSessionState);
                 state.LanguageMode = _LanguageMode == LanguageMode.FullLanguage ? PSLanguageMode.FullLanguage : PSLanguageMode.ConstrainedLanguage;
 
                 _Runspace = RunspaceFactory.CreateRunspace(state);
@@ -203,7 +204,7 @@ namespace PSRule.Pipeline
         {
             baselineRef = null;
             var r = _Unresolved.FirstOrDefault(i => ResourceIdEqualityComparer.IdEquals(i.Id, resourceId.Value));
-            if (!(r is BaselineRef br))
+            if (r is not BaselineRef br)
                 return false;
 
             baselineRef = br;

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -205,7 +205,7 @@ namespace PSRule.Pipeline
             WriteError(errorRecord);
         }
 
-        protected static ActionPreference GetPreferenceVariable(SessionState sessionState, string variableName)
+        protected static ActionPreference GetPreferenceVariable(System.Management.Automation.SessionState sessionState, string variableName)
         {
             return (ActionPreference)sessionState.PSVariable.GetValue(variableName);
         }

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -864,6 +864,45 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Execution.InitialSessionState' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.InitialSessionState | Should -Be 'BuiltIn';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.InitialSessionState' = 'Minimal' };
+            $option.Execution.InitialSessionState | Should -Be 'Minimal';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.InitialSessionState | Should -Be 'Minimal';
+        }
+
+        It 'from Environment' {
+            try {
+                # With bool
+                $Env:PSRULE_EXECUTION_INITIALSESSIONSTATE = 'minimal';
+                $option = New-PSRuleOption;
+                $option.Execution.InitialSessionState | Should -Be 'Minimal';
+
+                # With int
+                $Env:PSRULE_EXECUTION_INITIALSESSIONSTATE = '1';
+                $option = New-PSRuleOption;
+                $option.Execution.InitialSessionState | Should -Be 'Minimal';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_INITIALSESSIONSTATE' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -InitialSessionState 'Minimal' -Path $emptyOptionsFilePath;
+            $option.Execution.InitialSessionState | Should -Be 'Minimal';
+        }
+    }
+
     Context 'Read Include.Path' {
         It 'from default' {
             $option = New-PSRuleOption -Default;

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -55,6 +55,7 @@ execution:
   notProcessedWarning: false
   suppressedRuleWarning: false
   invariantCultureWarning: false
+  initialSessionState: Minimal
 
 # Configure input options
 input:


### PR DESCRIPTION
## PR Summary

  - Fixed could not load Microsoft.Management.Infrastructure.
    - To use minimal initial session state set `Execution.InitialSessionState` to `Minimal`.

Fixes #1249 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
