### PR TITLE
Pre-release v2.8.0-B0076

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.8.0-B0076 (pre-release)
+
 What's changed since pre-release v2.8.0-B0034:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v2.8.0-B0034:

- Engineering:
  - Bump Newtonsoft.Json to v13.0.3.
    [#1467](https://github.com/microsoft/PSRule/pull/1467)
  - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.1.
    [#1468](https://github.com/microsoft/PSRule/pull/1468)
- Bug fixes:
  - Fixed problem binding when not set locally by @BernieWhite.
    [#1473](https://github.com/microsoft/PSRule/issues/1473)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
