### PR TITLE
Fixes for LocalizedData variable #1083 #1477

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,14 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.8.0-B0076:
+
+- Bug fixes:
+  - Fixed LocalizedData is not exposed to if pre-conditions by @BernieWhite.
+    [#1083](https://github.com/microsoft/PSRule/issues/1083)
+  - Fixed LocalizedData is not exposed to conventions by @BernieWhite.
+    [#1477](https://github.com/microsoft/PSRule/issues/1477)
+
 ## v2.8.0-B0076 (pre-release)
 
 What's changed since pre-release v2.8.0-B0034:

--- a/src/PSRule/Definitions/Conventions/ScriptBlockConvention.cs
+++ b/src/PSRule/Definitions/Conventions/ScriptBlockConvention.cs
@@ -64,36 +64,37 @@ namespace PSRule.Definitions.Conventions
 
         public override void Initialize(RunspaceContext context, IEnumerable input)
         {
-            InvokeConventionBlock(_Initialize, input);
+            InvokeConventionBlock(context, Source, _Initialize, input);
         }
 
         public override void Begin(RunspaceContext context, IEnumerable input)
         {
-            InvokeConventionBlock(_Begin, input);
+            InvokeConventionBlock(context, Source, _Begin, input);
         }
 
         public override void Process(RunspaceContext context, IEnumerable input)
         {
-            InvokeConventionBlock(_Process, input);
+            InvokeConventionBlock(context, Source, _Process, input);
         }
 
         public override void End(RunspaceContext context, IEnumerable input)
         {
-            InvokeConventionBlock(_End, input);
+            InvokeConventionBlock(context, Source, _End, input);
         }
 
-        private static void InvokeConventionBlock(LanguageScriptBlock block, IEnumerable input)
+        private static void InvokeConventionBlock(RunspaceContext context, SourceFile source, LanguageScriptBlock block, IEnumerable input)
         {
             if (block == null)
                 return;
 
             try
             {
+                context.EnterLanguageScope(source);
                 block.Invoke();
             }
             finally
             {
-
+                context.ExitLanguageScope(source);
             }
         }
 

--- a/tests/PSRule.Tests/ConventionTests.cs
+++ b/tests/PSRule.Tests/ConventionTests.cs
@@ -61,6 +61,32 @@ namespace PSRule
             Assert.Equal(11, actual2);
         }
 
+        /// <summary>
+        /// Test that localized data is accessible to conventions at each block.
+        /// </summary>
+        [Fact]
+        public void WithLocalizedData()
+        {
+            var testObject1 = new TestObject { Name = "TestObject1" };
+            var option = GetOption();
+            option.Rule.Include = new string[] { "WithLocalizedDataPrecondition" };
+            option.Convention.Include = new string[] { "Convention.WithLocalizedData" };
+            var writer = new TestWriter(option);
+            var builder = PipelineBuilder.Invoke(GetSource(), option, null);
+            var pipeline = builder.Build(writer);
+
+            Assert.NotNull(pipeline);
+            pipeline.Begin();
+            pipeline.Process(PSObject.AsPSObject(testObject1));
+            pipeline.End();
+            Assert.NotEmpty(writer.Information);
+            Assert.Equal("LocalizedMessage for en. Format=Initialize.", writer.Information[0] as string);
+            Assert.Equal("LocalizedMessage for en. Format=Begin.", writer.Information[1] as string);
+            Assert.Equal("LocalizedMessage for en. Format=Precondition.", writer.Information[2] as string);
+            Assert.Equal("LocalizedMessage for en. Format=Process.", writer.Information[3] as string);
+            Assert.Equal("LocalizedMessage for en. Format=End.", writer.Information[4] as string);
+        }
+
         #region Helper methods
 
         private static Source[] GetSource()
@@ -70,9 +96,11 @@ namespace PSRule
             return builder.Build();
         }
 
-        private PSRuleOption GetOption(string path = null)
+        private static PSRuleOption GetOption(string path = null)
         {
-            return path == null ? new PSRuleOption() : PSRuleOption.FromFile(path);
+            var option = path == null ? new PSRuleOption() : PSRuleOption.FromFile(path);
+            option.Output.Culture = new[] { "en-US" };
+            return option;
         }
 
         private static string GetSourcePath(string fileName)

--- a/tests/PSRule.Tests/FromFileConventions.Rule.ps1
+++ b/tests/PSRule.Tests/FromFileConventions.Rule.ps1
@@ -69,3 +69,19 @@ Rule 'ConventionTest' {
     $store = $PSRule.GetService('Store');
     $Assert.HasFieldValue($store, 'Name', 'TestObject1');
 }
+
+# Synopsis: A convention for unit testing localized data.
+Export-PSRuleConvention 'Convention.WithLocalizedData' -Initialize {
+    Write-Information -MessageData ($LocalizedData.WithLocalizedDataMessage -f 'Initialize')
+} -Begin {
+    Write-Information -MessageData ($LocalizedData.WithLocalizedDataMessage -f 'Begin')
+} -Process {
+    Write-Information -MessageData ($LocalizedData.WithLocalizedDataMessage -f 'Process')
+} -End {
+    Write-Information -MessageData ($LocalizedData.WithLocalizedDataMessage -f 'End')
+}
+
+# Syopsis: Test localized data in pre-condition.
+Rule 'WithLocalizedDataPrecondition' -If { Write-Information -MessageData ($LocalizedData.WithLocalizedDataMessage -f 'Precondition'); $True; } {
+    $Assert.Pass();
+}

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -39,6 +39,9 @@
     <None Update="Dockerfile">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="en\PSRule-rules.psd1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="en\SuppressWithNonProdTag.md">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Tests/TestWriter.cs
+++ b/tests/PSRule.Tests/TestWriter.cs
@@ -12,6 +12,7 @@ namespace PSRule
     {
         internal List<ErrorRecord> Errors = new();
         internal List<string> Warnings = new();
+        internal List<object> Information = new();
         internal List<object> Output = new();
 
         public TestWriter(PSRuleOption option)
@@ -50,6 +51,16 @@ namespace PSRule
             {
                 Output.Add(sendToPipeline);
             }
+        }
+
+        public override bool ShouldWriteInformation()
+        {
+            return true;
+        }
+
+        public override void WriteInformation(InformationRecord informationRecord)
+        {
+            Information.Add(informationRecord.MessageData);
         }
     }
 }


### PR DESCRIPTION
## PR Summary

- Fixed LocalizedData is not exposed to if pre-conditions.
- Fixed LocalizedData is not exposed to conventions.

Fixes #1083 
Fixes #1477 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
