### PR TITLE
Added new function support #1227

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -35,6 +35,9 @@ What's changed since pre-release v2.7.0-B0016:
 - New features:
   - Added API version date comparison assertion method and expression by @BernieWhite.
     [#1356](https://github.com/microsoft/PSRule/issues/1356)
+  - Added support for new functions by @BernieWhite.
+    [#1227](https://github.com/microsoft/PSRule/issues/1227)
+    - Added support for `trim`, `replace`, `split`, `first`, and `last`.
 - Bug fixes:
   - Fixes CLI failed to load required assemblies by @BernieWhite.
     [#1361](https://github.com/microsoft/PSRule/issues/1361)

--- a/docs/expressions/functions.md
+++ b/docs/expressions/functions.md
@@ -22,12 +22,17 @@ Functions cover two (2) main scenarios:
 It may be necessary to perform minor transformation before evaluating a condition.
 
 - `boolean` - Convert a value to a boolean.
-- `string` - Convert a value to a string.
-- `integer` - Convert a value to an integer.
 - `concat` - Concatenate multiple values.
-- `substring` - Extract a substring from a string.
 - `configuration` - Get a configuration value.
+- `first` - Return the first element in an array or the first character of a string.
+- `integer` - Convert a value to an integer.
+- `last` - Return the last element in an array or the last character of a string.
 - `path` - Get a value from an object path.
+- `replace` - Replace an old string with a new string.
+- `split` - Split a string into an array by a delimiter.
+- `string` - Convert a value to a string.
+- `substring` - Extract a substring from a string.
+- `trim` - Remove whitespace from the start and end of a string.
 
 ## Supported conditions
 

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -3034,6 +3034,21 @@
             },
             {
               "$ref": "#/definitions/fn/definitions/function/definitions/configuration"
+            },
+            {
+              "$ref": "#/definitions/fn/definitions/function/definitions/replace"
+            },
+            {
+              "$ref": "#/definitions/fn/definitions/function/definitions/trim"
+            },
+            {
+              "$ref": "#/definitions/fn/definitions/function/definitions/first"
+            },
+            {
+              "$ref": "#/definitions/fn/definitions/function/definitions/last"
+            },
+            {
+              "$ref": "#/definitions/fn/definitions/function/definitions/split"
             }
           ],
           "definitions": {
@@ -3304,6 +3319,159 @@
               "additionalProperties": false,
               "required": [
                 "configuration"
+              ]
+            },
+            "replace": {
+              "type": "object",
+              "properties": {
+                "replace": {
+                  "type": "object",
+                  "title": "Trim",
+                  "description": "The replace function searches for a string and replaces them with a new string.",
+                  "markdownDescription": "The `replace` function searches for a string and replaces them with a new string.",
+                  "$ref": "#/definitions/fn/definitions/function"
+                },
+                "oldString": {
+                  "type": "string",
+                  "description": "The string to replace.",
+                  "minLength": 1
+                },
+                "newString": {
+                  "type": "string",
+                  "description": "The new string to replace oldString."
+                },
+                "caseSensitive": {
+                  "type": "boolean",
+                  "title": "Case-sensitive",
+                  "description": "Determines if the replace is case-sensitive. By default, a case-insensitive comparison is performed.",
+                  "default": false
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "replace",
+                "oldString",
+                "newString"
+              ]
+            },
+            "trim": {
+              "type": "object",
+              "properties": {
+                "trim": {
+                  "type": "object",
+                  "title": "Trim",
+                  "description": "Trim a string value by removing leading and trailings whitespace.",
+                  "markdownDescription": "Trim a string value by removing leading and trailings whitespace.",
+                  "$ref": "#/definitions/fn/definitions/function"
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "trim"
+              ]
+            },
+            "first": {
+              "type": "object",
+              "properties": {
+                "first": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "description": "The first function returns the first element in the array.",
+                      "markdownDescription": "The `first` function returns the first element in the array.",
+                      "items": {
+                        "$ref": "#/definitions/fn/definitions/function"
+                      },
+                      "additionalItems": false,
+                      "minItems": 2
+                    },
+                    {
+                      "type": "object",
+                      "description": "The first function returns the first element of arrays or the first character of a string.",
+                      "markdownDescription": "The `first` function returns the first element of arrays or the first character of a string.",
+                      "$ref": "#/definitions/fn/definitions/function"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "first"
+              ]
+            },
+            "last": {
+              "type": "object",
+              "properties": {
+                "last": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "description": "The last function returns the last element in the array.",
+                      "markdownDescription": "The `last` function returns the last element in the array.",
+                      "items": {
+                        "$ref": "#/definitions/fn/definitions/function"
+                      },
+                      "additionalItems": false,
+                      "minItems": 2
+                    },
+                    {
+                      "type": "object",
+                      "description": "The last function returns the last element of arrays or the last character of a string.",
+                      "markdownDescription": "The `last` function returns the last element of arrays or the last character of a string.",
+                      "$ref": "#/definitions/fn/definitions/function"
+                    }
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "last"
+              ]
+            },
+            "split": {
+              "type": "object",
+              "properties": {
+                "split": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "description": "The split function returns converts a string into an array by spliting based on a delimiter.",
+                      "markdownDescription": "The `split` function returns converts a string into an array by spliting based on a delimiter."
+                    },
+                    {
+                      "type": "object",
+                      "description": "The split function returns converts a string into an array by spliting based on a delimiter.",
+                      "markdownDescription": "The `split` function returns converts a string into an array by spliting based on a delimiter.",
+                      "$ref": "#/definitions/fn/definitions/function"
+                    }
+                  ],
+                  "default": {}
+                },
+                "delimiter": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "minItems": 1,
+                      "additionalItems": false
+                    }
+                  ],
+                  "default": [
+                    ""
+                  ]
+                }
+              },
+              "additionalProperties": false,
+              "required": [
+                "split",
+                "delimiter"
               ]
             }
           }

--- a/src/PSRule/Common/ArrayExtensions.cs
+++ b/src/PSRule/Common/ArrayExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+
+namespace PSRule.Common
+{
+    /// <summary>
+    /// Extension methods for arrays.
+    /// </summary>
+    internal static class ArrayExtensions
+    {
+        internal static object Last(this Array array)
+        {
+            return array.Length > 0 ? array.GetValue(array.Length - 1) : null;
+        }
+
+        internal static object First(this Array array)
+        {
+            return array.Length > 0 ? array.GetValue(0) : null;
+        }
+    }
+}

--- a/src/PSRule/Common/StringExtensions.cs
+++ b/src/PSRule/Common/StringExtensions.cs
@@ -1,8 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace PSRule
 {
@@ -77,6 +78,32 @@ namespace PSRule
         public static bool Contains(this string source, string value, StringComparison comparison)
         {
             return source?.IndexOf(value, comparison) >= 0;
+        }
+
+        public static string Replace(this string s, string oldString, string newString, bool caseSensitive)
+        {
+            if (string.IsNullOrEmpty(s) || string.IsNullOrEmpty(oldString) || s.Length < oldString.Length)
+                return s;
+
+            if (caseSensitive)
+                return s.Replace(oldString, newString);
+
+            var sb = new StringBuilder(s.Length);
+            var pos = 0;
+            var replaceWithEmpty = string.IsNullOrEmpty(newString);
+            int indexAt;
+            while ((indexAt = s.IndexOf(oldString, pos, StringComparison.OrdinalIgnoreCase)) != -1)
+            {
+                sb.Append(s, pos, indexAt - pos);
+                if (!replaceWithEmpty)
+                    sb.Append(newString);
+
+                pos = indexAt + oldString.Length;
+            }
+            if (pos < s.Length)
+                sb.Append(s, pos, s.Length - pos);
+
+            return sb.ToString();
         }
     }
 }

--- a/tests/PSRule.Tests/FunctionTests.cs
+++ b/tests/PSRule.Tests/FunctionTests.cs
@@ -237,6 +237,196 @@ namespace PSRule
             Assert.Null(fn(context, properties)(context));
         }
 
+        [Fact]
+        public void Replace()
+        {
+            var context = GetContext();
+            var fn = GetFunction("replace");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "oldString", "12" },
+                { "newString", "" },
+                { "replace", "Test123" }
+            };
+            Assert.Equal("Test3", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "oldString", "456" },
+                { "newString", "" },
+                { "replace", "Test123" }
+            };
+            Assert.Equal("Test123", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "oldString", "456" },
+                { "newString", "" },
+                { "replace", "" }
+            };
+            Assert.Equal("", fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Trim()
+        {
+            var context = GetContext();
+            var fn = GetFunction("trim");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "trim", " test " }
+            };
+            Assert.Equal("test", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "trim", "test" }
+            };
+            Assert.Equal("test", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "trim", "\r\ntest\r\n" }
+            };
+            Assert.Equal("test", fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void First()
+        {
+            var context = GetContext();
+            var fn = GetFunction("first");
+
+            // String
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "first", "Test123" }
+            };
+            Assert.Equal("T", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "first", "" }
+            };
+            Assert.Null(fn(context, properties)(context));
+
+            // Array
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "first", new string[] { "one", "two", "three" } }
+            };
+            Assert.Equal("one", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "first", new int[] { 1, 2, 3 } }
+            };
+            Assert.Equal(1, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "first", Array.Empty<object>() }
+            };
+            Assert.Null(fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Last()
+        {
+            var context = GetContext();
+            var fn = GetFunction("last");
+
+            // String
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "last", "Test123" }
+            };
+            Assert.Equal("3", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "last", "" }
+            };
+            Assert.Null(fn(context, properties)(context));
+
+            // Array
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "last", new string[] { "one", "two", "three" } }
+            };
+            Assert.Equal("three", fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "last", new int[] { 1, 2, 3 } }
+            };
+            Assert.Equal(3, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "last", Array.Empty<object>() }
+            };
+            Assert.Null(fn(context, properties)(context));
+        }
+
+        [Fact]
+        public void Split()
+        {
+            var context = GetContext();
+            var fn = GetFunction("split");
+
+            var properties = new LanguageExpression.PropertyBag
+            {
+                { "split", "One Two Three" },
+                { "delimiter", " " }
+            };
+            Assert.Equal(new string[] { "One", "Two", "Three" }, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "split", "One Two Three" },
+                { "delimiter", " Two " }
+            };
+            Assert.Equal(new string[] { "One", "Three" }, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "split", "One Two Three" },
+                { "delimiter", "/" }
+            };
+            Assert.Equal(new string[] { "One Two Three" }, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "split", "" },
+                { "delimiter", "/" }
+            };
+            Assert.Equal(new string[] { "" }, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "split", "One Two Three" },
+                { "delimiter", new string[] { " Two " } }
+            };
+            Assert.Equal(new string[] { "One", "Three" }, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "split", "One Two Three" },
+                { "delimiter", new string[] { " ", "Two" } }
+            };
+            Assert.Equal(new string[] { "One", "", "", "Three" }, fn(context, properties)(context));
+
+            properties = new LanguageExpression.PropertyBag
+            {
+                { "split", null },
+                { "delimiter", new string[] { " ", "Two" } }
+            };
+            Assert.Null(fn(context, properties)(context));
+        }
+
         #region Helper methods
 
         private static ExpressionBuilderFn GetFunction(string name)

--- a/tests/PSRule.Tests/Functions.Rule.jsonc
+++ b/tests/PSRule.Tests/Functions.Rule.jsonc
@@ -1,133 +1,244 @@
 [
-    {
-        // Synopsis: An expression function example.
-        "apiVersion": "github.com/microsoft/PSRule/v1",
-        "kind": "Selector",
-        "metadata": {
-            "name": "Json.Fn.Example1"
-        },
-        "spec": {
-            "if": {
-                "value": {
-                    "$": {
-                        "substring": {
-                            "path": "name"
-                        },
-                        "length": 7
-                    }
-                },
-                "equals": "TestObj"
-            }
-        }
+  {
+    // Synopsis: An expression function example.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Example1"
     },
-    {
-        // Synopsis: An expression function example.
-        "apiVersion": "github.com/microsoft/PSRule/v1",
-        "kind": "Selector",
-        "metadata": {
-            "name": "Json.Fn.Example2"
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "substring": {
+              "path": "name"
+            },
+            "length": 7
+          }
         },
-        "spec": {
-            "if": {
-                "value": {
-                    "$": {
-                        "configuration": "ConfigArray"
-                    }
-                },
-                "count": 5
-            }
-        }
-    },
-    {
-        // Synopsis: An expression function example.
-        "apiVersion": "github.com/microsoft/PSRule/v1",
-        "kind": "Selector",
-        "metadata": {
-            "name": "Json.Fn.Example3"
-        },
-        "spec": {
-            "if": {
-                "value": {
-                    "$": {
-                        "boolean": true
-                    }
-                },
-                "equals": true
-            }
-        }
-    },
-    {
-        // Synopsis: An expression function example.
-        "apiVersion": "github.com/microsoft/PSRule/v1",
-        "kind": "Selector",
-        "metadata": {
-            "name": "Json.Fn.Example4"
-        },
-        "spec": {
-            "if": {
-                "value": {
-                    "$": {
-                        "concat": [
-                            {
-                                "path": "name"
-                            },
-                            {
-                                "string": "-"
-                            },
-                            {
-                                "path": "name"
-                            }
-                        ]
-                    }
-                },
-                "equals": "TestObject1-TestObject1"
-            }
-        }
-    },
-    {
-        // Synopsis: An expression function example.
-        "apiVersion": "github.com/microsoft/PSRule/v1",
-        "kind": "Selector",
-        "metadata": {
-            "name": "Json.Fn.Example5"
-        },
-        "spec": {
-            "if": {
-                "value": {
-                    "$": {
-                        "integer": 6
-                    }
-                },
-                "greater": 5
-            }
-        }
-    },
-    {
-        // Synopsis: An expression function example.
-        "apiVersion": "github.com/microsoft/PSRule/v1",
-        "kind": "Selector",
-        "metadata": {
-            "name": "Json.Fn.Example6"
-        },
-        "spec": {
-            "if": {
-                "value": "TestObject1-TestObject1",
-                "equals": {
-                    "$": {
-                        "concat": [
-                            {
-                                "path": "name"
-                            },
-                            {
-                                "string": "-"
-                            },
-                            {
-                                "path": "name"
-                            }
-                        ]
-                    }
-                }
-            }
-        }
+        "equals": "TestObj"
+      }
     }
+  },
+  {
+    // Synopsis: An expression function example.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Example2"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "configuration": "ConfigArray"
+          }
+        },
+        "count": 5
+      }
+    }
+  },
+  {
+    // Synopsis: An expression function example.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Example3"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "boolean": true
+          }
+        },
+        "equals": true
+      }
+    }
+  },
+  {
+    // Synopsis: An expression function example.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Example4"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "concat": [
+              {
+                "path": "name"
+              },
+              {
+                "string": "-"
+              },
+              {
+                "path": "name"
+              }
+            ]
+          }
+        },
+        "equals": "TestObject1-TestObject1"
+      }
+    }
+  },
+  {
+    // Synopsis: An expression function example.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Example5"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "integer": 6
+          }
+        },
+        "greater": 5
+      }
+    }
+  },
+  {
+    // Synopsis: An expression function example.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Example6"
+    },
+    "spec": {
+      "if": {
+        "value": "TestObject1-TestObject1",
+        "equals": {
+          "$": {
+            "concat": [
+              {
+                "path": "name"
+              },
+              {
+                "string": "-"
+              },
+              {
+                "path": "name"
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  {
+    // Synopsis: A test for the replace function.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Replace"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "replace": {
+              "string": " test one "
+            },
+            "oldString": " ",
+            "newString": ""
+          }
+        },
+        "equals": "testone"
+      }
+    }
+  },
+  {
+    // Synopsis: A test for the trim function.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Trim"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "trim": {
+              "string": " test "
+            }
+          }
+        },
+        "equals": "test"
+      }
+    }
+  },
+  {
+    // Synopsis: A test for the first function.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.First"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "first": [
+              "abc",
+              "def"
+            ]
+          }
+        },
+        "equals": "abc"
+      }
+    }
+  },
+  {
+    // Synopsis: A test for the last function.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Last"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "last": [
+              "abc",
+              "def"
+            ]
+          }
+        },
+        "equals": "def"
+      }
+    }
+  },
+  {
+    // Synopsis: A test for the split function.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "Json.Fn.Split"
+    },
+    "spec": {
+      "if": {
+        "value": {
+          "$": {
+            "split": {
+              "string": "One Two Three"
+            },
+            "delimiter": [
+              " "
+            ]
+          }
+        },
+        "equals": [
+          "One",
+          "Two",
+          "Three"
+        ]
+      }
+    }
+  }
 ]

--- a/tests/PSRule.Tests/Functions.Rule.yaml
+++ b/tests/PSRule.Tests/Functions.Rule.yaml
@@ -86,3 +86,82 @@ spec:
         - path: name
         - string: '-'
         - path: name
+
+---
+# Synopsis: A test for the replace function.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Replace
+spec:
+  if:
+    value:
+      $:
+        replace:
+          string: ' test one '
+        oldString: ' '
+        newString: ''
+    equals: testone
+
+---
+# Synopsis: A test for the trim function.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Trim
+spec:
+  if:
+    value:
+      $:
+        trim:
+          string: ' test '
+    equals: test
+
+---
+# Synopsis: A test for the first function.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.First
+spec:
+  if:
+    value:
+      $:
+        first:
+        - string: abc
+        - string: def
+    equals: abc
+
+---
+# Synopsis: A test for the last function.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Last
+spec:
+  if:
+    value:
+      $:
+        last:
+        - string: abc
+        - string: def
+    equals: def
+
+---
+# Synopsis: A test for the split function.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: Yaml.Fn.Split
+spec:
+  if:
+    value:
+      $:
+        split:
+          string: One Two Three
+        delimiter:
+          - ' '
+    equals:
+    - One
+    - Two
+    - Three

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -1762,6 +1762,27 @@ namespace PSRule
             Assert.True(example6.Match(actual1));
         }
 
+        [Theory]
+        [InlineData("Yaml", FunctionsYamlFileName)]
+        [InlineData("Json", FunctionsJsonFileName)]
+        public void WithFunctionSpecific(string type, string path)
+        {
+            var example1 = GetSelectorVisitor($"{type}.Fn.Replace", GetSource(path), out _);
+            var example2 = GetSelectorVisitor($"{type}.Fn.Trim", GetSource(path), out _);
+            var example3 = GetSelectorVisitor($"{type}.Fn.First", GetSource(path), out _);
+            var example4 = GetSelectorVisitor($"{type}.Fn.Last", GetSource(path), out _);
+            var example5 = GetSelectorVisitor($"{type}.Fn.Split", GetSource(path), out _);
+            var actual1 = GetObject(
+                (name: "Name", value: "TestObject1")
+            );
+
+            Assert.True(example1.Match(actual1));
+            Assert.True(example2.Match(actual1));
+            Assert.True(example3.Match(actual1));
+            Assert.True(example4.Match(actual1));
+            Assert.True(example5.Match(actual1));
+        }
+
         #endregion Functions
 
         #region Helper methods

--- a/tests/PSRule.Tests/StringExtensionsTests.cs
+++ b/tests/PSRule.Tests/StringExtensionsTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xunit;
+
+namespace PSRule
+{
+    public sealed class StringExtensionsTests
+    {
+        [Fact]
+        public void Replace()
+        {
+            var actual = "One Two Three";
+            Assert.Equal("OneTwoThree", actual.Replace(" ", "", caseSensitive: true));
+            Assert.Equal("OneTwoThree", actual.Replace(" ", "", caseSensitive: false));
+            Assert.Equal("One Two ", actual.Replace("Three", "", caseSensitive: true));
+            Assert.Equal("One Two ", actual.Replace("Three", "", caseSensitive: false));
+            Assert.Equal(" Two Three", actual.Replace("One", "", caseSensitive: true));
+            Assert.Equal(" Two Three", actual.Replace("One", "", caseSensitive: false));
+            Assert.Equal("One 2 Three", actual.Replace("Two", "2", caseSensitive: true));
+            Assert.Equal("One 2 Three", actual.Replace("Two", "2", caseSensitive: false));
+            Assert.Equal("One Two Three", actual.Replace("two", "2", caseSensitive: true));
+            Assert.Equal("One 2 Three", actual.Replace("two", "2", caseSensitive: false));
+            Assert.Equal("One Two Three", actual.Replace("three", "3", caseSensitive: true));
+            Assert.Equal("One Two 3", actual.Replace("three", "3", caseSensitive: false));
+            Assert.Equal("One Two Three", actual.Replace("one", "1", caseSensitive: true));
+            Assert.Equal("1 Two Three", actual.Replace("one", "1", caseSensitive: false));
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added support for `trim`, `replace`, `split`, `first`, and `last` functions.

Fixes #1227

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
