### PR TITLE
Revert "Bump Microsoft.CodeAnalysis.Common from 4.2.0 to 4.3.0 (#1254)"

### DIFF
--- a/src/PSRule.BuildTask/PSRule.BuildTask.csproj
+++ b/src/PSRule.BuildTask/PSRule.BuildTask.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
   </ItemGroup>
 
   <!--<ItemGroup>


### PR DESCRIPTION
This reverts commit 2d78a2bda19820fe2618c429e1eac94d0766ce11.

## PR Summary

- Rollback to v4.2.0 of Microsoft.CodeAnalysis.Common to fix an issue with code generation task.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
