### PR TITLE
Improvements to scope and string #1382 #1383 #1384

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,16 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.7.0-B0070:
+
+- General improvements:
+  - Added support for `hasValue` expression with `scope` by @BernieWhite.
+    [#1382](https://github.com/microsoft/PSRule/issues/1382)
+  - Return target object scope as an array by @BernieWhite.
+    [#1383](https://github.com/microsoft/PSRule/issues/1383)
+  - Improve support of string comparisons to support an array of strings by @BernieWhite.
+    [#1384](https://github.com/microsoft/PSRule/issues/1384)
+
 ## v2.7.0-B0070 (pre-release)
 
 What's changed since pre-release v2.7.0-B0049:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Assert.md
@@ -223,7 +223,8 @@ Rule 'MinimumAPIVersionWithFlag' {
 
 ### Contains
 
-The `Contains` assertion method checks the field value contains the specified string.
+The `Contains` assertion method checks the operand contains the specified string.
+If the operand is an array of strings, only one string must contain the specified string.
 Optionally a case-sensitive compare can be used, however case is ignored by default.
 
 The following parameters are accepted:
@@ -284,7 +285,8 @@ Rule 'Count' {
 
 ### EndsWith
 
-The `EndsWith` assertion method checks the field value ends with the specified suffix.
+The `EndsWith` assertion method checks the operand ends with the specified suffix.
+If the operand is an array of strings, only one string must end with the specified suffix.
 Optionally a case-sensitive compare can be used, however case is ignored by default.
 
 The following parameters are accepted:
@@ -1070,8 +1072,9 @@ Rule 'Match' {
 
 ### NotContains
 
-The `NotContains` assertion method checks the field value contains the specified string.
+The `NotContains` assertion method checks the operand contains the specified string.
 This condition fails when any of the specified sub-strings are found.
+If the operand is an array of strings, this condition fails if any of the strings contain the specified string.
 Optionally a case-sensitive compare can be used, however case is ignored by default.
 
 The following parameters are accepted:
@@ -1130,8 +1133,9 @@ Rule 'NotCount' {
 
 ### NotEndsWith
 
-The `NotEndsWith` assertion method checks the field value ends with the specified suffix.
+The `NotEndsWith` assertion method checks the operand ends with the specified suffix.
 This condition fails when any of the specified sub-strings are found at the end of the operand.
+If the operand is an array of strings, this condition fails if any of the strings ends with the specified suffix.
 Optionally a case-sensitive compare can be used, however case is ignored by default.
 
 The following parameters are accepted:
@@ -1313,8 +1317,9 @@ Rule 'NotNull' {
 
 ### NotStartsWith
 
-The `NotStartsWith` assertion method checks the field value starts with the specified prefix.
+The `NotStartsWith` assertion method checks the operand starts with the specified prefix.
 This condition fails when any of the specified sub-strings are found at the start of the operand.
+If the operand is an array of strings, this condition fails if any of the strings start with the specified prefix.
 Optionally a case-sensitive compare can be used, however case is ignored by default.
 
 The following parameters are accepted:
@@ -1507,7 +1512,8 @@ Rule 'Subset' {
 
 ### StartsWith
 
-The `StartsWith` assertion method checks the field value starts with the specified prefix.
+The `StartsWith` assertion method checks the operand starts with the specified prefix.
+If the operand is an array of strings, only one string must start with the specified prefix.
 Optionally a case-sensitive compare can be used, however case is ignored by default.
 
 The following parameters are accepted:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -1734,7 +1734,7 @@ spec:
 
 ### Scope
 
-The comparison property `scope` is used with a condition to evaluate the scope of the object.
+The comparison property `scope` is used with a condition to evaluate any scopes assigned to the object.
 The `scope` property must be set to `.`.
 Any other value will cause the condition to evaluate to `false`.
 

--- a/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Variables.md
@@ -172,7 +172,7 @@ The following properties are available for read access:
   See option `Binding.Field` for more information.
 - `Input` - Allows adding additional input paths to the pipeline.
 - `Repository` - Provides access to information about the current repository.
-- `Scope` - The scope of the object currently being processed by the pipeline.
+- `Scope` - Any scopes assigned to the object currently being processed by the pipeline.
 - `Source` - A collection of sources for the object currently being processed on the pipeline.
 - `TargetObject` - The object currently being processed on the pipeline.
 - `TargetName` - The name of the object currently being processed on the pipeline.

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -1175,8 +1175,8 @@
             "scope": {
               "type": "string",
               "title": "Scope",
-              "description": "The scope of the object currently being processed by the pipeline.",
-              "markdownDescription": "The scope of the object currently being processed by the pipeline. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#scope)",
+              "description": "Any scopes assigned to the object currently being processed by the pipeline.",
+              "markdownDescription": "Any scopes assigned to the object currently being processed by the pipeline.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#scope)",
               "default": ".",
               "enum": [
                 "."
@@ -1463,12 +1463,15 @@
                 "hasValue": {
                   "type": "boolean",
                   "title": "Has Value",
-                  "description": "Must have a non-empty value.",
-                  "markdownDescription": "Must have a non-empty value. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasvalue)",
+                  "description": "When set to true, the operand must have a non-empty value. When set to false the operand must be null or empty.",
+                  "markdownDescription": "When set to `true`, the operand must have a non-empty value. When set to `false` the operand must be `null` or empty.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#hasvalue)",
                   "default": true
                 },
                 "field": {
                   "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
+                },
+                "scope": {
+                  "$ref": "#/definitions/expressions/definitions/properties/definitions/scope"
                 }
               },
               "required": [

--- a/src/PSRule/Common/DictionaryExtensions.cs
+++ b/src/PSRule/Common/DictionaryExtensions.cs
@@ -58,7 +58,7 @@ namespace PSRule
         public static bool TryPopStringArray(this IDictionary<string, object> dictionary, string key, out string[] value)
         {
             value = default;
-            return TryPopValue(dictionary, key, out var v) && ExpressionHelpers.TryConvertStringArray(v, out value);
+            return TryPopValue(dictionary, key, out var v) && ExpressionHelpers.TryStringOrArray(v, convert: true, value: out value);
         }
 
         [DebuggerStepThrough]
@@ -140,7 +140,7 @@ namespace PSRule
         public static bool TryGetStringArray(this IDictionary<string, object> dictionary, string key, out string[] value)
         {
             value = null;
-            return dictionary.TryGetValue(key, out var o) && ExpressionHelpers.TryConvertStringArray(o, out value);
+            return dictionary.TryGetValue(key, out var o) && ExpressionHelpers.TryStringOrArray(o, convert: true, value: out value);
         }
 
         [DebuggerStepThrough]

--- a/src/PSRule/Common/ExpressionHelpers.cs
+++ b/src/PSRule/Common/ExpressionHelpers.cs
@@ -243,20 +243,20 @@ namespace PSRule
             return value != null;
         }
 
-        internal static bool TryConvertStringArray(object o, out string[] value)
+        internal static bool TryStringOrArray(object o, bool convert, out string[] value)
         {
             // Handle single string
-            if (TryString(o, convert: true, value: out var s))
+            if (TryString(o, convert, value: out var s))
             {
                 value = new string[] { s };
                 return true;
             }
 
             // Handle multiple strings
-            return TryStringArray(o, out value);
+            return TryStringArray(o, convert, out value);
         }
 
-        internal static bool TryStringArray(object o, out string[] value)
+        internal static bool TryStringArray(object o, bool convert, out string[] value)
         {
             value = null;
             if (o is Array array)
@@ -264,7 +264,7 @@ namespace PSRule
                 value = new string[array.Length];
                 for (var i = 0; i < array.Length; i++)
                 {
-                    if (TryString(array.GetValue(i), out var s))
+                    if (TryString(array.GetValue(i), convert, value: out var s))
                         value[i] = s;
                 }
             }
@@ -273,7 +273,7 @@ namespace PSRule
                 value = new string[jArray.Count];
                 for (var i = 0; i < jArray.Count; i++)
                 {
-                    if (TryString(jArray[i], out var s))
+                    if (TryString(jArray[i], convert, out var s))
                         value[i] = s;
                 }
             }

--- a/src/PSRule/Common/HashtableExtensions.cs
+++ b/src/PSRule/Common/HashtableExtensions.cs
@@ -24,7 +24,7 @@ namespace PSRule
         public static bool TryGetStringArray(this Hashtable hashtable, string key, out string[] value)
         {
             value = null;
-            return hashtable.TryGetValue(key, out var o) && ExpressionHelpers.TryConvertStringArray(o, out value);
+            return hashtable.TryGetValue(key, out var o) && ExpressionHelpers.TryStringOrArray(o, convert: true, value: out value);
         }
 
         [DebuggerStepThrough]

--- a/src/PSRule/Common/PSObjectExtensions.cs
+++ b/src/PSRule/Common/PSObjectExtensions.cs
@@ -125,7 +125,7 @@ namespace PSRule
             return o != null && o.TryTargetInfo(out var targetInfo) ? targetInfo.TargetType : null;
         }
 
-        public static string GetScope(this PSObject o)
+        public static string[] GetScope(this PSObject o)
         {
             return o != null && o.TryTargetInfo(out var targetInfo) ? targetInfo.Scope : null;
         }
@@ -154,7 +154,7 @@ namespace PSRule
             if (TryProperty(value, PROPERTY_TYPE, out string type) && targetInfo.TargetType == null)
                 targetInfo.TargetType = type;
 
-            if (TryProperty(value, PROPERTY_SCOPE, out string scope) && targetInfo.Scope == null)
+            if (TryProperty(value, PROPERTY_SCOPE, out string[] scope) && targetInfo.Scope == null)
                 targetInfo.Scope = scope;
 
             if (TryProperty(value, PROPERTY_PATH, out string path) && targetInfo.Path == null)

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -968,13 +968,17 @@ namespace PSRule.Definitions.Expressions
                 GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(STARTSWITH, operand.Value, propertyValue);
-                if (!ExpressionHelpers.TryString(operand.Value, convert, out var value))
+                if (!ExpressionHelpers.TryStringOrArray(operand.Value, convert, out var value))
                     return NotString(context, operand);
 
-                for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
-                    if (ExpressionHelpers.StartsWith(value, propertyValue[i], caseSensitive))
-                        return Pass();
-
+                for (var i_propertyValue = 0; propertyValue != null && i_propertyValue < propertyValue.Length; i_propertyValue++)
+                {
+                    for (var i_value = 0; i_value < value.Length; i_value++)
+                    {
+                        if (ExpressionHelpers.StartsWith(value[i_value], propertyValue[i_propertyValue], caseSensitive))
+                            return Pass();
+                    }
+                }
                 return Fail(
                     context,
                     operand,
@@ -995,18 +999,21 @@ namespace PSRule.Definitions.Expressions
                 GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(NOTSTARTSWITH, operand.Value, propertyValue);
-                if (ExpressionHelpers.TryString(operand.Value, convert, out var value))
+                if (ExpressionHelpers.TryStringOrArray(operand.Value, convert, out var value))
                 {
-                    for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
+                    for (var i_propertyValue = 0; propertyValue != null && i_propertyValue < propertyValue.Length; i_propertyValue++)
                     {
-                        if (ExpressionHelpers.StartsWith(value, propertyValue[i], caseSensitive))
-                            return Fail(
-                                context,
-                                operand,
-                                ReasonStrings.Assert_StartsWith,
-                                value,
-                                propertyValue[i]
-                            );
+                        for (var i_value = 0; i_value < value.Length; i_value++)
+                        {
+                            if (ExpressionHelpers.StartsWith(value[i_value], propertyValue[i_propertyValue], caseSensitive))
+                                return Fail(
+                                    context,
+                                    operand,
+                                    ReasonStrings.Assert_StartsWith,
+                                    value[i_value],
+                                    propertyValue[i_propertyValue]
+                                );
+                        }
                     }
                 }
                 return Pass();
@@ -1023,13 +1030,17 @@ namespace PSRule.Definitions.Expressions
                 GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(ENDSWITH, operand.Value, propertyValue);
-                if (!ExpressionHelpers.TryString(operand.Value, convert, out var value))
+                if (!ExpressionHelpers.TryStringOrArray(operand.Value, convert, out var value))
                     return NotString(context, operand);
 
-                for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
-                    if (ExpressionHelpers.EndsWith(value, propertyValue[i], caseSensitive))
-                        return Pass();
-
+                for (var i_propertyValue = 0; propertyValue != null && i_propertyValue < propertyValue.Length; i_propertyValue++)
+                {
+                    for (var i_value = 0; i_value < value.Length; i_value++)
+                    {
+                        if (ExpressionHelpers.EndsWith(value[i_value], propertyValue[i_propertyValue], caseSensitive))
+                            return Pass();
+                    }
+                }
                 return Fail(
                     context,
                     operand,
@@ -1050,18 +1061,21 @@ namespace PSRule.Definitions.Expressions
                 GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(NOTENDSWITH, operand.Value, propertyValue);
-                if (ExpressionHelpers.TryString(operand.Value, convert, out var value))
+                if (ExpressionHelpers.TryStringOrArray(operand.Value, convert, out var value))
                 {
-                    for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
+                    for (var i_propertyValue = 0; propertyValue != null && i_propertyValue < propertyValue.Length; i_propertyValue++)
                     {
-                        if (ExpressionHelpers.EndsWith(value, propertyValue[i], caseSensitive))
-                            return Fail(
-                                context,
-                                operand,
-                                ReasonStrings.Assert_EndsWith,
-                                value,
-                                propertyValue[i]
-                            );
+                        for (var i_value = 0; i_value < value.Length; i_value++)
+                        {
+                            if (ExpressionHelpers.EndsWith(value[i_value], propertyValue[i_propertyValue], caseSensitive))
+                                return Fail(
+                                    context,
+                                    operand,
+                                    ReasonStrings.Assert_EndsWith,
+                                    value[i_value],
+                                    propertyValue[i_propertyValue]
+                                );
+                        }
                     }
                 }
                 return Pass();
@@ -1078,13 +1092,17 @@ namespace PSRule.Definitions.Expressions
                 GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(CONTAINS, operand.Value, propertyValue);
-                if (!ExpressionHelpers.TryString(operand.Value, convert, out var value))
+                if (!ExpressionHelpers.TryStringOrArray(operand.Value, convert, out var value))
                     return NotString(context, operand);
 
-                for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
-                    if (ExpressionHelpers.Contains(value, propertyValue[i], caseSensitive))
-                        return Pass();
-
+                for (var i_propertyValue = 0; propertyValue != null && i_propertyValue < propertyValue.Length; i_propertyValue++)
+                {
+                    for (var i_value = 0; i_value < value.Length; i_value++)
+                    {
+                        if (ExpressionHelpers.Contains(value[i_value], propertyValue[i_propertyValue], caseSensitive))
+                            return Pass();
+                    }
+                }
                 return Fail(
                     context,
                     operand,
@@ -1105,18 +1123,21 @@ namespace PSRule.Definitions.Expressions
                 GetCaseSensitive(properties, out var caseSensitive))
             {
                 context.ExpressionTrace(NOTCONTAINS, operand.Value, propertyValue);
-                if (ExpressionHelpers.TryString(operand.Value, convert, out var value))
+                if (ExpressionHelpers.TryStringOrArray(operand.Value, convert, out var value))
                 {
-                    for (var i = 0; propertyValue != null && i < propertyValue.Length; i++)
+                    for (var i_propertyValue = 0; propertyValue != null && i_propertyValue < propertyValue.Length; i_propertyValue++)
                     {
-                        if (ExpressionHelpers.Contains(value, propertyValue[i], caseSensitive))
-                            return Fail(
-                                context,
-                                operand,
-                                ReasonStrings.Assert_Contains,
-                                value,
-                                propertyValue[i]
-                            );
+                        for (var i_value = 0; i_value < value.Length; i_value++)
+                        {
+                            if (ExpressionHelpers.Contains(value[i_value], propertyValue[i_propertyValue], caseSensitive))
+                                return Fail(
+                                    context,
+                                    operand,
+                                    ReasonStrings.Assert_Contains,
+                                    value[i_value],
+                                    propertyValue[i_propertyValue]
+                                );
+                        }
                     }
                 }
                 return Pass();
@@ -1688,8 +1709,7 @@ namespace PSRule.Definitions.Expressions
                 if (svalue != DOT || context?.Context?.LanguageScope == null)
                     return Invalid(context, svalue);
 
-                if (!context.Context.LanguageScope.TryGetScope(o, out var scope) ||
-                    string.IsNullOrEmpty(scope))
+                if (!context.Context.LanguageScope.TryGetScope(o, out var scope))
                     return Invalid(context, svalue);
 
                 operand = Operand.FromScope(scope);

--- a/src/PSRule/Pipeline/TargetObject.cs
+++ b/src/PSRule/Pipeline/TargetObject.cs
@@ -62,7 +62,7 @@ namespace PSRule.Pipeline
             _Annotations = new Dictionary<Type, TargetObjectAnnotation>();
         }
 
-        internal TargetObject(PSObject o, string targetName = null, string targetType = null, string scope = null)
+        internal TargetObject(PSObject o, string targetName = null, string targetType = null, string[] scope = null)
             : this(o, null)
         {
             if (targetName != null)
@@ -71,7 +71,7 @@ namespace PSRule.Pipeline
             if (targetType != null)
                 TargetType = targetType;
 
-            if (scope != null)
+            if (scope != null && scope.Length > 0)
                 Scope = scope;
         }
 
@@ -85,7 +85,7 @@ namespace PSRule.Pipeline
 
         internal string TargetType { get; }
 
-        internal string Scope { get; }
+        internal string[] Scope { get; }
 
         internal string Path { get; }
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -449,17 +449,20 @@ namespace PSRule.Runtime
                 GuardNullOrEmptyParam(field, nameof(field), out result) ||
                 GuardNullParam(prefix, nameof(prefix), out result) ||
                 GuardField(inputObject, field, false, out var fieldValue, out result) ||
-                GuardString(Operand.FromPath(field), fieldValue, out var value, out result))
+                GuardStringOrArray(Operand.FromPath(field), fieldValue, out var value, out result))
                 return result;
 
             if (prefix == null || prefix.Length == 0)
                 return Pass();
 
             // Assert
-            for (var i = 0; i < prefix.Length; i++)
+            for (var i_prefix = 0; i_prefix < prefix.Length; i_prefix++)
             {
-                if (ExpressionHelpers.StartsWith(value, prefix[i], caseSensitive))
-                    return Pass();
+                for (var i_value = 0; i_value < value.Length; i_value++)
+                {
+                    if (ExpressionHelpers.StartsWith(value[i_value], prefix[i_prefix], caseSensitive))
+                        return Pass();
+                }
             }
             return Fail(Operand.FromPath(field), ReasonStrings.StartsWith, field, FormatArray(prefix));
         }
@@ -483,14 +486,17 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out var fieldValue, out result))
                 return result;
 
-            if (prefix == null || prefix.Length == 0 || GuardString(Operand.FromPath(field), fieldValue, out var value, out _))
+            if (prefix == null || prefix.Length == 0 || GuardStringOrArray(Operand.FromPath(field), fieldValue, out var value, out _))
                 return Pass();
 
             // Assert
-            for (var i = 0; i < prefix.Length; i++)
+            for (var i_prefix = 0; i_prefix < prefix.Length; i_prefix++)
             {
-                if (ExpressionHelpers.StartsWith(value, prefix[i], caseSensitive))
-                    return Fail(Operand.FromPath(field), ReasonStrings.Assert_StartsWith, value, prefix[i]);
+                for (var i_value = 0; i_value < value.Length; i_value++)
+                {
+                    if (ExpressionHelpers.StartsWith(value[i_value], prefix[i_prefix], caseSensitive))
+                        return Fail(Operand.FromPath(field), ReasonStrings.Assert_StartsWith, value, prefix[i_prefix]);
+                }
             }
             return Pass();
         }
@@ -505,17 +511,20 @@ namespace PSRule.Runtime
                 GuardNullOrEmptyParam(field, nameof(field), out result) ||
                 GuardNullParam(suffix, nameof(suffix), out result) ||
                 GuardField(inputObject, field, false, out var fieldValue, out result) ||
-                GuardString(Operand.FromPath(field), fieldValue, out var value, out result))
+                GuardStringOrArray(Operand.FromPath(field), fieldValue, out var value, out result))
                 return result;
 
             if (suffix == null || suffix.Length == 0)
                 return Pass();
 
             // Assert
-            for (var i = 0; i < suffix.Length; i++)
+            for (var i_suffix = 0; i_suffix < suffix.Length; i_suffix++)
             {
-                if (ExpressionHelpers.EndsWith(value, suffix[i], caseSensitive))
-                    return Pass();
+                for (var i_value = 0; i_value < value.Length; i_value++)
+                {
+                    if (ExpressionHelpers.EndsWith(value[i_value], suffix[i_suffix], caseSensitive))
+                        return Pass();
+                }
             }
             return Fail(Operand.FromPath(field), ReasonStrings.EndsWith, field, FormatArray(suffix));
         }
@@ -539,14 +548,17 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out var fieldValue, out result))
                 return result;
 
-            if (suffix == null || suffix.Length == 0 || GuardString(Operand.FromPath(field), fieldValue, out var value, out _))
+            if (suffix == null || suffix.Length == 0 || GuardStringOrArray(Operand.FromPath(field), fieldValue, out var value, out _))
                 return Pass();
 
             // Assert
-            for (var i = 0; i < suffix.Length; i++)
+            for (var i_suffix = 0; i_suffix < suffix.Length; i_suffix++)
             {
-                if (ExpressionHelpers.EndsWith(value, suffix[i], caseSensitive))
-                    return Fail(Operand.FromPath(field), ReasonStrings.Assert_EndsWith, value, suffix);
+                for (var i_value = 0; i_value < value.Length; i_value++)
+                {
+                    if (ExpressionHelpers.EndsWith(value[i_value], suffix[i_suffix], caseSensitive))
+                        return Fail(Operand.FromPath(field), ReasonStrings.Assert_EndsWith, value, suffix[i_suffix]);
+                }
             }
             return Pass();
         }
@@ -561,17 +573,20 @@ namespace PSRule.Runtime
                 GuardNullOrEmptyParam(field, nameof(field), out result) ||
                 GuardNullParam(text, nameof(text), out result) ||
                 GuardField(inputObject, field, false, out var fieldValue, out result) ||
-                GuardString(Operand.FromPath(field), fieldValue, out var value, out result))
+                GuardStringOrArray(Operand.FromPath(field), fieldValue, out var value, out result))
                 return result;
 
             if (text == null || text.Length == 0)
                 return Pass();
 
             // Assert
-            for (var i = 0; i < text.Length; i++)
+            for (var i_text = 0; i_text < text.Length; i_text++)
             {
-                if (ExpressionHelpers.Contains(value, text[i], caseSensitive))
-                    return Pass();
+                for (var i_value = 0; i_value < value.Length; i_value++)
+                {
+                    if (ExpressionHelpers.Contains(value[i_value], text[i_text], caseSensitive))
+                        return Pass();
+                }
             }
             return Fail(Operand.FromPath(field), ReasonStrings.Contains, field, FormatArray(text));
         }
@@ -595,14 +610,17 @@ namespace PSRule.Runtime
                 GuardField(inputObject, field, false, out var fieldValue, out result))
                 return result;
 
-            if (text == null || text.Length == 0 || GuardString(Operand.FromPath(field), fieldValue, out var value, out _))
+            if (text == null || text.Length == 0 || GuardStringOrArray(Operand.FromPath(field), fieldValue, out var value, out _))
                 return Pass();
 
             // Assert
-            for (var i = 0; i < text.Length; i++)
+            for (var i_text = 0; i_text < text.Length; i_text++)
             {
-                if (ExpressionHelpers.Contains(value, text[i], caseSensitive))
-                    return Fail(Operand.FromPath(field), ReasonStrings.Assert_Contains, value, text);
+                for (var i_value = 0; i_value < value.Length; i_value++)
+                {
+                    if (ExpressionHelpers.Contains(value[i_value], text[i_text], caseSensitive))
+                        return Fail(Operand.FromPath(field), ReasonStrings.Assert_Contains, value, text[i_text]);
+                }
             }
             return Pass();
         }
@@ -1423,6 +1441,23 @@ namespace PSRule.Runtime
         {
             result = null;
             if (ExpressionHelpers.TryString(fieldValue, out value))
+                return false;
+
+            result = Fail(operand, ReasonStrings.Type, TYPENAME_STRING, GetTypeName(fieldValue), fieldValue);
+            return true;
+        }
+
+        /// <summary>
+        /// Fails if the field value is not a string or an array of strings.
+        /// </summary>
+        /// <returns>Returns true if the field value is not a string or an array of strings.</returns>
+        /// <remarks>
+        /// Reason: The field value '{0}' is not a string.
+        /// </remarks>
+        private bool GuardStringOrArray(IOperand operand, object fieldValue, out string[] value, out AssertResult result)
+        {
+            result = null;
+            if (ExpressionHelpers.TryStringOrArray(fieldValue, convert: false, value: out value))
                 return false;
 
             result = Fail(operand, ReasonStrings.Type, TYPENAME_STRING, GetTypeName(fieldValue), fieldValue);

--- a/src/PSRule/Runtime/LanguageScope.cs
+++ b/src/PSRule/Runtime/LanguageScope.cs
@@ -45,7 +45,7 @@ namespace PSRule.Runtime
 
         bool TryGetName(object o, out string name, out string path);
 
-        bool TryGetScope(object o, out string scope);
+        bool TryGetScope(object o, out string[] scope);
     }
 
     internal sealed class LanguageScope : ILanguageScope
@@ -149,7 +149,7 @@ namespace PSRule.Runtime
             return false;
         }
 
-        public bool TryGetScope(object o, out string scope)
+        public bool TryGetScope(object o, out string[] scope)
         {
             if (_Context != null && _Context.TargetObject.Value == o)
             {

--- a/src/PSRule/Runtime/Operand.cs
+++ b/src/PSRule/Runtime/Operand.cs
@@ -132,7 +132,7 @@ namespace PSRule.Runtime
             return new Operand(OperandKind.Value, null, value);
         }
 
-        internal static IOperand FromScope(string scope)
+        internal static IOperand FromScope(string[] scope)
         {
             return new Operand(OperandKind.Scope, scope);
         }

--- a/src/PSRule/Runtime/PSRule.cs
+++ b/src/PSRule/Runtime/PSRule.cs
@@ -207,7 +207,7 @@ namespace PSRule.Runtime
         /// <summary>
         /// The bound scope of the target object.
         /// </summary>
-        public string Scope => GetContext().TargetObject.Scope;
+        public string[] Scope => GetContext().TargetObject.Scope;
 
         /// <summary>
         /// Attempts to read content from disk.

--- a/src/PSRule/Runtime/PSRuleMemberInfo.cs
+++ b/src/PSRule/Runtime/PSRuleMemberInfo.cs
@@ -51,7 +51,7 @@ namespace PSRule.Runtime
         public string TargetType { get; set; }
 
         [JsonProperty(PropertyName = "scope")]
-        public string Scope { get; set; }
+        public string[] Scope { get; set; }
 
         [JsonProperty(PropertyName = "path")]
         public string Path { get; set; }

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -41,7 +41,7 @@ namespace PSRule
             context.Begin();
             var selector = HostHelper.GetSelector(GetSource(path), context).ToArray();
             Assert.NotNull(selector);
-            Assert.Equal(97, selector.Length);
+            Assert.Equal(99, selector.Length);
 
             var actual = selector[0];
             var visitor = new SelectorVisitor(context, actual.Id, actual.Source, actual.Spec.If);
@@ -767,6 +767,7 @@ namespace PSRule
             var actual7 = GetObject((name: "value", value: "EFG"));
             var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
             var actual9 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.None));
+            var actual10 = GetObject((name: "value", value: new string[] { "hij", "abc" }));
 
             Assert.True(startsWith.Match(actual1));
             Assert.True(startsWith.Match(actual2));
@@ -777,6 +778,7 @@ namespace PSRule
             Assert.False(startsWith.Match(actual7));
             Assert.True(startsWith.Match(actual8));
             Assert.False(startsWith.Match(actual9));
+            Assert.True(startsWith.Match(actual10));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameStartsWith", GetSource(path), out var context);
@@ -809,6 +811,7 @@ namespace PSRule
             var actual7 = GetObject((name: "value", value: "EFG"));
             var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
             var actual9 = GetObject((name: "value", value: "hij"), (name: "OtherValue", value: TestEnumValue.None));
+            var actual10 = GetObject((name: "value", value: new string[] { "hij", "abc" }));
 
             Assert.False(notStartsWith.Match(actual1));
             Assert.False(notStartsWith.Match(actual2));
@@ -819,6 +822,7 @@ namespace PSRule
             Assert.False(notStartsWith.Match(actual7));
             Assert.False(notStartsWith.Match(actual8));
             Assert.True(notStartsWith.Match(actual9));
+            Assert.False(notStartsWith.Match(actual10));
         }
 
         [Theory]
@@ -836,6 +840,7 @@ namespace PSRule
             var actual7 = GetObject((name: "value", value: "EFG"));
             var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
             var actual9 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.None));
+            var actual10 = GetObject((name: "value", value: new string[] { "hij", "abc" }));
 
             Assert.True(endsWith.Match(actual1));
             Assert.True(endsWith.Match(actual2));
@@ -846,6 +851,7 @@ namespace PSRule
             Assert.False(endsWith.Match(actual7));
             Assert.True(endsWith.Match(actual8));
             Assert.False(endsWith.Match(actual9));
+            Assert.True(endsWith.Match(actual10));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameEndsWith", GetSource(path), out var context);
@@ -895,6 +901,7 @@ namespace PSRule
             var actual7 = GetObject((name: "value", value: "EFG"));
             var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
             var actual9 = GetObject((name: "value", value: "hij"), (name: "OtherValue", value: TestEnumValue.None));
+            var actual10 = GetObject((name: "value", value: new string[] { "hij", "abc" }));
 
             Assert.False(notEndsWith.Match(actual1));
             Assert.False(notEndsWith.Match(actual2));
@@ -905,6 +912,7 @@ namespace PSRule
             Assert.False(notEndsWith.Match(actual7));
             Assert.False(notEndsWith.Match(actual8));
             Assert.True(notEndsWith.Match(actual9));
+            Assert.False(notEndsWith.Match(actual10));
         }
 
         [Theory]
@@ -922,6 +930,7 @@ namespace PSRule
             var actual7 = GetObject((name: "value", value: "BCD"));
             var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
             var actual9 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.None));
+            var actual10 = GetObject((name: "value", value: new string[] { "hij", "abc" }));
 
             Assert.True(contains.Match(actual1));
             Assert.True(contains.Match(actual2));
@@ -932,6 +941,7 @@ namespace PSRule
             Assert.False(contains.Match(actual7));
             Assert.True(contains.Match(actual8));
             Assert.False(contains.Match(actual9));
+            Assert.True(contains.Match(actual10));
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameContains", GetSource(path), out var context);
@@ -964,6 +974,7 @@ namespace PSRule
             var actual7 = GetObject((name: "value", value: "BCD"));
             var actual8 = GetObject((name: "value", value: "abc"), (name: "OtherValue", value: TestEnumValue.All));
             var actual9 = GetObject((name: "value", value: "hij"), (name: "OtherValue", value: TestEnumValue.None));
+            var actual10 = GetObject((name: "value", value: new string[] { "hij", "abc" }));
 
             Assert.False(notContains.Match(actual1));
             Assert.False(notContains.Match(actual2));
@@ -974,6 +985,7 @@ namespace PSRule
             Assert.False(notContains.Match(actual7));
             Assert.False(notContains.Match(actual8));
             Assert.True(notContains.Match(actual9));
+            Assert.False(notContains.Match(actual10));
         }
 
         [Theory]
@@ -1712,27 +1724,41 @@ namespace PSRule
             );
 
             var equals = GetSelectorVisitor($"{type}ScopeEquals", GetSource(path), out var context);
-            context.EnterTargetObject(new TargetObject(testObject, scope: "/scope1"));
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope1" }));
             Assert.True(equals.Match(testObject));
 
-            context.EnterTargetObject(new TargetObject(testObject, scope: "/scope2"));
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope2" }));
             Assert.False(equals.Match(testObject));
 
             context.EnterTargetObject(new TargetObject(testObject));
             Assert.False(equals.Match(testObject));
 
             var startsWith = GetSelectorVisitor($"{type}ScopeStartsWith", GetSource(path), out context);
-            context.EnterTargetObject(new TargetObject(testObject, scope: "/scope1/"));
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope1/" }));
             Assert.True(startsWith.Match(testObject));
 
-            context.EnterTargetObject(new TargetObject(testObject, scope: "/scope2/"));
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope2/" }));
             Assert.True(startsWith.Match(testObject));
 
-            context.EnterTargetObject(new TargetObject(testObject, scope: "/scope2"));
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope2" }));
             Assert.False(startsWith.Match(testObject));
 
             context.EnterTargetObject(new TargetObject(testObject));
             Assert.False(startsWith.Match(testObject));
+
+            var hasValueFalse = GetSelectorVisitor($"{type}ScopeHasValueFalse", GetSource(path), out context);
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope1" }));
+            Assert.False(hasValueFalse.Match(testObject));
+
+            context.EnterTargetObject(new TargetObject(testObject));
+            Assert.True(hasValueFalse.Match(testObject));
+
+            var hasValueTrue = GetSelectorVisitor($"{type}ScopeHasValueTrue", GetSource(path), out context);
+            context.EnterTargetObject(new TargetObject(testObject, scope: new string[] { "/scope1" }));
+            Assert.True(hasValueTrue.Match(testObject));
+
+            context.EnterTargetObject(new TargetObject(testObject));
+            Assert.False(hasValueTrue.Match(testObject));
         }
 
         #endregion Properties

--- a/tests/PSRule.Tests/Selectors.Rule.jsonc
+++ b/tests/PSRule.Tests/Selectors.Rule.jsonc
@@ -1781,7 +1781,9 @@
     "spec": {
       "if": {
         "scope": ".",
-        "equals": "/scope1"
+        "equals": [
+          "/scope1"
+        ]
       }
     }
   },
@@ -1799,6 +1801,34 @@
           "/scope1/",
           "/scope2/"
         ]
+      }
+    }
+  },
+  {
+    // Synopsis: Test scope property with hasValue.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonScopeHasValueFalse"
+    },
+    "spec": {
+      "if": {
+        "scope": ".",
+        "hasValue": false
+      }
+    }
+  },
+  {
+    // Synopsis: Test scope property with hasValue.
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonScopeHasValueTrue"
+    },
+    "spec": {
+      "if": {
+        "scope": ".",
+        "hasValue": true
       }
     }
   },

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -1268,7 +1268,8 @@ metadata:
 spec:
   if:
     scope: .
-    equals: /scope1
+    equals:
+    - /scope1
 
 ---
 # Synopsis: Test scope property with startsWith.
@@ -1282,6 +1283,28 @@ spec:
     startsWith:
     - /scope1/
     - /scope2/
+
+---
+# Synopsis: Test scope property with hasValue.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlScopeHasValueFalse
+spec:
+  if:
+    scope: .
+    hasValue: false
+
+---
+# Synopsis: Test scope property with hasValue.
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlScopeHasValueTrue
+spec:
+  if:
+    scope: .
+    hasValue: true
 
 ---
 # Synopsis: Test comparison with apiVersion.


### PR DESCRIPTION
## PR Summary

- Added support for `hasValue` expression with `scope`.
- Return target object scope as an array.
- Improve support of string comparisons to support an array of strings.

Fixes #1382 
Fixes #1383 
Fixes #1384 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
