### PR TITLE
Fixed PathExpressionBuilder.GetAllRecurse #1301

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -23,6 +23,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v2.4.1:
+
+- Bug fixes:
+  - Fixed exception with `PathExpressionBuilder.GetAllRecurse` by @BernieWhite.
+    [#1301](https://github.com/microsoft/PSRule/issues/1301)
+
 ## v2.4.1
 
 What's changed since v2.4.0:

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -448,6 +448,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The object path expression reached the maximum depth of {0} evaluating the path &apos;{1}&apos;..
+        /// </summary>
+        internal static string ObjectPathRecurseMaxDepth {
+            get {
+                return ResourceManager.GetString("ObjectPathRecurseMaxDepth", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Options file does not exist..
         /// </summary>
         internal static string OptionsNotFound {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -385,4 +385,7 @@
   <data name="DebugTargetSubselectorMismatch" xml:space="preserve">
     <value>Target failed sub-selector pre-condition.</value>
   </data>
+  <data name="ObjectPathRecurseMaxDepth" xml:space="preserve">
+    <value>The object path expression reached the maximum depth of {0} evaluating the path '{1}'.</value>
+  </data>
 </root>

--- a/src/PSRule/Runtime/ObjectPath/Exceptions.cs
+++ b/src/PSRule/Runtime/ObjectPath/Exceptions.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.Serialization;
+using System.Security.Permissions;
+using PSRule.Pipeline;
+
+namespace PSRule.Runtime.ObjectPath
+{
+    /// <summary>
+    /// An exception thrown by PSRule when evaluating an object path.
+    /// </summary>
+    [Serializable]
+    public sealed class ObjectPathEvaluateException : PipelineException
+    {
+        /// <inheritdoc/>
+        public ObjectPathEvaluateException()
+        {
+        }
+
+        /// <inheritdoc/>
+        public ObjectPathEvaluateException(string message) : base(message)
+        {
+        }
+
+        /// <inheritdoc/>
+        public ObjectPathEvaluateException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <inheritdoc/>
+        private ObjectPathEvaluateException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+
+        /// <inheritdoc/>
+        [SecurityPermission(SecurityAction.Demand, SerializationFormatter = true)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            if (info == null)
+                throw new ArgumentNullException(nameof(info));
+
+            base.GetObjectData(info, context);
+        }
+    }
+}

--- a/src/PSRule/Runtime/ObjectPath/PathExpressionBuilder.cs
+++ b/src/PSRule/Runtime/ObjectPath/PathExpressionBuilder.cs
@@ -11,6 +11,7 @@ using System.Management.Automation;
 using System.Reflection;
 using System.Threading;
 using Newtonsoft.Json.Linq;
+using PSRule.Resources;
 
 namespace PSRule.Runtime.ObjectPath
 {
@@ -19,6 +20,16 @@ namespace PSRule.Runtime.ObjectPath
     /// </summary>
     internal sealed class PathExpressionBuilder
     {
+        private const int DEFAULT_RECURSE_MAX_DEPTH = 100;
+        private static readonly object[] DEFAULT_EMPTY_ARRAY = new object[] { };
+
+        private readonly int _RecurseMaxDepth;
+
+        public PathExpressionBuilder()
+        {
+            _RecurseMaxDepth = DEFAULT_RECURSE_MAX_DEPTH;
+        }
+
         private sealed class DynamicPropertyBinder : GetMemberBinder
         {
             internal DynamicPropertyBinder(string name, bool ignoreCase)
@@ -196,7 +207,7 @@ namespace PSRule.Runtime.ObjectPath
                 var caseSensitive = context.CaseSensitive != caseSensitiveFlag;
                 var result = new List<object>();
                 var success = 0;
-                foreach (var i in GetAllRecurse(input, memberName, caseSensitive))
+                foreach (var i in GetAllRecurse(input, memberName, caseSensitive, 0))
                 {
                     if (!next(context, i, out var items, out _))
                         continue;
@@ -369,11 +380,22 @@ namespace PSRule.Runtime.ObjectPath
         private static IEnumerable<object> GetAll(object o)
         {
             var baseObject = ExpressionHelpers.GetBaseObject(o);
+            if (IsSimpleType(baseObject))
+                return DEFAULT_EMPTY_ARRAY;
+
             return baseObject is IEnumerable ? GetAllIndex(baseObject) : GetAllField(baseObject);
         }
 
-        private static IEnumerable<object> GetAllRecurse(object o, string fieldName, bool caseSensitive)
+        private static bool IsSimpleType(object o)
         {
+            return o is string || (o != null && o.GetType().IsValueType);
+        }
+
+        private IEnumerable<object> GetAllRecurse(object o, string fieldName, bool caseSensitive, int depth)
+        {
+            if (depth > _RecurseMaxDepth)
+                throw new ObjectPathEvaluateException(string.Format(Thread.CurrentThread.CurrentCulture, PSRuleResources.ObjectPathRecurseMaxDepth, _RecurseMaxDepth, fieldName));
+
             foreach (var i in GetAll(o))
             {
                 if (TryGetField(i, fieldName, caseSensitive, out var value))
@@ -382,7 +404,7 @@ namespace PSRule.Runtime.ObjectPath
                 }
                 else
                 {
-                    foreach (var c in GetAllRecurse(i, fieldName, caseSensitive))
+                    foreach (var c in GetAllRecurse(i, fieldName, caseSensitive, depth + 1))
                         yield return c;
                 }
             }

--- a/tests/PSRule.Tests/PathExpressionTests.cs
+++ b/tests/PSRule.Tests/PathExpressionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Management.Automation;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PSRule.Runtime.ObjectPath;
@@ -299,11 +300,16 @@ namespace PSRule
             Assert.NotNull(actual);
             Assert.Single(actual);
             Assert.Equal("TestObject2", actual[0]);
+
+            // Handle exception cases
+            var pso = GetPSObjectContent();
+            expression = PathExpression.Create("$..value");
+            Assert.False(expression.TryGet(pso, true, out object[] _));
         }
 
         #region Helper methods
 
-        private object GetJsonContent()
+        private static object GetJsonContent()
         {
             var settings = new JsonLoadSettings
             {
@@ -313,6 +319,15 @@ namespace PSRule
             using var stream = new StreamReader(path);
             using var reader = new JsonTextReader(stream);
             return JToken.Load(reader, settings);
+        }
+
+        private static object GetPSObjectContent()
+        {
+            var result = new PSObject();
+            result.Properties.Add(new PSNoteProperty("string", ""));
+            result.Properties.Add(new PSNoteProperty("date", DateTime.Now));
+            result.Properties.Add(new PSNoteProperty("int", 0));
+            return result;
         }
 
         #endregion Helper methods


### PR DESCRIPTION
## PR Summary

- Fixed exception with `PathExpressionBuilder.GetAllRecurse`.

Fixes #1301 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
