### PR TITLE
Added API version date comparison #1356

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The following commands exist in the `PSRule` module:
 The following conceptual topics exist in the `PSRule` module:
 
 - [Assert](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Assert/)
+  - [APIVersion](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Assert/#apiversion)
   - [Contains](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Assert/#contains)
   - [Count](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Assert/#count)
   - [EndsWith](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Assert/#endswith)
@@ -235,6 +236,7 @@ The following conceptual topics exist in the `PSRule` module:
 - [Expressions](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/)
   - [AllOf](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#allof)
   - [AnyOf](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#anyof)
+  - [APIVersion](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#apiversion)
   - [Contains](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#contains)
   - [Count](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#count)
   - [EndsWith](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#endswith)

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -32,6 +32,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v2.7.0-B0016:
 
+- New features:
+  - Added API version date comparison assertion method and expression by @BernieWhite.
+    [#1356](https://github.com/microsoft/PSRule/issues/1356)
 - Bug fixes:
   - Fixes CLI failed to load required assemblies by @BernieWhite.
     [#1361](https://github.com/microsoft/PSRule/issues/1361)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -18,6 +18,7 @@ Expressions are comprised of nested conditions, operators, and comparison proper
 
 The following conditions are available:
 
+- [APIVersion](#apiversion)
 - [Contains](#contains)
 - [Count](#count)
 - [Equals](#equals)
@@ -156,6 +157,54 @@ spec:
       exists: true
     - field: 'AlternativeName'
       exists: true
+```
+
+### APIVersion
+
+The `apiVersion` condition determines if the operand is a valid date version.
+A constraint can optionally be provided to require the date version to be within a range.
+Supported version constraints for expression are the same as the `$Assert.APIVersion` assertion helper.
+
+Syntax:
+
+```yaml
+apiVersion: <string>
+includePrerelease: <bool>
+```
+
+For example:
+
+```yaml
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Rule
+metadata:
+  name: 'ExampleAPIVersion'
+spec:
+  condition:
+    field: 'engine.apiVersion'
+    apiVersion: '>=2015-10-01'
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleAnyAPIVersion'
+spec:
+  if:
+    field: 'engine.apiVersion'
+    apiVersion: ''
+
+---
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: 'ExampleAPIVersionIncludingPrerelease'
+spec:
+  if:
+    field: 'engine.apiVersion'
+    apiVersion: '>=2015-10-01'
+    includePrerelease: true
 ```
 
 ### Contains

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -914,6 +914,9 @@
           "$ref": "#/definitions/expressions/definitions/conditions/definitions/version"
         },
         {
+          "$ref": "#/definitions/expressions/definitions/conditions/definitions/apiVersion"
+        },
+        {
           "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasDefault"
         },
         {
@@ -1279,6 +1282,9 @@
             },
             {
               "$ref": "#/definitions/expressions/definitions/conditions/definitions/version"
+            },
+            {
+              "$ref": "#/definitions/expressions/definitions/conditions/definitions/apiVersion"
             },
             {
               "$ref": "#/definitions/expressions/definitions/conditions/definitions/hasDefault"
@@ -2629,6 +2635,41 @@
               },
               "required": [
                 "version"
+              ],
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/expressions/definitions/properties"
+                }
+              ],
+              "additionalProperties": false,
+              "minProperties": 2
+            },
+            "apiVersion": {
+              "type": "object",
+              "properties": {
+                "apiVersion": {
+                  "type": "string",
+                  "title": "API Version",
+                  "description": "Must be a valid date version. A constraint can optionally be provided to require the date version to be within a range.",
+                  "markdownDescription": "Must be a valid date version. A constraint can optionally be provided to require the date version to be within a range. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#apiversion)",
+                  "default": ""
+                },
+                "includePrerelease": {
+                  "type": "boolean",
+                  "title": "Include pre-release",
+                  "description": "Determines if pre-release versions are included. By default, pre-release versions are not included.",
+                  "markdownDescription": "Determines if pre-release versions are included. By default, pre-release versions are not included. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#apiversion)",
+                  "default": false
+                },
+                "field": {
+                  "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                },
+                "value": {
+                  "$ref": "#/definitions/expressions/definitions/properties/definitions/value"
+                }
+              },
+              "required": [
+                "apiVersion"
               ],
               "oneOf": [
                 {

--- a/src/PSRule.Types/Data/ModuleConstraint.cs
+++ b/src/PSRule.Types/Data/ModuleConstraint.cs
@@ -13,7 +13,7 @@ namespace PSRule.Data
         /// </summary>
         /// <param name="module">The name of the module.</param>
         /// <param name="constraint">The version constraint of the module.</param>
-        public ModuleConstraint(string module, IVersionConstraint constraint)
+        public ModuleConstraint(string module, ISemanticVersionConstraint constraint)
         {
             Module = module;
             Constraint = constraint;
@@ -27,6 +27,6 @@ namespace PSRule.Data
         /// <summary>
         /// The version constraint of the module.
         /// </summary>
-        public IVersionConstraint Constraint { get; }
+        public ISemanticVersionConstraint Constraint { get; }
     }
 }

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -717,6 +717,43 @@ namespace PSRule
         }
 
         [Fact]
+        public void APIVersion()
+        {
+            SetContext();
+            var assert = GetAssertionHelper();
+            var value = GetObject(
+                (name: "version", value: "2015-10-01"),
+                (name: "version2", value: "2015-10-01-preview"),
+                (name: "version3", value: "2022-01-01-preview"),
+                (name: "notversion", value: "x.y.z")
+            );
+
+            Assert.True(assert.APIVersion(value, "version", "2015-10-01").Result);
+            Assert.True(assert.APIVersion(value, "version", "=2015-10-01").Result);
+            Assert.True(assert.APIVersion(value, "version", ">=2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version", "<2015-10-01").Result);
+            Assert.True(assert.APIVersion(value, "version", ">2014-01-01").Result);
+            Assert.True(assert.APIVersion(value, "version", ">=2015-10-01-preview").Result);
+            Assert.True(assert.APIVersion(value, "version", ">=2015-10-01-preview", includePrerelease: true).Result);
+
+            Assert.False(assert.APIVersion(value, "version2", "2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version2", "=2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version2", ">=2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version2", "<2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version2", ">2014-01-01").Result);
+            Assert.True(assert.APIVersion(value, "version2", ">=2015-10-01-preview").Result);
+            Assert.True(assert.APIVersion(value, "version2", ">=2015-10-01-preview", includePrerelease: true).Result);
+
+            Assert.False(assert.APIVersion(value, "version3", "2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version3", "=2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version3", ">=2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version3", "<2015-10-01").Result);
+            Assert.False(assert.APIVersion(value, "version3", ">2014-01-01").Result);
+            Assert.False(assert.APIVersion(value, "version3", ">=2015-10-01-preview").Result);
+            Assert.True(assert.APIVersion(value, "version3", ">=2015-10-01-preview", includePrerelease: true).Result);
+        }
+
+        [Fact]
         public void Greater()
         {
             SetContext();

--- a/tests/PSRule.Tests/DateVersionTests.cs
+++ b/tests/PSRule.Tests/DateVersionTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Data;
+using Xunit;
+
+namespace PSRule
+{
+    /// <summary>
+    /// Tests for date version comparison.
+    /// </summary>
+    public sealed class DateVersionTests
+    {
+        /// <summary>
+        /// Test parsing of versions.
+        /// </summary>
+        [Fact]
+        public void Version()
+        {
+            Assert.True(DateVersion.TryParseVersion("2015-10-01", out var actual));
+            Assert.Equal(2015, actual.Year);
+            Assert.Equal(10, actual.Month);
+            Assert.Equal(1, actual.Day);
+            Assert.Equal(string.Empty, actual.Prerelease.Value);
+
+            Assert.True(DateVersion.TryParseVersion("2015-1-01-prerelease", out actual));
+            Assert.Equal(2015, actual.Year);
+            Assert.Equal(1, actual.Month);
+            Assert.Equal(1, actual.Day);
+            Assert.Equal("prerelease", actual.Prerelease.Value);
+        }
+
+        /// <summary>
+        /// Test ordering of versions by comparison.
+        /// </summary>
+        [Fact]
+        public void VersionOrder()
+        {
+            Assert.True(DateVersion.TryParseVersion("2015-10-01", out var actual1));
+            Assert.True(DateVersion.TryParseVersion("2015-10-01-prerelease", out var actual2));
+            Assert.True(DateVersion.TryParseVersion("2022-03-01", out var actual3));
+            Assert.True(DateVersion.TryParseVersion("2022-01-03", out var actual4));
+
+            Assert.True(actual1.CompareTo(actual1) == 0);
+            Assert.True(actual1.CompareTo(actual2) > 0);
+            Assert.True(actual1.CompareTo(actual3) < 0);
+            Assert.True(actual1.CompareTo(actual4) < 0);
+            Assert.True(actual2.CompareTo(actual2) == 0);
+            Assert.True(actual2.CompareTo(actual1) < 0);
+            Assert.True(actual2.CompareTo(actual3) < 0);
+            Assert.True(actual2.CompareTo(actual4) < 0);
+            Assert.True(actual3.CompareTo(actual4) > 0);
+            Assert.True(actual1.CompareTo(actual4) < 0);
+        }
+
+        /// <summary>
+        /// Test parsing of constraints.
+        /// </summary>
+        [Fact]
+        public void Constraint()
+        {
+            // Versions
+            Assert.True(DateVersion.TryParseVersion("2015-10-01", out var version1));
+            Assert.True(DateVersion.TryParseVersion("2015-10-01-alpha.9", out var version2));
+            Assert.True(DateVersion.TryParseVersion("2022-03-01", out var version3));
+            Assert.False(DateVersion.TryParseVersion("2022-03-01-", out var _));
+            Assert.True(DateVersion.TryParseVersion("2022-03-01-0", out var _));
+
+            // Constraints
+            Assert.True(DateVersion.TryParseConstraint("2015-10-01", out var actual1));
+            Assert.True(DateVersion.TryParseConstraint("2015-10-01-alpha.3", out var actual2));
+            Assert.True(DateVersion.TryParseConstraint(">2015-10-01-alpha.3", out var actual3));
+            Assert.True(DateVersion.TryParseConstraint(">2015-10-01-alpha.1", out var actual4));
+            Assert.True(DateVersion.TryParseConstraint("<2015-10-01-beta", out var actual5));
+            Assert.True(DateVersion.TryParseConstraint("<2022-03-01", out var actual7));
+            Assert.True(DateVersion.TryParseConstraint("=2015-10-01", out var actual8));
+            Assert.True(DateVersion.TryParseConstraint(">=2015-10-01", out var actual9));
+            Assert.True(DateVersion.TryParseConstraint(">=2015-10-01-0", out var actual10));
+            Assert.True(DateVersion.TryParseConstraint("<2022-03-01", out var actual11));
+            Assert.True(DateVersion.TryParseConstraint("<2022-03-01-9999999999", out var actual12));
+            Assert.True(DateVersion.TryParseConstraint("<2015-10-01-0", out var actual14));
+            Assert.True(DateVersion.TryParseConstraint("2015-10-01|| >=2022-03-01-0 2022-03-01", out var actual15));
+            Assert.True(DateVersion.TryParseConstraint("2015-10-01 ||>=2022-03-01-0 || 2022-03-01", out var actual16));
+            Assert.True(DateVersion.TryParseConstraint("2015-10-01||2022-03-01", out var actual17));
+            Assert.True(DateVersion.TryParseConstraint(">=2015-09-01", out var actual18, includePrerelease: true));
+            Assert.True(DateVersion.TryParseConstraint("<=2022-03-01-0", out var actual19, includePrerelease: true));
+            Assert.True(DateVersion.TryParseConstraint("@pre >=2015-09-01", out var actual20));
+            Assert.True(DateVersion.TryParseConstraint("@prerelease <=2022-03-01-0", out var actual21));
+
+            // Version1 - 2015-10-01
+            Assert.True(actual1.Equals(version1));
+            Assert.False(actual2.Equals(version1));
+            Assert.True(actual3.Equals(version1));
+            Assert.True(actual4.Equals(version1));
+            Assert.False(actual5.Equals(version1));
+            Assert.True(actual7.Equals(version1));
+            Assert.True(actual8.Equals(version1));
+            Assert.True(actual9.Equals(version1));
+            Assert.True(actual10.Equals(version1));
+            Assert.True(actual11.Equals(version1));
+            Assert.True(actual12.Equals(version1));
+            Assert.False(actual14.Equals(version1));
+            Assert.True(actual15.Equals(version1));
+            Assert.True(actual16.Equals(version1));
+            Assert.True(actual17.Equals(version1));
+            Assert.True(actual18.Equals(version1));
+            Assert.True(actual19.Equals(version1));
+            Assert.True(actual20.Equals(version1));
+            Assert.True(actual21.Equals(version1));
+
+            // Version3 - 2015-10-01-alpha.9
+            Assert.False(actual1.Equals(version2));
+            Assert.False(actual2.Equals(version2));
+            Assert.True(actual3.Equals(version2));
+            Assert.True(actual4.Equals(version2));
+            Assert.True(actual5.Equals(version2));
+            Assert.False(actual7.Equals(version2));
+            Assert.False(actual8.Equals(version2));
+            Assert.False(actual9.Equals(version2));
+            Assert.True(actual10.Equals(version2));
+            Assert.False(actual11.Equals(version2));
+            Assert.False(actual12.Equals(version2));
+            Assert.False(actual14.Equals(version2));
+            Assert.False(actual15.Equals(version2));
+            Assert.False(actual16.Equals(version2));
+            Assert.False(actual17.Equals(version2));
+            Assert.True(actual18.Equals(version2));
+            Assert.True(actual19.Equals(version2));
+            Assert.True(actual20.Equals(version2));
+            Assert.True(actual21.Equals(version2));
+
+            // Version4 - 2022-03-01
+            Assert.False(actual1.Equals(version3));
+            Assert.False(actual2.Equals(version3));
+            Assert.True(actual3.Equals(version3));
+            Assert.True(actual4.Equals(version3));
+            Assert.False(actual5.Equals(version3));
+            Assert.False(actual7.Equals(version3));
+            Assert.False(actual8.Equals(version3));
+            Assert.True(actual9.Equals(version3));
+            Assert.True(actual10.Equals(version3));
+            Assert.False(actual11.Equals(version3));
+            Assert.False(actual12.Equals(version3));
+            Assert.False(actual14.Equals(version3));
+            Assert.True(actual15.Equals(version3));
+            Assert.True(actual16.Equals(version3));
+            Assert.True(actual17.Equals(version3));
+            Assert.True(actual18.Equals(version3));
+            Assert.False(actual19.Equals(version3));
+            Assert.True(actual20.Equals(version3));
+            Assert.False(actual21.Equals(version3));
+        }
+
+        /// <summary>
+        /// Test parsing and order of pre-releases.
+        /// </summary>
+        [Fact]
+        public void Prerelease()
+        {
+            var actual1 = new DateVersion.PR(null);
+            var actual2 = new DateVersion.PR("alpha");
+            var actual3 = new DateVersion.PR("alpha.1");
+            var actual4 = new DateVersion.PR("alpha.beta");
+            var actual5 = new DateVersion.PR("beta");
+            var actual6 = new DateVersion.PR("beta.2");
+            var actual7 = new DateVersion.PR("beta.11");
+            var actual8 = new DateVersion.PR("rc.1");
+            var actual9 = new DateVersion.PR("alpha.9");
+
+            Assert.True(actual1.CompareTo(actual1) == 0);
+            Assert.True(actual1.CompareTo(actual2) > 0);
+            Assert.True(actual1.CompareTo(actual6) > 0);
+            Assert.True(actual2.CompareTo(actual3) < 0);
+            Assert.True(actual3.CompareTo(actual4) < 0);
+            Assert.True(actual4.CompareTo(actual5) < 0);
+            Assert.True(actual5.CompareTo(actual6) < 0);
+            Assert.True(actual6.CompareTo(actual7) < 0);
+            Assert.True(actual7.CompareTo(actual8) < 0);
+            Assert.True(actual8.CompareTo(actual1) < 0);
+            Assert.True(actual8.CompareTo(actual2) > 0);
+            Assert.True(actual9.CompareTo(actual3) > 0);
+        }
+    }
+}

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -41,7 +41,7 @@ namespace PSRule
             context.Begin();
             var selector = HostHelper.GetSelector(GetSource(path), context).ToArray();
             Assert.NotNull(selector);
-            Assert.Equal(94, selector.Length);
+            Assert.Equal(97, selector.Length);
 
             var actual = selector[0];
             var visitor = new SelectorVisitor(context, actual.Id, actual.Source, actual.Spec.If);
@@ -1539,6 +1539,47 @@ namespace PSRule
             Assert.False(version.Match(actual7));
 
             version = GetSelectorVisitor($"{type}VersionAnyVersion", GetSource(path), out _);
+            Assert.True(version.Match(actual1));
+            Assert.True(version.Match(actual2));
+            Assert.True(version.Match(actual3));
+            Assert.True(version.Match(actual4));
+            Assert.True(version.Match(actual5));
+            Assert.False(version.Match(actual6));
+            Assert.False(version.Match(actual7));
+        }
+
+        [Theory]
+        [InlineData("Yaml", SelectorYamlFileName)]
+        [InlineData("Json", SelectorJsonFileName)]
+        public void APIVersion(string type, string path)
+        {
+            var actual1 = GetObject((name: "dateVersion", value: "2015-10-01"));
+            var actual2 = GetObject((name: "dateVersion", value: "2014-01-01"));
+            var actual3 = GetObject((name: "dateVersion", value: "2022-01-01"));
+            var actual4 = GetObject((name: "dateVersion", value: "2015-10-01-preview"));
+            var actual5 = GetObject((name: "dateVersion", value: "2022-01-01-preview"));
+            var actual6 = GetObject();
+            var actual7 = GetObject((name: "dateVersion", value: "a-b-c"));
+
+            var version = GetSelectorVisitor($"{type}APIVersion", GetSource(path), out _);
+            Assert.True(version.Match(actual1));
+            Assert.False(version.Match(actual2));
+            Assert.True(version.Match(actual3));
+            Assert.False(version.Match(actual4));
+            Assert.False(version.Match(actual5));
+            Assert.False(version.Match(actual6));
+            Assert.False(version.Match(actual7));
+
+            version = GetSelectorVisitor($"{type}APIVersionWithPrerelease", GetSource(path), out _);
+            Assert.True(version.Match(actual1));
+            Assert.False(version.Match(actual2));
+            Assert.True(version.Match(actual3));
+            Assert.False(version.Match(actual4));
+            Assert.True(version.Match(actual5));
+            Assert.False(version.Match(actual6));
+            Assert.False(version.Match(actual7));
+
+            version = GetSelectorVisitor($"{type}APIVersionAnyVersion", GetSource(path), out _);
             Assert.True(version.Match(actual1));
             Assert.True(version.Match(actual2));
             Assert.True(version.Match(actual3));

--- a/tests/PSRule.Tests/Selectors.Rule.jsonc
+++ b/tests/PSRule.Tests/Selectors.Rule.jsonc
@@ -1801,5 +1801,48 @@
         ]
       }
     }
+  },
+  {
+    // Synopsis: Test comparison with apiVersion.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonAPIVersion"
+    },
+    "spec": {
+      "if": {
+        "field": "dateVersion",
+        "apiVersion": ">=2015-10-01"
+      }
+    }
+  },
+  {
+    // Synopsis: Test comparison with apiVersion.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonAPIVersionWithPrerelease"
+    },
+    "spec": {
+      "if": {
+        "field": "dateVersion",
+        "apiVersion": ">=2015-10-01",
+        "includePrerelease": true
+      }
+    }
+  },
+  {
+    // Synopsis: Test comparison with apiVersion.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonAPIVersionAnyVersion"
+    },
+    "spec": {
+      "if": {
+        "field": "dateVersion",
+        "apiVersion": ""
+      }
+    }
   }
 ]

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -1282,3 +1282,37 @@ spec:
     startsWith:
     - /scope1/
     - /scope2/
+
+---
+# Synopsis: Test comparison with apiVersion.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlAPIVersion
+spec:
+  if:
+    field: dateVersion
+    apiVersion: '>=2015-10-01'
+
+---
+# Synopsis: Test comparison with apiVersion.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlAPIVersionWithPrerelease
+spec:
+  if:
+    field: dateVersion
+    apiVersion: '>=2015-10-01'
+    includePrerelease: true
+
+---
+# Synopsis: Test comparison with apiVersion.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlAPIVersionAnyVersion
+spec:
+  if:
+    field: dateVersion
+    apiVersion: ''

--- a/tests/PSRule.Tests/SemanticVersionTests.cs
+++ b/tests/PSRule.Tests/SemanticVersionTests.cs
@@ -6,6 +6,9 @@ using Xunit;
 
 namespace PSRule
 {
+    /// <summary>
+    /// Tests for semantic version comparison.
+    /// </summary>
     public sealed class SemanticVersionTests
     {
         /// <summary>
@@ -40,10 +43,10 @@ namespace PSRule
         [Fact]
         public void VersionOrder()
         {
-            SemanticVersion.TryParseVersion("1.0.0", out var actual1);
-            SemanticVersion.TryParseVersion("1.2.0", out var actual2);
-            SemanticVersion.TryParseVersion("10.0.0", out var actual3);
-            SemanticVersion.TryParseVersion("1.0.2", out var actual4);
+            Assert.True(SemanticVersion.TryParseVersion("1.0.0", out var actual1));
+            Assert.True(SemanticVersion.TryParseVersion("1.2.0", out var actual2));
+            Assert.True(SemanticVersion.TryParseVersion("10.0.0", out var actual3));
+            Assert.True(SemanticVersion.TryParseVersion("1.0.2", out var actual4));
 
             Assert.True(actual1.CompareTo(actual1) == 0);
             Assert.True(actual1.CompareTo(actual2) < 0);


### PR DESCRIPTION
## PR Summary

- Added API version date comparison assertion method and expression.

Fixes #1356 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
