### PR TITLE
Fixes no output with using job summary #1483

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,13 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+What's changed since pre-release v2.8.0-B0121:
+
+- Bug fixes:
+  - Fixed no output with using job summary with as summary by @BernieWhite.
+    [#1483](https://github.com/microsoft/PSRule/issues/1483)
+    - Fixed output and added error for unsupported scenarios.
+
 ## v2.8.0-B0121 (pre-release)
 
 What's changed since pre-release v2.8.0-B0076:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,3 +75,16 @@ This error typically indicates a problem with the YAML syntax in the `ps-rule.ya
 Double check the file for incorrect indentation or missing punctuation such as `-` and `:` characters.
 
 If you still have an issue, try resaving the file as UTF-8 in an editor such as Visual Studio Code.
+
+## PSR0002 - Summary results are not supported with Job Summaries
+
+!!! Error
+
+    PSR0002: Summary results are not supported with Job Summaries.
+
+Currently using the `Output.As` with the `Summary` option is not supported with job summaries.
+Choose to use one or the other.
+
+If you have a specific use case your would like to enable, please start a [discussion][3].
+
+  [3]: https://github.com/microsoft/PSRule/discussions

--- a/src/PSRule/Pipeline/Output/JobSummaryWriter.cs
+++ b/src/PSRule/Pipeline/Output/JobSummaryWriter.cs
@@ -40,6 +40,9 @@ namespace PSRule.Pipeline.Output
             _JobSummary = JobSummaryFormat.Default;
             _Stream = stream;
             _Source = source;
+
+            if (Option.Output.As == ResultFormat.Summary && inner != null)
+                inner.WriteError(new PipelineConfigurationException("Output.As", PSRuleResources.PSR0002), "PSRule.Output.AsOutputSerialization", System.Management.Automation.ErrorCategory.InvalidOperation);
         }
 
         public override void Begin()

--- a/src/PSRule/Pipeline/PipelineWriter.cs
+++ b/src/PSRule/Pipeline/PipelineWriter.cs
@@ -344,7 +344,10 @@ namespace PSRule.Pipeline
         public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
             if (sendToPipeline is InvokeResult && Option.Output.As == ResultFormat.Summary)
+            {
+                base.WriteObject(sendToPipeline, enumerateCollection);
                 return;
+            }
 
             if (sendToPipeline is InvokeResult result)
             {
@@ -393,7 +396,10 @@ namespace PSRule.Pipeline
         public override void WriteObject(object sendToPipeline, bool enumerateCollection)
         {
             if (sendToPipeline is InvokeResult && Option.Output.As == ResultFormat.Summary)
+            {
+                base.WriteObject(sendToPipeline, enumerateCollection);
                 return;
+            }
 
             if (sendToPipeline is InvokeResult result)
             {

--- a/src/PSRule/Resources/PSRuleResources.Designer.cs
+++ b/src/PSRule/Resources/PSRuleResources.Designer.cs
@@ -574,6 +574,15 @@ namespace PSRule.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PSR0002: Summary results are not supported with Job Summaries. See https://aka.ms/ps-rule/troubleshooting..
+        /// </summary>
+        internal static string PSR0002 {
+            get {
+                return ResourceManager.GetString("PSR0002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Failed to deserialize the file &apos;{0}&apos;: {1}.
         /// </summary>
         internal static string ReadFileFailed {

--- a/src/PSRule/Resources/PSRuleResources.resx
+++ b/src/PSRule/Resources/PSRuleResources.resx
@@ -403,4 +403,7 @@
   <data name="DeprecatedOption" xml:space="preserve">
     <value>The option '{0}' is deprecated and will be removed with PSRule v3. See http://aka.ms/ps-rule/deprecations for more detail.</value>
   </data>
+  <data name="PSR0002" xml:space="preserve">
+    <value>PSR0002: Summary results are not supported with Job Summaries. See https://aka.ms/ps-rule/troubleshooting.</value>
+  </data>
 </root>


### PR DESCRIPTION
## PR Summary

- Fixed no output with using job summary with as summary.
  - Fixed output and added error for unsupported scenarios.

Fixes #1483

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
