### PR TITLE
Fixes exception calling RuleSource value #1343

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since v2.6.0:
+
+- Bug fixes:
+  - Fixes exception calling `RuleSource` value cannot be null by @BernieWhite.
+    [#1343](https://github.com/microsoft/PSRule/issues/1343)
+
 ## v2.6.0
 
 What's changed since v2.5.3:

--- a/src/PSRule/Common/Engine.cs
+++ b/src/PSRule/Common/Engine.cs
@@ -1,19 +1,10 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
-using System.IO;
-using PSRule.Configuration;
-
 namespace PSRule
 {
     internal static partial class Engine
     {
-        internal static string GetLocalPath()
-        {
-            return PSRuleOption.GetRootedBasePath(Path.GetDirectoryName(AppContext.BaseDirectory));
-        }
-
         internal static string GetVersion()
         {
             return _Version;

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -542,6 +542,9 @@ namespace PSRule.Configuration
         /// <returns>A absolute path.</returns>
         internal static string GetRootedPath(string path, bool normalize = false, string basePath = null)
         {
+            if (string.IsNullOrEmpty(path))
+                path = string.Empty;
+
             basePath ??= GetWorkingPath();
             var rootedPath = Path.IsPathRooted(path) ? Path.GetFullPath(path) : Path.GetFullPath(Path.Combine(basePath, path));
             return normalize ? rootedPath.Replace(Backslash, Slash) : rootedPath;
@@ -558,6 +561,9 @@ namespace PSRule.Configuration
         /// </remarks>
         internal static string GetRootedBasePath(string path, bool normalize = false)
         {
+            if (string.IsNullOrEmpty(path))
+                path = string.Empty;
+
             var rootedPath = GetRootedPath(path);
             var basePath = rootedPath.Length > 0 && IsSeparator(rootedPath[rootedPath.Length - 1])
                 ? rootedPath

--- a/src/PSRule/Help/MarkdownStream.cs
+++ b/src/PSRule/Help/MarkdownStream.cs
@@ -158,11 +158,11 @@ namespace PSRule.Help
         /// If the current character and sequential characters are line ending control characters, skip ahead.
         /// </summary>
         /// <param name="max">The number of line endings to skip. When max is 0, sequential line endings will be skipped.</param>
+        /// <param name="ignoreEscaping">Determines if escaped characters are skipped.</param>
         /// <returns>The number of line endings skipped.</returns>
         public int SkipLineEnding(int max = 1, bool ignoreEscaping = false)
         {
             var skipped = 0;
-
             while ((Current == CarrageReturn || Current == NewLine) && (max == 0 || skipped < max))
             {
                 if (Remaining == 0)
@@ -171,7 +171,7 @@ namespace PSRule.Help
                 if (Current == CarrageReturn && Peak() == NewLine)
                     Next();
 
-                Next(ignoreEscaping: ignoreEscaping);
+                Next(ignoreEscaping);
                 skipped++;
             }
             return skipped;
@@ -205,32 +205,27 @@ namespace PSRule.Help
         /// Skip ahead if the current character is expected. Keep skipping when the character is repeated.
         /// </summary>
         /// <param name="c">The character to skip.</param>
+        /// <param name="max">The maximum number of characters to skip.</param>
         /// <returns>The number of characters that where skipped.</returns>
         public int Skip(char c, int max)
         {
             var skipped = 0;
-
             while (Current == c && (max == 0 || skipped < max))
             {
                 Next();
-
                 skipped++;
             }
-
             return skipped;
         }
 
         public int Skip(string sequence, int max = 0, bool ignoreEscaping = false)
         {
             var skipped = 0;
-
             while (IsSequence(sequence) && (max == 0 || skipped < max))
             {
                 Skip(sequence.Length, ignoreEscaping);
-
                 skipped++;
             }
-
             return skipped;
         }
 
@@ -238,14 +233,12 @@ namespace PSRule.Help
         /// Skip ahead a number of characters. Use Next() in preference of Skip if the number to skip is 1.
         /// </summary>
         /// <param name="toSkip">The number of characters to skip</param>
+        /// <param name="ignoreEscaping">Determines if escaped characters are skipped.</param>
         public void Skip(int toSkip, bool ignoreEscaping = false)
         {
             toSkip = HasRemaining(toSkip) ? toSkip : Remaining;
-
             for (var i = 0; i < toSkip; i++)
-            {
                 Next(ignoreEscaping);
-            }
         }
 
         /// <summary>

--- a/src/PSRule/Pipeline/CommandLineBuilder.cs
+++ b/src/PSRule/Pipeline/CommandLineBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
+using System.IO;
 using PSRule.Configuration;
 
 namespace PSRule.Pipeline
@@ -22,7 +24,7 @@ namespace PSRule.Pipeline
         /// <returns>A builder object to configure the pipeline.</returns>
         public static IInvokePipelineBuilder Invoke(string[] module, PSRuleOption option, IHostContext hostContext)
         {
-            var sourcePipeline = new SourcePipelineBuilder(hostContext, option);
+            var sourcePipeline = new SourcePipelineBuilder(hostContext, option, GetLocalPath());
             for (var i = 0; i < module.Length; i++)
                 sourcePipeline.ModuleByName(module[i]);
 
@@ -44,7 +46,7 @@ namespace PSRule.Pipeline
         /// <returns>A builder object to configure the pipeline.</returns>
         public static IInvokePipelineBuilder Assert(string[] module, PSRuleOption option, IHostContext hostContext)
         {
-            var sourcePipeline = new SourcePipelineBuilder(hostContext, option);
+            var sourcePipeline = new SourcePipelineBuilder(hostContext, option, GetLocalPath());
             for (var i = 0; module != null && i < module.Length; i++)
                 sourcePipeline.ModuleByName(module[i]);
 
@@ -52,6 +54,15 @@ namespace PSRule.Pipeline
             var pipeline = new AssertPipelineBuilder(source, hostContext);
             pipeline.Configure(option);
             return pipeline;
+        }
+
+        internal static string GetLocalPath()
+        {
+            if (string.IsNullOrEmpty(AppContext.BaseDirectory) ||
+                string.IsNullOrEmpty(Path.GetDirectoryName(AppContext.BaseDirectory)))
+                return null;
+
+            return PSRuleOption.GetRootedBasePath(Path.GetDirectoryName(AppContext.BaseDirectory));
         }
     }
 }

--- a/src/PSRule/Pipeline/SourcePipeline.cs
+++ b/src/PSRule/Pipeline/SourcePipeline.cs
@@ -119,14 +119,14 @@ namespace PSRule.Pipeline
         private readonly bool _UseDefaultPath;
         private readonly string _LocalPath;
 
-        internal SourcePipelineBuilder(IHostContext hostContext, PSRuleOption option)
+        internal SourcePipelineBuilder(IHostContext hostContext, PSRuleOption option, string localPath = null)
         {
             _Source = new Dictionary<string, Source>(StringComparer.OrdinalIgnoreCase);
             _HostContext = hostContext;
             _Writer = new HostPipelineWriter(hostContext, option, ShouldProcess);
             _Writer.EnterScope("[Discovery.Source]");
             _UseDefaultPath = option == null || option.Include == null || option.Include.Path == null;
-            _LocalPath = Engine.GetLocalPath();
+            _LocalPath = localPath;
 
             // Include paths from options
             if (!_UseDefaultPath)
@@ -243,6 +243,10 @@ namespace PSRule.Pipeline
         /// </summary>
         private bool TryPackagedModule(string name, out string path)
         {
+            path = null;
+            if (_LocalPath == null)
+                return false;
+
             Log($"Looking for modules in: {_LocalPath}");
             path = PSRuleOption.GetRootedBasePath(Path.Combine(_LocalPath, "Modules", name));
             return System.IO.Directory.Exists(path);

--- a/tests/PSRule.Tests/ModuleConfigTests.cs
+++ b/tests/PSRule.Tests/ModuleConfigTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
@@ -13,7 +13,7 @@ using Assert = Xunit.Assert;
 
 namespace PSRule
 {
-    public sealed class ConfigTests
+    public sealed class ModuleConfigTests
     {
         [Theory]
         [InlineData("ModuleConfig.Rule.yaml")]
@@ -26,21 +26,25 @@ namespace PSRule
             Assert.Equal("Configuration1", configuration[0].Name);
         }
 
-        private PSRuleOption GetOption()
+        #region Helper methods
+
+        private static PSRuleOption GetOption()
         {
             return new PSRuleOption();
         }
 
-        private Source[] GetSource(string path)
+        private static Source[] GetSource(string path)
         {
             var builder = new SourcePipelineBuilder(null, null);
             builder.Directory(GetSourcePath(path));
             return builder.Build();
         }
 
-        private string GetSourcePath(string fileName)
+        private static string GetSourcePath(string fileName)
         {
             return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
         }
+
+        #endregion Helper methods
     }
 }

--- a/tests/PSRule.Tests/PSRuleOptionTests.cs
+++ b/tests/PSRule.Tests/PSRuleOptionTests.cs
@@ -10,11 +10,18 @@ using Xunit;
 
 namespace PSRule
 {
-    [Trait(LANGUAGE, LANGUAGEELEMENT)]
-    public sealed class ConfigurationTests
+    public sealed class PSRuleOptionTests
     {
-        private const string LANGUAGE = "Language";
-        private const string LANGUAGEELEMENT = "Variable";
+        [Fact]
+        public void GetRootedBasePath()
+        {
+            var pwd = Directory.GetCurrentDirectory();
+            var basePwd = $"{pwd}{Path.DirectorySeparatorChar}";
+            Assert.Equal(basePwd, PSRuleOption.GetRootedBasePath(null));
+            Assert.Equal(basePwd, PSRuleOption.GetRootedBasePath(pwd));
+            Assert.Equal(pwd, PSRuleOption.GetRootedPath(null));
+            Assert.Equal(pwd, PSRuleOption.GetRootedPath(pwd));
+        }
 
         [Fact]
         public void Configuration()
@@ -67,6 +74,8 @@ namespace PSRule
             Assert.Equal("East US", pso.PropertyValue<string>("location"));
         }
 
+        #region Helper methods
+
         private static Runtime.Configuration GetConfigurationHelper(PSRuleOption option)
         {
             var builder = new OptionContextBuilder(option, null, null, null);
@@ -97,5 +106,7 @@ namespace PSRule
         {
             return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName);
         }
+
+        #endregion Helper methods
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixes exception calling `RuleSource` value cannot be null.

Fixes #1343 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
