### PR TITLE
Fixes handling of ulong with LessOrEqual #1366

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,9 +30,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.7.0-B0031:
+
 - Bug fixes:
-  - Fixed loop stuck parsing JSON allOf not rule condition by @BernieWhite.
+  - Fixed loop stuck parsing JSON `allOf` `not` rule condition by @BernieWhite.
     [#1370](https://github.com/microsoft/PSRule/issues/1370)
+  - Fixed handling of uint64 with `LessOrEqual` assertion method by @BernieWhite.
+    [#1366](https://github.com/microsoft/PSRule/issues/1366)
 
 ## v2.7.0-B0031 (pre-release)
 

--- a/src/PSRule/Common/ExpressionHelpers.cs
+++ b/src/PSRule/Common/ExpressionHelpers.cs
@@ -380,9 +380,19 @@ namespace PSRule
                 value = i;
                 return true;
             }
+            else if (o is uint ui)
+            {
+                value = (long)ui;
+                return true;
+            }
             else if (o is long l)
             {
                 value = l;
+                return true;
+            }
+            else if (o is ulong ul && ul <= long.MaxValue)
+            {
+                value = (long)ul;
                 return true;
             }
             else if (o is JToken token && token.Type == JTokenType.Integer)

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -771,6 +771,17 @@ namespace PSRule
             Assert.Equal("value", assert.Greater(value, "value", 3).ToResultReason().FirstOrDefault().Path);
             Assert.Equal("jvalue", assert.Greater(value, "jvalue", 4).ToResultReason().FirstOrDefault().Path);
 
+            // ULong
+            value = GetObject((name: "value", value: (ulong)3), (name: "jvalue", value: new JValue((ulong)3)));
+            Assert.True(assert.Greater(value, "value", 2).Result);
+            Assert.False(assert.Greater(value, "value", 3).Result);
+            Assert.False(assert.Greater(value, "value", 4).Result);
+            Assert.True(assert.Greater(value, "value", 0).Result);
+            Assert.True(assert.Greater(value, "value", -1).Result);
+            Assert.False(assert.Greater(value, "jvalue", 4).Result);
+
+            Assert.Equal("value", assert.Greater(value, "value", 3).ToResultReason().FirstOrDefault().Path);
+
             // String
             value = GetObject((name: "value", value: "abc"));
             Assert.True(assert.Greater(value, "value", 2).Result);
@@ -819,6 +830,17 @@ namespace PSRule
             var value = GetObject((name: "value", value: 3), (name: "jvalue", value: new JValue(3)));
 
             // Int
+            Assert.True(assert.GreaterOrEqual(value, "value", 2).Result);
+            Assert.True(assert.GreaterOrEqual(value, "value", 3).Result);
+            Assert.False(assert.GreaterOrEqual(value, "value", 4).Result);
+            Assert.True(assert.GreaterOrEqual(value, "value", 0).Result);
+            Assert.True(assert.GreaterOrEqual(value, "value", -1).Result);
+            Assert.False(assert.GreaterOrEqual(value, "jvalue", 4).Result);
+
+            Assert.Equal("jvalue", assert.GreaterOrEqual(value, "jvalue", 4).ToResultReason().FirstOrDefault().Path);
+
+            // ULong
+            value = GetObject((name: "value", value: (ulong)3), (name: "jvalue", value: new JValue((ulong)3)));
             Assert.True(assert.GreaterOrEqual(value, "value", 2).Result);
             Assert.True(assert.GreaterOrEqual(value, "value", 3).Result);
             Assert.False(assert.GreaterOrEqual(value, "value", 4).Result);
@@ -885,6 +907,17 @@ namespace PSRule
 
             Assert.Equal("value", assert.Less(value, "value", -1).ToResultReason().FirstOrDefault().Path);
 
+            // ULong
+            value = GetObject((name: "value", value: (ulong)3), (name: "jvalue", value: new JValue((ulong)3)));
+            Assert.False(assert.Less(value, "value", 2).Result);
+            Assert.False(assert.Less(value, "value", 3).Result);
+            Assert.True(assert.Less(value, "value", 4).Result);
+            Assert.False(assert.Less(value, "value", 0).Result);
+            Assert.False(assert.Less(value, "value", -1).Result);
+            Assert.True(assert.Less(value, "jvalue", 4).Result);
+
+            Assert.Equal("value", assert.Less(value, "value", -1).ToResultReason().FirstOrDefault().Path);
+
             // String
             value = GetObject((name: "value", value: "abc"));
             Assert.False(assert.Less(value, "value", 2).Result);
@@ -933,6 +966,17 @@ namespace PSRule
             var value = GetObject((name: "value", value: 3), (name: "jvalue", value: new JValue(3)));
 
             // Int
+            Assert.False(assert.LessOrEqual(value, "value", 2).Result);
+            Assert.True(assert.LessOrEqual(value, "value", 3).Result);
+            Assert.True(assert.LessOrEqual(value, "value", 4).Result);
+            Assert.False(assert.LessOrEqual(value, "value", 0).Result);
+            Assert.False(assert.LessOrEqual(value, "value", -1).Result);
+            Assert.True(assert.LessOrEqual(value, "jvalue", 4).Result);
+
+            Assert.Equal("value", assert.LessOrEqual(value, "value", 0).ToResultReason().FirstOrDefault().Path);
+
+            // ULong
+            value = GetObject((name: "value", value: (ulong)3), (name: "jvalue", value: new JValue((ulong)3)));
             Assert.False(assert.LessOrEqual(value, "value", 2).Result);
             Assert.True(assert.LessOrEqual(value, "value", 3).Result);
             Assert.True(assert.LessOrEqual(value, "value", 4).Result);


### PR DESCRIPTION
## PR Summary

- Fixed handling of uint64 with `LessOrEqual` assertion method.

Fixes #1366 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
