### PR TITLE
Logging output improvements #1456 #1432

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 See [upgrade notes][1] for helpful information when upgrading from previous versions.
 
-  [1]: https://microsoft.github.io/PSRule/latest/upgrade-notes/
+  [1]: https://aka.ms/ps-rule/upgrade
 
 ## Current release
 

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,14 +6,14 @@ discussion: false
 
 See [upgrade notes][1] for helpful information when upgrading from previous versions.
 
-  [1]: https://microsoft.github.io/PSRule/latest/upgrade-notes/
+  [1]: https://aka.ms/ps-rule/upgrade
 
 **Important notes**:
 
 - Several properties of rule and language block elements will be removed from v3.
   See [deprecations][2] for details.
 
-  [2]: https://microsoft.github.io/PSRule/latest/deprecations/#deprecations-for-v3
+  [2]: https://aka.ms/ps-rule/deprecations#deprecations-for-v3
 
 **Experimental features**:
 
@@ -33,6 +33,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since v2.7.0:
 
 - General improvements:
+  - **Important change**: Replaced `SuppressedRuleWarning` execution option with `RuleSuppressed` by @BernieWhite.
+    [#1456](https://github.com/microsoft/PSRule/issues/1456)
+    - Improved options for output of suppressed rules with `RuleSuppressed` option.
+    - Deprecated `SuppressedRuleWarning` option, which will be removed in v3.
+  - Added support for logging excluded rules by @BernieWhite.
+    [#1432](https://github.com/microsoft/PSRule/issues/1432)
   - Added additional options to schema for PSRule for Azure by @BernieWhite.
     [#1446](https://github.com/microsoft/PSRule/issues/1446)
   - Improved error message for failing to read options file by @BernieWhite.

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -22,18 +22,19 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-AliasReferenceWarning <Boolean>] [-DuplicateResourceId <ExecutionActionPreference>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-IncludeModule <String[]>]
- [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>]
- [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
- [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
- [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-InconclusiveWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>]
+ [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
+ [-SuppressionGroupExpired <ExecutionActionPreference>] [-ExecutionRuleExcluded <ExecutionActionPreference>]
+ [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
+ [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
+ [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
+ [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -45,18 +46,19 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>]
  [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>]
  [-AliasReferenceWarning <Boolean>] [-DuplicateResourceId <ExecutionActionPreference>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-IncludeModule <String[]>]
- [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>]
- [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
- [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
- [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-InconclusiveWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>]
+ [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
+ [-SuppressionGroupExpired <ExecutionActionPreference>] [-ExecutionRuleExcluded <ExecutionActionPreference>]
+ [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
+ [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
+ [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
+ [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -67,18 +69,19 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-BindingField <Hashtable>] [-BindingNameSeparator <String>] [-BindingPreferTargetInfo <Boolean>]
  [-TargetName <String[]>] [-TargetType <String[]>] [-BindingUseQualifiedName <Boolean>]
  [-Convention <String[]>] [-AliasReferenceWarning <Boolean>] [-DuplicateResourceId <ExecutionActionPreference>]
- [-InconclusiveWarning <Boolean>] [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
- [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-IncludeModule <String[]>]
- [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>]
- [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
- [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
- [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
- [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
- [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
- [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
- [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
- [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-InconclusiveWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>]
+ [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
+ [-SuppressionGroupExpired <ExecutionActionPreference>] [-ExecutionRuleExcluded <ExecutionActionPreference>]
+ [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
+ [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
+ [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
+ [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
+ [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
+ [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
+ [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
+ [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
+ [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
+ [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -1029,6 +1032,57 @@ The `Execution.InitialSessionState` option determines how the initial session st
 Type: SessionState
 Parameter Sets: (All)
 Aliases: ExecutionInitialSessionState
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionRuleExcluded
+
+Sets the option `Execution.RuleExcluded`.
+The `Execution.RuleExcluded` option determines how to handle excluded rules.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionRuleSuppressed
+
+Sets the option `Execution.RuleSuppressed`.
+The `Execution.RuleSuppressed` option determines how to handle suppressed rules.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SuppressionGroupExpired
+
+Sets the option `Execution.SuppressionGroupExpired`.
+The `Execution.SuppressionGroupExpired` option determines how to handle expired suppression groups.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases: ExecutionSuppressionGroupExpired
 
 Required: False
 Position: Named

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -19,18 +19,19 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-BindingPreferTargetInfo <Boolean>] [-TargetName <String[]>] [-TargetType <String[]>]
  [-BindingUseQualifiedName <Boolean>] [-Convention <String[]>] [-AliasReferenceWarning <Boolean>]
  [-DuplicateResourceId <ExecutionActionPreference>] [-InconclusiveWarning <Boolean>]
- [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>] [-InvariantCultureWarning <Boolean>]
- [-InitialSessionState <SessionState>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
- [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreObjectSource <Boolean>]
- [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
- [-InputPathIgnore <String[]>] [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
- [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-NotProcessedWarning <Boolean>]
+ [-SuppressedRuleWarning <Boolean>] [-SuppressionGroupExpired <ExecutionActionPreference>]
+ [-ExecutionRuleExcluded <ExecutionActionPreference>] [-ExecutionRuleSuppressed <ExecutionActionPreference>]
+ [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
+ [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
+ [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
+ [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
+ [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -946,6 +947,57 @@ The `Execution.InitialSessionState` option determines how the initial session st
 Type: SessionState
 Parameter Sets: (All)
 Aliases: ExecutionInitialSessionState
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionRuleExcluded
+
+Sets the option `Execution.RuleExcluded`.
+The `Execution.RuleExcluded` option determines how to handle excluded rules.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionRuleSuppressed
+
+Sets the option `Execution.RuleSuppressed`.
+The `Execution.RuleSuppressed` option determines how to handle suppressed rules.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SuppressionGroupExpired
+
+Sets the option `Execution.SuppressionGroupExpired`.
+The `Execution.SuppressionGroupExpired` option determines how to handle expired suppression groups.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases: ExecutionSuppressionGroupExpired
 
 Required: False
 Position: Named

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -1030,6 +1030,9 @@ variables:
 
 ### Execution.SuppressedRuleWarning
 
+This option has been deprecated and will be removed from v3 in favor of `ruleSuppressed`.
+Use `ruleSuppressed` instead.
+
 When evaluating rules, it is possible to output suppressed rules as warnings.
 
 Suppressed rules will:
@@ -1131,6 +1134,120 @@ env:
 # Azure Pipelines: Using environment variable
 variables:
 - name: PSRULE_EXECUTION_SUPPRESSIONGROUPEXPIRED
+  value: Error
+```
+
+### Execution.RuleExcluded
+
+Determines how to handle excluded rules.
+Regardless of the value, excluded rules are ignored.
+By defaut, a rule is excluded silently, however this behaviour can be modified by this option.
+
+The following preferences are available:
+
+- `None` (0) - No preference.
+  Inherits the default of `Ignore`.
+- `Ignore` (1) - Continue to execute silently.
+  This is the default.
+- `Warn` (2) - Continue to execute but log a warning.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+```powershell
+# PowerShell: Using the ExecutionRuleExcluded parameter
+$option = New-PSRuleOption -ExecutionRuleExcluded 'Warn';
+```
+
+```powershell
+# PowerShell: Using the Execution.RuleExcluded hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.RuleExcluded' = 'Warn' };
+```
+
+```powershell
+# PowerShell: Using the ExecutionRuleExcluded parameter to set YAML
+Set-PSRuleOption -ExecutionRuleExcluded 'Warn';
+```
+
+```yaml
+# YAML: Using the execution/ruleExcluded property
+execution:
+  ruleExcluded: Warn
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_RULEEXCLUDED=Warn
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_RULEEXCLUDED: Warn
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_RULEEXCLUDED
+  value: Warn
+```
+
+### Execution.RuleSuppressed
+
+Determines how to handle suppressed rules.
+Regardless of the value, a suppressed rule is ignored.
+By defaut, a warning is generated, however this behaviour can be modified by this option.
+
+This option replaces `suppressedRuleWarning`.
+You do not need to configure both options.
+If `suppressedRuleWarning` is configured, it will override `ruleSuppressed` with `Warn` or `Ignore` until removal in PSRule v3.
+
+The following preferences are available:
+
+- `None` (0) - No preference.
+  Inherits the default of `Warn`.
+- `Ignore` (1) - Continue to execute silently.
+- `Warn` (2) - Continue to execute but log a warning.
+  This is the default.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+```powershell
+# PowerShell: Using the ExecutionRuleSuppressed parameter
+$option = New-PSRuleOption -ExecutionRuleSuppressed 'Error';
+```
+
+```powershell
+# PowerShell: Using the Execution.RuleSuppressed hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.RuleSuppressed' = 'Error' };
+```
+
+```powershell
+# PowerShell: Using the ExecutionRuleSuppressed parameter to set YAML
+Set-PSRuleOption -ExecutionRuleSuppressed 'Error';
+```
+
+```yaml
+# YAML: Using the execution/ruleSuppressed property
+execution:
+  ruleSuppressed: Error
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_RULESUPPRESSED=Error
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_RULESUPPRESSED: Error
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_RULESUPPRESSED
   value: Error
 ```
 
@@ -3210,7 +3327,7 @@ rule:
 
 ## NOTE
 
-An online version of this document is available at https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/.
+An online version of this document is available at <https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/>.
 
 ## SEE ALSO
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -7,6 +7,30 @@ discussion: false
 
 ## Deprecations for v3
 
+### Execution options
+
+PSRule provides a number of execution options that control logging of certain events.
+In many cases these options turn a warning on or off.
+
+These options are deprecated but replaced to provide more choice to when configuring logging options.
+Now you can configure the following:
+
+- `Ignore` (1) - Continue to execute silently.
+- `Warn` (2) - Continue to execute but log a warning.
+  This is the default.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+The following execution options have been deprecated and will be removed from _v3_.
+
+- `Execution.SuppressedRuleWarning` is replaced with `Execution.RuleSuppressed`.
+  Set `Execution.RuleSuppressed` to `Warn` to log a warning from _v2.8.0_.
+  If both options are set, `Execution.SuppressedRuleWarning` takes precedence until _v3_.
+
+!!! Tip
+    You do not need to configure both options.
+    If you have the deprecated option configured, switch to the new option.
+
 ### Rule output object
 
 Several properties of the rule object have been renamed to improve consistency with other objects.

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -158,7 +158,7 @@ Rules sources in the current working directory are only included if `-Path .` or
 
 The old behavior:
 
-```powershell
+```powershell title="PowerShell"
 Set-Location docs\scenarios\azure-resources
 Get-PSRule
 
@@ -174,7 +174,7 @@ storageAccounts.UseEncryption                                  Use at-rest stora
 
 The new behavior:
 
-```powershell
+```powershell title="PowerShell"
 Set-Location docs\scenarios\azure-resources
 Get-PSRule
 
@@ -217,7 +217,7 @@ Detect uses the following logic:
 To force usage of the `Client` output style set the `Output.Style` option.
 For example:
 
-```yaml
+```yaml title="ps-rule.yaml"
 # YAML: Using the output/style property
 output:
   style: Client
@@ -228,13 +228,13 @@ output:
 export PSRULE_OUTPUT_STYLE=Client
 ```
 
-```yaml
+```yaml title="GitHub Actions"
 # GitHub Actions: Using environment variable
 env:
   PSRULE_OUTPUT_STYLE: Client
 ```
 
-```yaml
+```yaml title="Azure Pipelines"
 # Azure Pipelines: Using environment variable
 variables:
 - name: PSRULE_OUTPUT_STYLE
@@ -255,7 +255,7 @@ Previously in PSRule _v0.22.0_ and prior the `$Rule` automatic variable had the 
 
 For example:
 
-```powershell
+```powershell title="PowerShell rules"
 Rule 'Rule1' {
     $Rule.TargetName -eq 'Name1';
     $Rule.TargetType -eq '.json';
@@ -269,7 +269,7 @@ Rules referencing the deprecated properties of `$Rule` must be updated.
 
 For example:
 
-```powershell
+```powershell title="PowerShell rules"
 Rule 'Rule1' {
     $PSRule.TargetName -eq 'Name1';
     $PSRule.TargetType -eq '.json';

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -346,16 +346,43 @@
         },
         "suppressedRuleWarning": {
           "type": "boolean",
-          "title": "Warn on suppressed rules",
-          "description": "Enable or disable warnings for suppressed rules. The default is true.",
-          "markdownDescription": "Enable or disable warnings for suppressed rules. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionsuppressedrulewarning)",
-          "default": true
+          "title": "Warn on suppressed rules | DEPRECATED",
+          "description": "This option has been deprecated and will be removed from v3 in favor of ruleSuppressed. Enable or disable warnings for suppressed rules. The default is true.",
+          "markdownDescription": "This option has been deprecated and will be removed from v3 in favor of `ruleSuppressed`.\n\nEnable or disable warnings for suppressed rules. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionsuppressedrulewarning)",
+          "default": true,
+          "deprecated": true
         },
         "suppressionGroupExpired": {
           "type": "string",
           "title": "Expired suppression groups",
           "description": "Determines how to handle expired suppression groups. Regardless of the value, an expired suppression group will be ignored. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed.",
           "markdownDescription": "Determines how to handle expired suppression groups.\n\nRegardless of the value, an expired suppression group will be ignored. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionsuppressiongroupexpired)",
+          "enum": [
+            "Ignore",
+            "Warn",
+            "Error",
+            "Debug"
+          ],
+          "default": "Warn"
+        },
+        "ruleExcluded": {
+          "type": "string",
+          "title": "Rule excluded",
+          "description": "Determines how to handle excluded rules. Regardless of the value, excluded rules are ignored. By default, rules are excluded silently. When set to Error, an error is thrown. When set to Warn, a warning is generated. When set to Debug, a message is written to the debug log.",
+          "markdownDescription": "Determines how to handle excluded rules.\n\nRegardless of the value, excluded rules are ignored. By default, rules are excluded silently.\n\n- When set to `Error`, an error is thrown.\n- When set to `Warn`, a warning is generated.\n- When set to `Debug`, a message is written to the debug log.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionruleexecluded)",
+          "enum": [
+            "Ignore",
+            "Warn",
+            "Error",
+            "Debug"
+          ],
+          "default": "Ignore"
+        },
+        "ruleSuppressed": {
+          "type": "string",
+          "title": "Rule suppressed",
+          "description": "Determines how to handle suppressed rules. Regardless of the value, a suppressed rule is ignored. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed. This option replaces suppressedRuleWarning. You do not need to configure both options. If suppressedRuleWarning is configured, it will override ruleSuppressed with Warn or Ignore until removal in PSRule v3.",
+          "markdownDescription": "Determines how to handle suppressed rules.\n\nRegardless of the value, a suppressed rule is ignored. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\nThis option replaces `suppressedRuleWarning`. You do not need to configure both options. If `suppressedRuleWarning` is configured, it will override `ruleSuppressed` with `Warn` or `Ignore` until removal in PSRule v3.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionrulesuppressed)",
           "enum": [
             "Ignore",
             "Warn",

--- a/src/PSRule/Common/RunspaceContextDiagnosticExtensions.cs
+++ b/src/PSRule/Common/RunspaceContextDiagnosticExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using PSRule.Configuration;
 using PSRule.Definitions;
+using PSRule.Definitions.SuppressionGroups;
 using PSRule.Pipeline;
 using PSRule.Resources;
 using PSRule.Runtime;
@@ -40,6 +41,17 @@ namespace PSRule
             context.Writer.WriteWarning(PSRuleResources.RuleNotFound);
         }
 
+        /// <summary>
+        /// The option '{0}' is deprecated and will be removed with PSRule v3. See http://aka.ms/ps-rule/deprecations for more detail.
+        /// </summary>
+        internal static void WarnDeprecatedOption(this RunspaceContext context, string option)
+        {
+            if (context.Writer == null || !context.Writer.ShouldWriteWarning())
+                return;
+
+            context.Writer.WriteWarning(PSRuleResources.DeprecatedOption, option);
+        }
+
         internal static void WarnDuplicateRuleName(this RunspaceContext context, string ruleName)
         {
             if (context == null || context.Writer == null || !context.Writer.ShouldWriteWarning())
@@ -64,6 +76,15 @@ namespace PSRule
 
             var action = context.Pipeline.Option.Execution.SuppressionGroupExpired.GetValueOrDefault(ExecutionOption.Default.SuppressionGroupExpired.Value);
             context.Throw(action, PSRuleResources.SuppressionGroupExpired, suppressionGroupId.Value);
+        }
+
+        internal static void RuleExcluded(this RunspaceContext context, ResourceId ruleId)
+        {
+            if (context == null || context.Pipeline == null)
+                return;
+
+            var action = context.Pipeline.Option.Execution.RuleExcluded.GetValueOrDefault(ExecutionOption.Default.RuleExcluded.Value);
+            context.Throw(action, PSRuleResources.SuppressionGroupExpired, ruleId.Value);
         }
 
         internal static void Throw(this RunspaceContext context, ExecutionActionPreference action, string message, params object[] args)

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -18,12 +18,13 @@ namespace PSRule.Configuration
         private const LanguageMode DEFAULT_LANGUAGEMODE = Configuration.LanguageMode.FullLanguage;
         private const bool DEFAULT_INCONCLUSIVEWARNING = true;
         private const bool DEFAULT_NOTPROCESSEDWARNING = true;
-        private const bool DEFAULT_SUPPRESSEDRULEWARNING = true;
         private const bool DEFAULT_ALIASREFERENCEWARNING = true;
         private const bool DEFAULT_INVARIANTCULTUREWARNING = true;
         private const ExecutionActionPreference DEFAULT_DUPLICATERESOURCEID = ExecutionActionPreference.Error;
         private const SessionState DEFAULT_INITIALSESSIONSTATE = SessionState.BuiltIn;
         private const ExecutionActionPreference DEFAULT_SUPPRESSIONGROUPEXPIRED = ExecutionActionPreference.Warn;
+        private const ExecutionActionPreference DEFAULT_RULEEXCLUDED = ExecutionActionPreference.Ignore;
+        private const ExecutionActionPreference DEFAULT_RULESUPPRESSED = ExecutionActionPreference.Warn;
 
         internal static readonly ExecutionOption Default = new()
         {
@@ -34,8 +35,9 @@ namespace PSRule.Configuration
             InvariantCultureWarning = DEFAULT_INVARIANTCULTUREWARNING,
             InitialSessionState = DEFAULT_INITIALSESSIONSTATE,
             NotProcessedWarning = DEFAULT_NOTPROCESSEDWARNING,
-            SuppressedRuleWarning = DEFAULT_SUPPRESSEDRULEWARNING,
             SuppressionGroupExpired = DEFAULT_SUPPRESSIONGROUPEXPIRED,
+            RuleExcluded = DEFAULT_RULEEXCLUDED,
+            RuleSuppressed = DEFAULT_RULESUPPRESSED,
         };
 
         /// <summary>
@@ -50,8 +52,12 @@ namespace PSRule.Configuration
             InvariantCultureWarning = null;
             InitialSessionState = null;
             NotProcessedWarning = null;
+#pragma warning disable CS0612 // Type or member is obsolete
             SuppressedRuleWarning = null;
+#pragma warning restore CS0612 // Type or member is obsolete
             SuppressionGroupExpired = null;
+            RuleExcluded = null;
+            RuleSuppressed = null;
         }
 
         /// <summary>
@@ -70,8 +76,12 @@ namespace PSRule.Configuration
             InvariantCultureWarning = option.InvariantCultureWarning;
             InitialSessionState = option.InitialSessionState;
             NotProcessedWarning = option.NotProcessedWarning;
+#pragma warning disable CS0612 // Type or member is obsolete
             SuppressedRuleWarning = option.SuppressedRuleWarning;
+#pragma warning restore CS0612 // Type or member is obsolete
             SuppressionGroupExpired = option.SuppressionGroupExpired;
+            RuleExcluded = option.RuleExcluded;
+            RuleSuppressed = option.RuleSuppressed;
         }
 
         /// <inheritdoc/>
@@ -83,6 +93,7 @@ namespace PSRule.Configuration
         /// <inheritdoc/>
         public bool Equals(ExecutionOption other)
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             return other != null &&
                 AliasReferenceWarning == other.AliasReferenceWarning &&
                 DuplicateResourceId == other.DuplicateResourceId &&
@@ -91,8 +102,11 @@ namespace PSRule.Configuration
                 InvariantCultureWarning == other.InvariantCultureWarning &&
                 InitialSessionState == other.InitialSessionState &&
                 NotProcessedWarning == other.NotProcessedWarning &&
-                SuppressedRuleWarning == other.NotProcessedWarning &&
-                SuppressionGroupExpired == other.SuppressionGroupExpired;
+                SuppressedRuleWarning == other.SuppressedRuleWarning &&
+                SuppressionGroupExpired == other.SuppressionGroupExpired &&
+                RuleExcluded == other.RuleExcluded &&
+                RuleSuppressed == other.RuleSuppressed;
+#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         /// <inheritdoc/>
@@ -108,8 +122,12 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (InvariantCultureWarning.HasValue ? InvariantCultureWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (InitialSessionState.HasValue ? InitialSessionState.Value.GetHashCode() : 0);
                 hash = hash * 23 + (NotProcessedWarning.HasValue ? NotProcessedWarning.Value.GetHashCode() : 0);
+#pragma warning disable CS0612 // Type or member is obsolete
                 hash = hash * 23 + (SuppressedRuleWarning.HasValue ? SuppressedRuleWarning.Value.GetHashCode() : 0);
+#pragma warning restore CS0612 // Type or member is obsolete
                 hash = hash * 23 + (SuppressionGroupExpired.HasValue ? SuppressionGroupExpired.Value.GetHashCode() : 0);
+                hash = hash * 23 + (RuleExcluded.HasValue ? RuleExcluded.Value.GetHashCode() : 0);
+                hash = hash * 23 + (RuleSuppressed.HasValue ? RuleSuppressed.Value.GetHashCode() : 0);
                 return hash;
             }
         }
@@ -120,6 +138,7 @@ namespace PSRule.Configuration
         /// </summary>
         internal static ExecutionOption Combine(ExecutionOption o1, ExecutionOption o2)
         {
+#pragma warning disable CS0612 // Type or member is obsolete
             var result = new ExecutionOption(o1)
             {
                 AliasReferenceWarning = o1.AliasReferenceWarning ?? o2.AliasReferenceWarning,
@@ -130,7 +149,11 @@ namespace PSRule.Configuration
                 SuppressedRuleWarning = o1.SuppressedRuleWarning ?? o2.SuppressedRuleWarning,
                 InvariantCultureWarning = o1.InvariantCultureWarning ?? o2.InvariantCultureWarning,
                 InitialSessionState = o1.InitialSessionState ?? o2.InitialSessionState,
+                SuppressionGroupExpired = o1.SuppressionGroupExpired ?? o2.SuppressionGroupExpired,
+                RuleExcluded = o1.RuleExcluded ?? o2.RuleExcluded,
+                RuleSuppressed = o1.RuleSuppressed ?? o2.RuleSuppressed,
             };
+#pragma warning restore CS0612 // Type or member is obsolete
             return result;
         }
 
@@ -196,8 +219,33 @@ namespace PSRule.Configuration
         /// <summary>
         /// Determines if a warning is raised when a rule is suppressed.
         /// </summary>
-        [DefaultValue(null)]
+        [DefaultValue(null), Obsolete("Use RuleSuppressed instead. See http://aka.ms/ps-rule/deprecations for more detail.")]
         public bool? SuppressedRuleWarning { get; set; }
+
+        /// <summary>
+        /// Determines how to handle rules that are excluded.
+        /// By default, a excluded rules do not generated any output.
+        /// When set to Error, an error is thrown.
+        /// When set to Warn, a warning is generated.
+        /// When set to Debug, a message is written to the debug log.
+        /// </summary>
+        [DefaultValue(null)]
+        public ExecutionActionPreference? RuleExcluded { get; set; }
+
+        /// <summary>
+        /// Determines how to handle rules that are suppressed.
+        /// This option replaces <seealso cref="SuppressedRuleWarning"/>.
+        /// By default, a warning is generated.
+        /// When set to Error, an error is thrown.
+        /// When set to Debug, a message is written to the debug log.
+        /// When set to Ignore, no output will be displayed.
+        /// </summary>
+        /// <remarks>
+        /// If <seealso cref="SuppressedRuleWarning"/> is <c>true</c> this option will be overridden to <c>Warn</c>.
+        /// If <seealso cref="SuppressedRuleWarning"/> is <c>false</c> this option will be overridden to <c>Ignore</c>.
+        /// </remarks>
+        [DefaultValue(null)]
+        public ExecutionActionPreference? RuleSuppressed { get; set; }
 
         internal void Load(EnvironmentHelper env)
         {
@@ -223,10 +271,18 @@ namespace PSRule.Configuration
                 NotProcessedWarning = bvalue;
 
             if (env.TryBool("PSRULE_EXECUTION_SUPPRESSEDRULEWARNING", out bvalue))
+#pragma warning disable CS0612 // Type or member is obsolete
                 SuppressedRuleWarning = bvalue;
+#pragma warning restore CS0612 // Type or member is obsolete
 
             if (env.TryEnum("PSRULE_EXECUTION_SUPPRESSIONGROUPEXPIRED", out ExecutionActionPreference suppressionGroupExpired))
                 SuppressionGroupExpired = suppressionGroupExpired;
+
+            if (env.TryEnum("PSRULE_EXECUTION_RULEEXCLUDED", out ExecutionActionPreference ruleExcluded))
+                RuleExcluded = ruleExcluded;
+
+            if (env.TryEnum("PSRULE_EXECUTION_RULESUPPRESSED", out ExecutionActionPreference ruleSuppressed))
+                RuleSuppressed = ruleSuppressed;
         }
 
         internal void Load(Dictionary<string, object> index)
@@ -253,10 +309,18 @@ namespace PSRule.Configuration
                 NotProcessedWarning = bvalue;
 
             if (index.TryPopBool("Execution.SuppressedRuleWarning", out bvalue))
+#pragma warning disable CS0612 // Type or member is obsolete
                 SuppressedRuleWarning = bvalue;
+#pragma warning restore CS0612 // Type or member is obsolete
 
             if (index.TryPopEnum("Execution.SuppressionGroupExpired", out ExecutionActionPreference suppressionGroupExpired))
                 SuppressionGroupExpired = suppressionGroupExpired;
+
+            if (index.TryPopEnum("Execution.RuleExcluded", out ExecutionActionPreference ruleExcluded))
+                RuleExcluded = ruleExcluded;
+
+            if (index.TryPopEnum("Execution.RuleSuppressed", out ExecutionActionPreference ruleSuppressed))
+                RuleSuppressed = ruleSuppressed;
         }
     }
 }

--- a/src/PSRule/Definitions/DependencyGraphBuilder.cs
+++ b/src/PSRule/Definitions/DependencyGraphBuilder.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using PSRule.Pipeline;
 using PSRule.Resources;
+using PSRule.Rules;
 using PSRule.Runtime;
 
 namespace PSRule.Definitions
@@ -40,6 +41,8 @@ namespace PSRule.Definitions
 
                 if (filter == null || filter(item))
                     Include(index, item, parentId: null);
+                else if (item is RuleBlock)
+                    _Context.RuleExcluded(item.Id);
             }
         }
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -106,7 +106,7 @@ function Invoke-PSRule {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -264,7 +264,7 @@ function Test-PSRuleTarget {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -383,7 +383,7 @@ function Get-PSRuleTarget {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         $isDeviceGuard = IsDeviceGuardEnabled;
 
@@ -537,7 +537,7 @@ function Assert-PSRule {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -688,7 +688,7 @@ function Get-PSRule {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -808,7 +808,7 @@ function Get-PSRuleBaseline {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -916,7 +916,7 @@ function Export-PSRuleBaseline {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -1022,7 +1022,7 @@ function Get-PSRuleHelp {
         }
 
         # Get an options object
-        $Option = New-PSRuleOption @optionParams;
+        $Option = New-PSRuleOption @optionParams -WarningAction SilentlyContinue;
 
         # Discover scripts in the specified paths
         $sourceParams = @{ };
@@ -1197,12 +1197,21 @@ function New-PSRuleOption {
         # Sets the Execution.SuppressedRuleWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionSuppressedRuleWarning')]
+        [System.Obsolete('Use ExecutionRuleSuppressed instead. See http://aka.ms/ps-rule/deprecations for more detail.')]
         [System.Boolean]$SuppressedRuleWarning = $True,
 
         # Sets the Execution.SuppressionGroupExpired option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionSuppressionGroupExpired')]
         [PSRule.Configuration.ExecutionActionPreference]$SuppressionGroupExpired = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.RuleExcluded option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleExcluded = [PSRule.Configuration.ExecutionActionPreference]::Ignore,
+
+        # Sets the Execution.RuleSuppressed option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleSuppressed = [PSRule.Configuration.ExecutionActionPreference]::Warn,
 
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
@@ -1498,12 +1507,21 @@ function Set-PSRuleOption {
         # Sets the Execution.SuppressedRuleWarning option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionSuppressedRuleWarning')]
+        [System.Obsolete('Use ExecutionRuleSuppressed instead. See http://aka.ms/ps-rule/deprecations for more detail.')]
         [System.Boolean]$SuppressedRuleWarning = $True,
 
         # Sets the Execution.SuppressionGroupExpired option
         [Parameter(Mandatory = $False)]
         [Alias('ExecutionSuppressionGroupExpired')]
         [PSRule.Configuration.ExecutionActionPreference]$SuppressionGroupExpired = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.RuleExcluded option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleExcluded = [PSRule.Configuration.ExecutionActionPreference]::Ignore,
+
+        # Sets the Execution.RuleSuppressed option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleSuppressed = [PSRule.Configuration.ExecutionActionPreference]::Warn,
 
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
@@ -2253,6 +2271,14 @@ function SetOptions {
         [Alias('ExecutionSuppressionGroupExpired')]
         [PSRule.Configuration.ExecutionActionPreference]$SuppressionGroupExpired = [PSRule.Configuration.ExecutionActionPreference]::Warn,
 
+        # Sets the Execution.RuleExcluded option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleExcluded = [PSRule.Configuration.ExecutionActionPreference]::Ignore,
+
+        # Sets the Execution.RuleSuppressed option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleSuppressed = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -2463,6 +2489,16 @@ function SetOptions {
         # Sets option Execution.SuppressionGroupExpired
         if ($PSBoundParameters.ContainsKey('SuppressionGroupExpired')) {
             $Option.Execution.SuppressionGroupExpired = $SuppressionGroupExpired;
+        }
+
+        # Sets option Execution.RuleExcluded
+        if ($PSBoundParameters.ContainsKey('ExecutionRuleExcluded')) {
+            $Option.Execution.RuleExcluded = $ExecutionRuleExcluded;
+        }
+
+        # Sets option Execution.RuleSuppressed
+        if ($PSBoundParameters.ContainsKey('ExecutionRuleSuppressed')) {
+            $Option.Execution.RuleSuppressed = $ExecutionRuleSuppressed;
         }
 
         # Sets option Include.Module

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -36,6 +36,11 @@ namespace PSRule.Pipeline
             if (RuleCount == 0)
                 Context.WarnRuleNotFound();
 
+#pragma warning disable CS0612 // Type or member is obsolete
+            if (context.Option.Execution.SuppressedRuleWarning.HasValue)
+                Context.WarnDeprecatedOption("Execution.SuppressedRuleWarning");
+#pragma warning restore CS0612 // Type or member is obsolete
+
             _Outcome = outcome;
             _IsSummary = context.Option.Output.As.Value == ResultFormat.Summary;
             _Summary = _IsSummary ? new Dictionary<string, RuleSummaryRecord>() : null;
@@ -119,14 +124,14 @@ namespace PSRule.Pipeline
                             suppressedRuleCounter++;
 
                             if (!_IsSummary)
-                                Context.WarnRuleSuppressed(ruleId: ruleRecord.RuleId);
+                                Context.RuleSuppressed(ruleId: ruleRecord.RuleId);
                         }
                         // Check for suppression group
                         else if (_SuppressionGroupFilter.TrySuppressionGroup(ruleId: ruleRecord.RuleId, targetObject, out var suppression))
                         {
                             ruleRecord.OutcomeReason = RuleOutcomeReason.Suppressed;
                             if (!_IsSummary)
-                                Context.WarnRuleSuppressionGroup(ruleId: ruleRecord.RuleId, suppression);
+                                Context.RuleSuppressionGroup(ruleId: ruleRecord.RuleId, suppression);
                             else
                                 suppressionGroupCounter[suppression] = suppressionGroupCounter.TryGetValue(suppression, out var count) ? ++count : 1;
                         }
@@ -171,7 +176,7 @@ namespace PSRule.Pipeline
                         Context.WarnRuleCountSuppressed(ruleCount: suppressedRuleCounter);
 
                     foreach (var keyValuePair in suppressionGroupCounter)
-                        Context.WarnRuleSuppressionGroupCount(suppression: keyValuePair.Key, count: keyValuePair.Value);
+                        Context.RuleSuppressionGroupCount(suppression: keyValuePair.Key, count: keyValuePair.Value);
                 }
                 return result;
             }

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -205,6 +205,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The option &apos;{0}&apos; is deprecated and will be removed with PSRule v3. See http://aka.ms/ps-rule/deprecations for more detail..
+        /// </summary>
+        internal static string DeprecatedOption {
+            get {
+                return ResourceManager.GetString("DeprecatedOption", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The resource &apos;{0}&apos; is using a duplicate resource identifier. A resource with the identifier &apos;{1}&apos; already exists. Each resource must have a unique name, ref, and aliases. See https://aka.ms/ps-rule/naming for guidance on naming within PSRule..
         /// </summary>
         internal static string DuplicateResourceId {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -400,4 +400,7 @@
   <data name="PSR0001" xml:space="preserve">
     <value>PSR0001: Unable to read options file '{0}'. Please check the file is valid, indented correctly, and encoded as UTF-8. See https://aka.ms/ps-rule/ts-options. {1}</value>
   </data>
+  <data name="DeprecatedOption" xml:space="preserve">
+    <value>The option '{0}' is deprecated and will be removed with PSRule v3. See http://aka.ms/ps-rule/deprecations for more detail.</value>
+  </data>
 </root>

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -1212,7 +1212,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show Warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Warn -OutputAs Detail -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1226,7 +1226,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $False -OutputAs Detail -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Ignore -OutputAs Detail -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1237,7 +1237,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Warn -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1249,7 +1249,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -SuppressedRuleWarning $False -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Ignore -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1293,7 +1293,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False -OutputCulture 'en-US';
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Detail -InvariantCultureWarning $False -OutputCulture 'en-US';
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1317,7 +1317,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'Show warnings for all rules when rule property is null or empty' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Detail -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Detail -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1329,7 +1329,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Detail -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Ignore -OutputAs Detail -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1340,7 +1340,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False -SuppressionGroupExpired Ignore -OutputCulture 'en-US';
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Summary -InvariantCultureWarning $False -SuppressionGroupExpired Ignore -OutputCulture 'en-US';
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1358,7 +1358,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'Show warnings for all rules when rule property is null or empty' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $True -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Summary -InvariantCultureWarning $False;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1372,7 +1372,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressedRuleWarning $False -OutputAs Summary -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Ignore -OutputAs Summary -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -703,7 +703,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     Context 'Read Execution.SuppressedRuleWarning' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
-            $option.Execution.SuppressedRuleWarning | Should -Be $True;
+            $option.Execution.SuppressedRuleWarning | Should -Be $Null;
         }
 
         It 'from Hashtable' {
@@ -779,10 +779,99 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
                 Remove-Item 'Env:PSRULE_EXECUTION_SUPPRESSIONGROUPEXPIRED' -Force;
             }
         }
+    }
+
+    Context 'Read Execution.RuleExcluded' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.RuleExcluded | Should -Be 'Ignore'
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.RuleExcluded' = 'error' };
+            $option.Execution.RuleExcluded | Should -Be 'Error';
+
+            $option = New-PSRuleOption -Option @{ 'Execution.RuleExcluded' = 'Error' };
+            $option.Execution.RuleExcluded | Should -Be 'Error';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.RuleExcluded | Should -Be 'Warn';
+        }
+
+        It 'from Environment' {
+            try {
+                # With enum
+                $Env:PSRULE_EXECUTION_RULEEXCLUDED = 'error';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleExcluded | Should -Be 'Error';
+
+                # With enum
+                $Env:PSRULE_EXECUTION_RULEEXCLUDED = 'Error';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleExcluded | Should -Be 'Error';
+
+                # With int
+                $Env:PSRULE_EXECUTION_RULEEXCLUDED = '3';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleExcluded | Should -Be 'Error';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_RULEEXCLUDED' -Force;
+            }
+        }
 
         It 'from parameter' {
-            $option = New-PSRuleOption -SuppressionGroupExpired 'Error' -Path $emptyOptionsFilePath;
-            $option.Execution.SuppressionGroupExpired | Should -Be 'Error';
+            $option = New-PSRuleOption -ExecutionRuleExcluded 'Error' -Path $emptyOptionsFilePath;
+            $option.Execution.RuleExcluded | Should -Be 'Error';
+        }
+    }
+
+    Context 'Read Execution.RuleSuppressed' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.RuleSuppressed | Should -Be 'Warn'
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.RuleSuppressed' = 'error' };
+            $option.Execution.RuleSuppressed | Should -Be 'Error';
+
+            $option = New-PSRuleOption -Option @{ 'Execution.RuleSuppressed' = 'Error' };
+            $option.Execution.RuleSuppressed | Should -Be 'Error';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.RuleSuppressed | Should -Be 'Error';
+        }
+
+        It 'from Environment' {
+            try {
+                # With enum
+                $Env:PSRULE_EXECUTION_RULESUPPRESSED = 'error';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleSuppressed | Should -Be 'Error';
+
+                # With enum
+                $Env:PSRULE_EXECUTION_RULESUPPRESSED = 'Error';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleSuppressed | Should -Be 'Error';
+
+                # With int
+                $Env:PSRULE_EXECUTION_RULESUPPRESSED = '3';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleSuppressed | Should -Be 'Error';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_RULESUPPRESSED' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionRuleSuppressed 'Error' -Path $emptyOptionsFilePath;
+            $option.Execution.RuleSuppressed | Should -Be 'Error';
         }
     }
 

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -58,6 +58,8 @@ execution:
   notProcessedWarning: false
   suppressedRuleWarning: false
   suppressionGroupExpired: Debug
+  ruleExcluded: Warn
+  ruleSuppressed: Error
 
 # Configure input options
 input:


### PR DESCRIPTION
## PR Summary

- **Important change**: Replaced `SuppressedRuleWarning` execution option with `RuleSuppressed`.
  - Improved options for output of suppressed rules with `RuleSuppressed` option.
  - Deprecated `SuppressedRuleWarning` option, which will be removed in v3.
- Added support for logging excluded rules.

Progress towards #1456
Fixes #1432

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
