### PR TITLE
Fixed object path wildcard selector #1376

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.7.0-B0049:
+
+- Bug fixes:
+  - Fixed object path fails to iterate JSON object with wildcard selector by @BernieWhite.
+    [#1376](https://github.com/microsoft/PSRule/issues/1376)
+
 ## v2.7.0-B0049 (pre-release)
 
 What's changed since pre-release v2.7.0-B0031:

--- a/src/PSRule/Runtime/ObjectPath/PathExpressionBuilder.cs
+++ b/src/PSRule/Runtime/ObjectPath/PathExpressionBuilder.cs
@@ -386,6 +386,12 @@ namespace PSRule.Runtime.ObjectPath
             if (IsSimpleType(baseObject))
                 return DEFAULT_EMPTY_ARRAY;
 
+            if (baseObject is JObject jObject)
+                return GetAllField(jObject);
+
+            if (baseObject is JArray jArray)
+                return GetAllIndex(jArray);
+
             return baseObject is IEnumerable ? GetAllIndex(baseObject) : GetAllField(baseObject);
         }
 
@@ -436,6 +442,12 @@ namespace PSRule.Runtime.ObjectPath
             else if (o is PSObject psObject)
             {
                 foreach (var property in psObject.Properties)
+                    yield return property.Value;
+            }
+            // Handle JObject
+            else if (o is JObject jObject)
+            {
+                foreach (var property in jObject.Properties())
                     yield return property.Value;
             }
             // Handle DynamicObjects

--- a/tests/PSRule.Tests/ObjectFromFile.json
+++ b/tests/PSRule.Tests/ObjectFromFile.json
@@ -1,82 +1,104 @@
 // Some comments
 [
+  // Some comments
+  {
     // Some comments
-    {
-        // Some comments
-        "TargetName": "TestObject1",
-        "Spec": { // Some comments
-            "": {
-                "Key": "value"
-            },
-            "Properties": {
-                "Value1": 1,
-                "Kind": "Test",
-                "array": [
-                    {
-                        "id": "1"
-                    },
-                    {
-                        "id": "2"
-                    }
-                ],
-                "array2": [
-                    "1",
-                    "2",
-                    "3"
-                ],
-                "array3": [
-                    [
-                        "nested"
-                    ],
-                    [
-                        1,
-                        2,
-                        3
-                    ]
-                ],
-                "from": null
-            }
-        }, // Some comments
-        "_PSRule": {
-            "path": "master.items[0]",
-            "source": [
-                {
-                    "file": "some-file.json",
-                    "line": 1,
-                    "type": "Origin"
-                }
-            ],
-            "issue": [
-                {
-                    "type": "Downstream.Issue",
-                    "name": "Custom.NoNesting",
-                    "message": "A custom downstream issue reporting nesting not allowed."
-                }
+    "TargetName": "TestObject1",
+    "Spec": { // Some comments
+      "": {
+        "Key": "value"
+      },
+      "Properties": {
+        "Value1": 1,
+        "Kind": "Test",
+        "array": [
+          {
+            "id": "1"
+          },
+          {
+            "id": "2"
+          }
+        ],
+        "array2": [
+          "1",
+          "2",
+          "3"
+        ],
+        "array3": [
+          [
+            "nested"
+          ],
+          [
+            1,
+            2,
+            3
+          ]
+        ],
+        "from": null
+      },
+      "config": {
+        "example": [
+          {
+            "prop": [
+              {
+                "public": true
+              }
             ]
+          }
+        ]
+      }
+    }, // Some comments
+    "_PSRule": {
+      "path": "master.items[0]",
+      "source": [
+        {
+          "file": "some-file.json",
+          "line": 1,
+          "type": "Origin"
         }
-    },
-    {
-        "TargetName": "TestObject2",
-        "Spec": {
-            "Properties": {
-                "Value2": 2,
-                "Kind": "Test",
-                "array": [
-                    {
-                        "id": "1"
-                    },
-                    {
-                        "id": "2"
-                    },
-                    null
-                ],
-                "array2": [
-                    "1",
-                    "2",
-                    "3"
-                ],
-                "from": "abc"
-            }
+      ],
+      "issue": [
+        {
+          "type": "Downstream.Issue",
+          "name": "Custom.NoNesting",
+          "message": "A custom downstream issue reporting nesting not allowed."
         }
+      ]
     }
+  },
+  {
+    "TargetName": "TestObject2",
+    "Spec": {
+      "Properties": {
+        "Value2": 2,
+        "Kind": "Test",
+        "array": [
+          {
+            "id": "1"
+          },
+          {
+            "id": "2"
+          },
+          null
+        ],
+        "array2": [
+          "1",
+          "2",
+          "3"
+        ],
+        "from": "abc"
+      },
+      "config": {
+        "example": [
+          {
+            "prop": [
+              {
+                "public": false
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
 ]

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -852,7 +852,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             $result[0].Source[0].File | Should -Be 'some-file.json';
             $result[0].Source[0].Line | Should -Be 1;
             $result[1].Source[0].File.Split([char[]]@('\', '/'))[-1] | Should -Be 'ObjectFromFile.json';
-            $result[1].Source[0].Line | Should -Be 59;
+            $result[1].Source[0].Line | Should -Be 70;
 
             # Multiple file
             $result = @(Invoke-PSRule -Path $ruleFilePath -Name 'WithFormat' -InputPath $inputFiles);

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -6,9 +6,9 @@
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>PSRule</RootNamespace>
-    <DebugType>portable</DebugType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+    <DebugType>Full</DebugType>
+    <!--<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>-->
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 

--- a/tests/PSRule.Tests/PathExpressionTests.cs
+++ b/tests/PSRule.Tests/PathExpressionTests.cs
@@ -307,6 +307,32 @@ namespace PSRule
             Assert.False(expression.TryGet(pso, true, out object[] _));
         }
 
+        [Fact]
+        public void WithArrayExpand()
+        {
+            var testObject = GetJsonContent() as JArray;
+            var expression = PathExpression.Create("Spec.config.[*][*].prop[*].public");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject[0], true, out object[] actual));
+            Assert.Equal(true, actual[0]);
+            Assert.True(expression.TryGet(testObject[1], true, out actual));
+            Assert.Equal(false, actual[0]);
+
+            expression = PathExpression.Create("Spec.config[*][*].prop[*].public");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject[0], true, out actual));
+            Assert.Equal(true, actual[0]);
+            Assert.True(expression.TryGet(testObject[1], true, out actual));
+            Assert.Equal(false, actual[0]);
+
+            expression = PathExpression.Create("Spec.config.[*].[*].prop[*].public");
+            Assert.True(expression.IsArray);
+            Assert.True(expression.TryGet(testObject[0], true, out actual));
+            Assert.Equal(true, actual[0]);
+            Assert.True(expression.TryGet(testObject[1], true, out actual));
+            Assert.Equal(false, actual[0]);
+        }
+
         #region Helper methods
 
         private static object GetJsonContent()


### PR DESCRIPTION
## PR Summary

- Fixed object path fails to iterate JSON object with wildcard selector.

Fixes #1376 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
