### PR TITLE
Fixed NUnit output escaping #1316

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v2.5.1:
+
+- Bug fixes:
+  - Fixed NUnit output does not escape characters in all result properties by @BernieWhite.
+    [#1316](https://github.com/microsoft/PSRule/issues/1316)
+
 ## v2.5.1
 
 What's changed since v2.5.0:

--- a/src/PSRule/Pipeline/Output/NUnit3OutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/NUnit3OutputWriter.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Xml;
 using PSRule.Configuration;
 using PSRule.Resources;
 using PSRule.Rules;
@@ -23,7 +24,7 @@ namespace PSRule.Pipeline.Output
 
         public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
-            if (!(sendToPipeline is InvokeResult result))
+            if (sendToPipeline is not InvokeResult result)
                 return;
 
             Add(result);
@@ -31,16 +32,49 @@ namespace PSRule.Pipeline.Output
 
         protected override string Serialize(InvokeResult[] o)
         {
-            _Builder.Append("<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"no\"?>");
+            var settings = new XmlWriterSettings
+            {
+                Encoding = Encoding.UTF8, // Consider using: Option.Output.GetEncoding()
+                // Consider using: Indent = true,
+            };
+            using var xml = XmlWriter.Create(_Builder, settings);
+            xml.WriteStartDocument(standalone: false);
 
             float time = o.Sum(r => r.Time);
             var total = o.Sum(r => r.Total);
             var error = o.Sum(r => r.Error);
             var fail = o.Sum(r => r.Fail);
 
-            _Builder.Append($"<test-results xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"nunit_schema_2.5.xsd\" name=\"PSRule\" total=\"{total}\" errors=\"{error}\" failures=\"{fail}\" not-run=\"0\" inconclusive=\"0\" ignored=\"0\" skipped=\"0\" invalid=\"0\" date=\"{DateTime.UtcNow.ToString("yyyy-MM-dd", Thread.CurrentThread.CurrentCulture)}\" time=\"{TimeSpan.FromMilliseconds(time)}\">");
-            _Builder.Append($"<environment user=\"{Environment.UserName}\" machine-name=\"{Environment.MachineName}\" cwd=\"{Configuration.PSRuleOption.GetWorkingPath()}\" user-domain=\"{Environment.UserDomainName}\" platform=\"{Environment.OSVersion.Platform}\" nunit-version=\"2.5.8.0\" os-version=\"{Environment.OSVersion.Version}\" clr-version=\"{Environment.Version}\" />");
-            _Builder.Append($"<culture-info current-culture=\"{Thread.CurrentThread.CurrentCulture}\" current-uiculture=\"{Thread.CurrentThread.CurrentUICulture}\" />");
+            xml.WriteStartElement("test-results");
+            xml.WriteAttributeString("xsi", "noNamespaceSchemaLocation", "http://www.w3.org/2001/XMLSchema-instance", "nunit_schema_2.5.xsd");
+            xml.WriteAttributeString("name", "PSRule");
+            xml.WriteAttributeString("total", total.ToString());
+            xml.WriteAttributeString("errors", error.ToString());
+            xml.WriteAttributeString("failures", fail.ToString());
+            xml.WriteAttributeString("not-run", "0");
+            xml.WriteAttributeString("inconclusive", "0");
+            xml.WriteAttributeString("ignored", "0");
+            xml.WriteAttributeString("skipped", "0");
+            xml.WriteAttributeString("invalid", "0");
+            xml.WriteAttributeString("date", DateTime.UtcNow.ToString("yyyy-MM-dd", Thread.CurrentThread.CurrentCulture));
+            xml.WriteAttributeString("time", TimeSpan.FromMilliseconds(time).ToString());
+
+            xml.WriteStartElement("environment");
+            xml.WriteAttributeString("user", Environment.UserName);
+            xml.WriteAttributeString("machine-name", Environment.MachineName);
+            xml.WriteAttributeString("cwd", PSRuleOption.GetWorkingPath());
+            xml.WriteAttributeString("user-domain", Environment.UserDomainName);
+            xml.WriteAttributeString("platform", Environment.OSVersion.Platform.ToString());
+            xml.WriteAttributeString("nunit-version", "2.5.8.0");
+            xml.WriteAttributeString("os-version", Environment.OSVersion.Version.ToString());
+            xml.WriteAttributeString("clr-version", Environment.Version.ToString());
+            xml.WriteEndElement();
+
+            xml.WriteStartElement("culture-info");
+            xml.WriteAttributeString("current-culture", Thread.CurrentThread.CurrentCulture.ToString());
+            xml.WriteAttributeString("current-uiculture", Thread.CurrentThread.CurrentUICulture.ToString());
+            xml.WriteEndElement();
+
             foreach (var result in o)
             {
                 if (result.Total == 0)
@@ -68,35 +102,63 @@ namespace PSRule.Pipeline.Output
                     asserts: failedCount,
                     testCases: testCases
                 );
-                VisitFixture(fixture: fixture);
+                VisitFixture(xml, fixture);
             }
-            _Builder.Append("</test-results>");
+            xml.WriteEndElement();
+            xml.WriteEndDocument();
+            xml.Flush();
             return _Builder.ToString();
         }
 
-        private void VisitFixture(TestFixture fixture)
+        private static void VisitFixture(XmlWriter xml, TestFixture fixture)
         {
-            _Builder.Append($"<test-suite type=\"TestFixture\" name=\"{fixture.Name}\" executed=\"{fixture.Executed}\" result=\"{(fixture.Success ? "Success" : "Failure")}\" success=\"{fixture.Success}\" time=\"{fixture.Time.ToString(Thread.CurrentThread.CurrentCulture)}\" asserts=\"{fixture.Asserts}\" description=\"{fixture.Description}\"><results>");
-            foreach (var testCase in fixture.Results)
-                VisitTestCase(testCase: testCase);
+            xml.WriteStartElement("test-suite");
+            xml.WriteAttributeString("type", "TestFixture");
+            xml.WriteAttributeString("name", fixture.Name);
+            xml.WriteAttributeString("executed", fixture.Executed.ToString());
+            xml.WriteAttributeString("result", fixture.Success ? "Success" : "Failure");
+            xml.WriteAttributeString("success", fixture.Success.ToString());
 
-            _Builder.Append("</results></test-suite>");
+            xml.WriteAttributeString("time", fixture.Time.ToString(Thread.CurrentThread.CurrentCulture));
+            xml.WriteAttributeString("asserts", fixture.Asserts.ToString());
+            xml.WriteAttributeString("description", fixture.Description);
+
+            xml.WriteStartElement("results");
+            foreach (var testCase in fixture.Results)
+                VisitTestCase(xml, testCase);
+
+            xml.WriteEndElement();
+            xml.WriteEndElement();
         }
 
-        private void VisitTestCase(TestCase testCase)
+        private static void VisitTestCase(XmlWriter xml, TestCase testCase)
         {
-            _Builder.Append($"<test-case description=\"{testCase.Description}\" name=\"{testCase.Name}\" time=\"{testCase.Time.ToString(Thread.CurrentThread.CurrentCulture)}\" asserts=\"0\" success=\"{testCase.Success}\" result=\"{(testCase.Success ? "Success" : "Failure")}\" executed=\"{testCase.Executed}\">");
+            xml.WriteStartElement("test-case");
+            xml.WriteAttributeString("description", testCase.Description);
+            xml.WriteAttributeString("name", testCase.Name);
+            xml.WriteAttributeString("time", testCase.Time.ToString(Thread.CurrentThread.CurrentCulture));
+            xml.WriteAttributeString("asserts", "0");
+            xml.WriteAttributeString("success", testCase.Success.ToString());
+            xml.WriteAttributeString("result", testCase.Success ? "Success" : "Failure");
+            xml.WriteAttributeString("executed", testCase.Executed.ToString());
             if (!testCase.Success)
             {
-                _Builder.Append("<failure>");
-                _Builder.Append($"<message><![CDATA[{testCase.FailureMessage}]]></message>");
-                _Builder.Append($"<stack-trace><![CDATA[{testCase.ScriptStackTrace}]]></stack-trace>");
-                _Builder.Append("</failure>");
+                xml.WriteStartElement("failure");
+
+                xml.WriteStartElement("message");
+                xml.WriteCData(testCase.FailureMessage);
+                xml.WriteEndElement();
+
+                xml.WriteStartElement("stack-trace");
+                xml.WriteCData(testCase.ScriptStackTrace);
+                xml.WriteEndElement();
+
+                xml.WriteEndElement();
             }
-            _Builder.Append("</test-case>");
+            xml.WriteEndElement();
         }
 
-        private string FailureMessage(Rules.RuleRecord record)
+        private string FailureMessage(RuleRecord record)
         {
             var useMarkdown = Option.Output.Style == OutputStyle.AzurePipelines;
             var sb = new StringBuilder();

--- a/tests/PSRule.Tests/OutputWriterTests.cs
+++ b/tests/PSRule.Tests/OutputWriterTests.cs
@@ -4,6 +4,7 @@
 using System.Collections;
 using System.Linq;
 using System.Management.Automation;
+using System.Xml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PSRule.Configuration;
@@ -277,6 +278,30 @@ namespace PSRule
 ]", output.Output.OfType<string>().FirstOrDefault());
         }
 
+        [Fact]
+        public void NUnit3()
+        {
+            var option = GetOption();
+            option.Repository.Url = "https://github.com/microsoft/PSRule.UnitTest";
+            var output = new TestWriter(option);
+            var result = new InvokeResult();
+            result.Add(GetPass());
+            result.Add(GetFail());
+            result.Add(GetFail("rid-003", SeverityLevel.Warning));
+            result.Add(GetFail("rid-004", SeverityLevel.Information, "Synopsis \"with quotes\"."));
+            var writer = new NUnit3OutputWriter(output, option);
+            writer.Begin();
+            writer.WriteObject(result, false);
+            writer.End();
+
+            var s = output.Output.OfType<string>().FirstOrDefault();
+            var doc = new XmlDocument();
+            doc.LoadXml(s);
+
+            var xml = doc["test-results"]["test-suite"].OuterXml;
+            Assert.Equal("<test-suite type=\"TestFixture\" name=\"TestObject1\" executed=\"True\" result=\"Failure\" success=\"False\" time=\"0\" asserts=\"3\" description=\"\"><results><test-case description=\"This is rule 001.\" name=\"TestObject1 -- rule-001\" time=\"0\" asserts=\"0\" success=\"True\" result=\"Success\" executed=\"True\" /><test-case description=\"This is rule 002.\" name=\"TestObject1 -- rule-002\" time=\"0\" asserts=\"0\" success=\"False\" result=\"Failure\" executed=\"True\"><failure><message><![CDATA[Recommendation for rule 002\r\n]]></message><stack-trace><![CDATA[]]></stack-trace></failure></test-case><test-case description=\"This is rule 002.\" name=\"TestObject1 -- rule-002\" time=\"0\" asserts=\"0\" success=\"False\" result=\"Failure\" executed=\"True\"><failure><message><![CDATA[Recommendation for rule 002\r\n]]></message><stack-trace><![CDATA[]]></stack-trace></failure></test-case><test-case description=\"Synopsis &quot;with quotes&quot;.\" name=\"TestObject1 -- rule-002\" time=\"0\" asserts=\"0\" success=\"False\" result=\"Failure\" executed=\"True\"><failure><message><![CDATA[Recommendation for rule 002\r\n]]></message><stack-trace><![CDATA[]]></stack-trace></failure></test-case></results></test-suite>", xml);
+        }
+
         #region Helper methods
 
         private static RuleRecord GetPass()
@@ -304,7 +329,7 @@ namespace PSRule
             );
         }
 
-        private static RuleRecord GetFail(string ruleRef = "rid-002", SeverityLevel level = SeverityLevel.Error)
+        private static RuleRecord GetFail(string ruleRef = "rid-002", SeverityLevel level = SeverityLevel.Error, string synopsis = "This is rule 002.")
         {
             return new RuleRecord(
                 runId: "run-001",
@@ -318,7 +343,7 @@ namespace PSRule
                     "rule-002",
                     "Rule 002",
                     "TestModule",
-                    synopsis: new InfoString("This is rule 002."),
+                    synopsis: new InfoString(synopsis),
                     recommendation: new InfoString("Recommendation for rule 002")
                 ),
                 field: new Hashtable(),


### PR DESCRIPTION
## PR Summary

- Fixed NUnit output does not escape characters in all result properties.

Fixes #1316 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
