### PR TITLE
Added fixes for link and sub-selectors #1393 #1394

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,14 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.7.0-B0097:
+
+- Bug fixes:
+  - Fixed null reference for link property by @BernieWhite.
+    [#1393](https://github.com/microsoft/PSRule/issues/1393)
+  - Fixed reason are emitted for pre-condition sub-selectors by @BernieWhite.
+    [#1394](https://github.com/microsoft/PSRule/issues/1394)
+
 ## v2.7.0-B0097 (pre-release)
 
 What's changed since pre-release v2.7.0-B0070:

--- a/src/PSRule/Definitions/Expressions/ExpressionContext.cs
+++ b/src/PSRule/Definitions/Expressions/ExpressionContext.cs
@@ -80,7 +80,7 @@ namespace PSRule.Definitions.Expressions
 
         public void Reason(IOperand operand, string text, params object[] args)
         {
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text) || !RunspaceContext.CurrentThread.IsScope(RunspaceScope.Rule))
                 return;
 
             _Reason ??= new List<ResultReason>();
@@ -89,7 +89,7 @@ namespace PSRule.Definitions.Expressions
 
         public void Reason(string text, params object[] args)
         {
-            if (string.IsNullOrEmpty(text))
+            if (string.IsNullOrEmpty(text) || !RunspaceContext.CurrentThread.IsScope(RunspaceScope.Rule))
                 return;
 
             _Reason ??= new List<ResultReason>();

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -205,11 +205,20 @@ namespace PSRule.Definitions.Expressions
         {
             return (context, o) =>
             {
-                // Evalute sub-selector pre-condition
-                if (!AcceptsSubselector(context, subselector, o))
+                try
                 {
-                    context.Debug(PSRuleResources.DebugTargetSubselectorMismatch);
-                    return null;
+                    context.PushScope(RunspaceScope.Precondition);
+
+                    // Evalute sub-selector pre-condition
+                    if (!AcceptsSubselector(context, subselector, o))
+                    {
+                        context.Debug(PSRuleResources.DebugTargetSubselectorMismatch);
+                        return null;
+                    }
+                }
+                finally
+                {
+                    context.PopScope(RunspaceScope.Precondition);
                 }
                 return fn(context, o);
             };

--- a/src/PSRule/Rules/RuleHelpInfo.cs
+++ b/src/PSRule/Rules/RuleHelpInfo.cs
@@ -85,7 +85,7 @@ namespace PSRule.Rules
         /// <param name="url">A URL to the online help location.</param>
         internal static void SetOnlineHelpUrl(this IRuleHelpInfoV2 info, string url)
         {
-            if (info == null || info.Annotations == null) return;
+            if (info == null || info.Annotations == null || string.IsNullOrEmpty(url)) return;
             info.Annotations[ONLINE_HELP_LINK_ANNOTATION] = url;
         }
     }

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -576,11 +576,11 @@ namespace PSRule.Runtime
         {
             // TODO: Look at scope caching, and a scope stack.
 
-            if (!source.Exists())
-                throw new FileNotFoundException(PSRuleResources.ScriptNotFound, source.Path);
-
             if (Source != null && Source.File == source)
                 return Source;
+
+            if (!source.Exists())
+                throw new FileNotFoundException(PSRuleResources.ScriptNotFound, source.Path);
 
             _LanguageScopes.UseScope(source.Module);
 


### PR DESCRIPTION
## PR Summary

- Fixed null reference for link property.
- Fixed reason are emitted for pre-condition sub-selectors.

Fixes #1393 
Fixes #1394 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
