### PR TITLE
Added case sensitive match #1480

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -32,6 +32,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v2.8.0-B0121:
 
+- General improvements:
+  - Added support for case sensitivity matching with `match` and `notMatch` expressions by @BernieWhite.
+    [#1480](https://github.com/microsoft/PSRule/issues/1480)
 - Bug fixes:
   - Fixed no output with using job summary with as summary by @BernieWhite.
     [#1483](https://github.com/microsoft/PSRule/issues/1483)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Expressions.md
@@ -1215,10 +1215,14 @@ spec:
 
 The `match` condition can be used to compare if a field matches a supplied regular expression.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  By default, case-insensitive comparison is performed.
+
 Syntax:
 
 ```yaml
 match: <string>
+caseSensitive: <boolean>
 ```
 
 For example:
@@ -1606,10 +1610,14 @@ spec:
 
 The `notMatch` condition can be used to compare if a field does not matches a supplied regular expression.
 
+- `caseSensitive` - Optionally, a case sensitive-comparison can be performed.
+  By default, case-insensitive comparison is performed.
+
 Syntax:
 
 ```yaml
 notMatch: <string>
+caseSensitive: <boolean>
 ```
 
 For example:
@@ -1702,6 +1710,13 @@ The following properties are accepted:
 
 - `caseSensitive` - Optionally, a case-sensitive comparison can be performed for string values.
   By default, case-insensitive comparison is performed.
+
+Syntax:
+
+```yaml
+notWithinPath: <array>
+caseSensitive: <boolean>
+```
 
 For example:
 
@@ -2045,6 +2060,13 @@ The following properties are accepted:
 - `caseSensitive` - Optionally, a case-sensitive comparison can be performed for string values.
   By default, case-insensitive comparison is performed.
 
+Syntax:
+
+```yaml
+withinPath: <array>
+caseSensitive: <boolean>
+```
+
 For example:
 
 ```yaml
@@ -2076,7 +2098,7 @@ spec:
 
 ## NOTE
 
-An online version of this document is available at https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/.
+An online version of this document is available at <https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/>.
 
 ## SEE ALSO
 

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -1546,6 +1546,13 @@
                   "markdownDescription": "Must match the regular expression. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#match)",
                   "default": ""
                 },
+                "caseSensitive": {
+                  "type": "boolean",
+                  "title": "Case sensitive",
+                  "description": "Determines if the regular expression uses case-sensitive matching.",
+                  "markdownDescription": "Determines if the regular expression uses case-sensitive matching. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#match)",
+                  "default": false
+                },
                 "field": {
                   "$ref": "#/definitions/expressions/definitions/properties/definitions/field"
                 },
@@ -1583,6 +1590,13 @@
                   "description": "Must not match the regular expression.",
                   "markdownDescription": "Must not match the regular expression. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notmatch)",
                   "default": ""
+                },
+                "caseSensitive": {
+                  "type": "boolean",
+                  "title": "Case sensitive",
+                  "description": "Determines if the regular expression uses case-sensitive matching.",
+                  "markdownDescription": "Determines if the regular expression uses case-sensitive matching. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Expressions/#notmatch)",
+                  "default": false
                 },
                 "field": {
                   "$ref": "#/definitions/expressions/definitions/properties/definitions/field"

--- a/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
+++ b/src/PSRule/Definitions/Expressions/LanguageExpressions.cs
@@ -642,12 +642,15 @@ namespace PSRule.Definitions.Expressions
         internal static bool Match(ExpressionContext context, ExpressionInfo info, object[] args, object o)
         {
             var properties = GetProperties(args);
-            return !TryPropertyAny(properties, MATCH, out var propertyValue) || !TryOperand(context, MATCH, o, properties, out var operand)
-                ? Invalid(context, MATCH)
-                : Condition(
+            if (!TryPropertyAny(properties, MATCH, out var propertyValue) ||
+                !TryOperand(context, MATCH, o, properties, out var operand) ||
+                !GetCaseSensitive(properties, out var caseSensitive))
+                return Invalid(context, MATCH);
+
+            return Condition(
                     context,
                     operand,
-                    ExpressionHelpers.Match(propertyValue, operand.Value, caseSensitive: false),
+                    ExpressionHelpers.Match(propertyValue, operand.Value, caseSensitive),
                     ReasonStrings.Assert_DoesNotMatch,
                     operand.Value,
                     propertyValue
@@ -663,13 +666,14 @@ namespace PSRule.Definitions.Expressions
             if (TryFieldNotExists(context, o, properties))
                 return PassPathNotFound(context, NOTMATCH);
 
-            if (!TryOperand(context, NOTMATCH, o, properties, out var operand))
+            if (!TryOperand(context, NOTMATCH, o, properties, out var operand) ||
+                !GetCaseSensitive(properties, out var caseSensitive))
                 return Invalid(context, NOTMATCH);
 
             return Condition(
                 context,
                 operand,
-                !ExpressionHelpers.Match(propertyValue, operand.Value, caseSensitive: false),
+                !ExpressionHelpers.Match(propertyValue, operand.Value, caseSensitive),
                 ReasonStrings.Assert_Matches,
                 operand.Value,
                 propertyValue

--- a/tests/PSRule.Tests/SelectorTests.cs
+++ b/tests/PSRule.Tests/SelectorTests.cs
@@ -41,7 +41,7 @@ namespace PSRule
             context.Begin();
             var selector = HostHelper.GetSelectorForTests(GetSource(path), context).ToArray();
             Assert.NotNull(selector);
-            Assert.Equal(99, selector.Length);
+            Assert.Equal(101, selector.Length);
 
             var actual = selector[0];
             var visitor = new SelectorVisitor(context, actual.Id, actual.Source, actual.Spec.If);
@@ -262,18 +262,26 @@ namespace PSRule
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameMatch", GetSource(path), out var context);
-            var actual6 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "TargetObject1")
             );
-            var actual7 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "TargetObject2")
             );
 
-            context.EnterTargetObject(new TargetObject(actual6));
-            Assert.True(withName.Match(actual6));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.True(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual7));
-            Assert.False(withName.Match(actual7));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.False(withName.Match(actual2));
+
+            // With case-sensitivity
+            var withCaseSensitivity = GetSelectorVisitor($"{type}MatchCaseSensitive", GetSource(path), out _);
+            actual1 = GetObject((name: "value", value: "abc"));
+            actual2 = GetObject((name: "value", value: "aBc"));
+
+            Assert.True(withCaseSensitivity.Match(actual1));
+            Assert.False(withCaseSensitivity.Match(actual2));
         }
 
         [Theory]
@@ -294,18 +302,26 @@ namespace PSRule
 
             // With name
             var withName = GetSelectorVisitor($"{type}NameNotMatch", GetSource(path), out var context);
-            var actual6 = GetObject(
+            actual1 = GetObject(
                (name: "Name", value: "TargetObject1")
             );
-            var actual7 = GetObject(
+            actual2 = GetObject(
                (name: "Name", value: "TargetObject2")
             );
 
-            context.EnterTargetObject(new TargetObject(actual6));
-            Assert.False(withName.Match(actual6));
+            context.EnterTargetObject(new TargetObject(actual1));
+            Assert.False(withName.Match(actual1));
 
-            context.EnterTargetObject(new TargetObject(actual7));
-            Assert.True(withName.Match(actual7));
+            context.EnterTargetObject(new TargetObject(actual2));
+            Assert.True(withName.Match(actual2));
+
+            // With case-sensitivity
+            var withCaseSensitivity = GetSelectorVisitor($"{type}NotMatchCaseSensitive", GetSource(path), out _);
+            actual1 = GetObject((name: "value", value: "abc"));
+            actual2 = GetObject((name: "value", value: "aBc"));
+
+            Assert.False(withCaseSensitivity.Match(actual1));
+            Assert.True(withCaseSensitivity.Match(actual2));
         }
 
         [Theory]

--- a/tests/PSRule.Tests/Selectors.Rule.jsonc
+++ b/tests/PSRule.Tests/Selectors.Rule.jsonc
@@ -296,6 +296,21 @@
     }
   },
   {
+    // Synopsis: Test match
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonMatchCaseSensitive"
+    },
+    "spec": {
+      "if": {
+        "field": "Value",
+        "match": "^(abc|efg)$",
+        "caseSensitive": true
+      }
+    }
+  },
+  {
     // Synopsis: Test notMatch
     "apiVersion": "github.com/microsoft/PSRule/v1",
     "kind": "Selector",
@@ -306,6 +321,21 @@
       "if": {
         "field": "Value",
         "notMatch": "^(abc|efg)$"
+      }
+    }
+  },
+  {
+    // Synopsis: Test notMatch
+    "apiVersion": "github.com/microsoft/PSRule/v1",
+    "kind": "Selector",
+    "metadata": {
+      "name": "JsonNotMatchCaseSensitive"
+    },
+    "spec": {
+      "if": {
+        "field": "Value",
+        "notMatch": "^(abc|efg)$",
+        "caseSensitive": true
       }
     }
   },

--- a/tests/PSRule.Tests/Selectors.Rule.yaml
+++ b/tests/PSRule.Tests/Selectors.Rule.yaml
@@ -13,15 +13,15 @@ spec:
   if:
     # Additional comments
     allOf:
-    # Additional comments
-    - field: Name
       # Additional comments
-      equals: TargetObject1
-      # Additional comments
-    - field: Value
-      # Additional comments
-      equals: value1
-      # Additional comments
+      - field: Name
+        # Additional comments
+        equals: TargetObject1
+        # Additional comments
+      - field: Value
+        # Additional comments
+        equals: value1
+        # Additional comments
 
 ---
 # Synopsis: A selector to match objects using a specific JSON schema
@@ -54,10 +54,10 @@ metadata:
 spec:
   if:
     anyOf:
-    - field: 'AlternateName'
-      exists: true
-    - field: 'Name'
-      exists: true
+      - field: 'AlternateName'
+        exists: true
+      - field: 'Name'
+        exists: true
 
 ---
 # Synopsis: Test AllOf
@@ -68,10 +68,10 @@ metadata:
 spec:
   if:
     allOf:
-    - field: 'AlternateName'
-      exists: true
-    - field: 'Name'
-      exists: true
+      - field: 'AlternateName'
+        exists: true
+      - field: 'Name'
+        exists: true
 
 ---
 # Synopsis: Test Not
@@ -83,10 +83,10 @@ spec:
   if:
     not:
       anyOf:
-      - field: 'AlternateName'
-        exists: true
-      - field: 'Name'
-        exists: true
+        - field: 'AlternateName'
+          exists: true
+        - field: 'Name'
+          exists: true
 
 ---
 # Synopsis: Test custom value is in
@@ -98,8 +98,8 @@ spec:
   if:
     field: 'CustomValue'
     in:
-    - 'Value1'
-    - 'Value2'
+      - 'Value1'
+      - 'Value2'
 
 ---
 # Synopsis: Test exists true
@@ -132,19 +132,19 @@ metadata:
 spec:
   if:
     allOf:
-    - field: 'ValueString'
-      equals: 'abc'
-      caseSensitive: true
-    - field: 'ValueInt'
-      equals: 123
-    - field: 'ValueBool'
-      equals: true
-    - anyOf:
-      - field: 'ValueEnum'
-        exists: false
-      - field: 'ValueEnum'
-        equals: 'All'
-        convert: true
+      - field: 'ValueString'
+        equals: 'abc'
+        caseSensitive: true
+      - field: 'ValueInt'
+        equals: 123
+      - field: 'ValueBool'
+        equals: true
+      - anyOf:
+          - field: 'ValueEnum'
+            exists: false
+          - field: 'ValueEnum'
+            equals: 'All'
+            convert: true
 
 ---
 # Synopsis: Test notEquals
@@ -155,19 +155,19 @@ metadata:
 spec:
   if:
     allOf:
-    - field: 'ValueString'
-      notEquals: 'abc'
-      caseSensitive: true
-    - field: 'ValueInt'
-      notEquals: 123
-    - field: 'ValueBool'
-      notEquals: true
-    - anyOf:
-      - field: 'ValueEnum'
-        exists: false
-      - field: 'ValueEnum'
-        notEquals: 'All'
-        convert: true
+      - field: 'ValueString'
+        notEquals: 'abc'
+        caseSensitive: true
+      - field: 'ValueInt'
+        notEquals: 123
+      - field: 'ValueBool'
+        notEquals: true
+      - anyOf:
+          - field: 'ValueEnum'
+            exists: false
+          - field: 'ValueEnum'
+            notEquals: 'All'
+            convert: true
 
 ---
 # Synopsis: Test hasValue true
@@ -203,6 +203,18 @@ spec:
     match: '^(abc|efg)$'
 
 ---
+# Synopsis: Test match
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlMatchCaseSensitive
+spec:
+  if:
+    field: 'Value'
+    match: '^(abc|efg)$'
+    caseSensitive: true
+
+---
 # Synopsis: Test notMatch
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Selector
@@ -214,6 +226,18 @@ spec:
     notMatch: '^(abc|efg)$'
 
 ---
+# Synopsis: Test notMatch
+apiVersion: github.com/microsoft/PSRule/v1
+kind: Selector
+metadata:
+  name: YamlNotMatchCaseSensitive
+spec:
+  if:
+    field: 'Value'
+    notMatch: '^(abc|efg)$'
+    caseSensitive: true
+
+---
 # Synopsis: Test in
 apiVersion: github.com/microsoft/PSRule/v1
 kind: Selector
@@ -223,8 +247,8 @@ spec:
   if:
     field: 'Value'
     in:
-    - 'Value1'
-    - 'Value2'
+      - 'Value1'
+      - 'Value2'
 
 ---
 # Synopsis: Test notIn
@@ -236,8 +260,8 @@ spec:
   if:
     field: 'Value'
     notIn:
-    - 'Value1'
-    - 'Value2'
+      - 'Value1'
+      - 'Value2'
 
 ---
 # Synopsis: Test less
@@ -248,11 +272,11 @@ metadata:
 spec:
   if:
     anyOf:
-    - field: 'Value'
-      less: 3
-    - field: 'ValueStr'
-      less: 0
-      convert: true
+      - field: 'Value'
+        less: 3
+      - field: 'ValueStr'
+        less: 0
+        convert: true
 
 ---
 # Synopsis: Test lessOrEquals
@@ -263,11 +287,11 @@ metadata:
 spec:
   if:
     anyOf:
-    - field: 'Value'
-      lessOrEquals: 3
-    - field: 'ValueStr'
-      lessOrEquals: 0
-      convert: true
+      - field: 'Value'
+        lessOrEquals: 3
+      - field: 'ValueStr'
+        lessOrEquals: 0
+        convert: true
 
 ---
 # Synopsis: Test greater
@@ -278,11 +302,11 @@ metadata:
 spec:
   if:
     anyOf:
-    - field: 'Value'
-      greater: 3
-    - field: 'ValueStr'
-      greater: -1
-      convert: true
+      - field: 'Value'
+        greater: 3
+      - field: 'ValueStr'
+        greater: -1
+        convert: true
 
 ---
 # Synopsis: Test greaterOrEquals
@@ -293,11 +317,11 @@ metadata:
 spec:
   if:
     anyOf:
-    - field: 'Value'
-      greaterOrEquals: 3
-    - field: 'ValueStr'
-      greaterOrEquals: -1
-      convert: true
+      - field: 'Value'
+        greaterOrEquals: 3
+      - field: 'ValueStr'
+        greaterOrEquals: -1
+        convert: true
 
 ---
 # Synopsis: Test startsWith
@@ -308,22 +332,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            startsWith: 'a'
+          - field: 'Value'
+            startsWith: 'e'
+            caseSensitive: true
       - field: 'Value'
-        startsWith: 'a'
-      - field: 'Value'
-        startsWith: 'e'
-        caseSensitive: true
-    - field: 'Value'
-      startsWith:
-      - 'a'
-      - 'e'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        startsWith: 'a'
-        convert: true
+        startsWith:
+          - 'a'
+          - 'e'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            startsWith: 'a'
+            convert: true
 
 ---
 # Synopsis: Test notStartsWith
@@ -334,22 +358,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            notStartsWith: 'a'
+          - field: 'Value'
+            notStartsWith: 'e'
+            caseSensitive: true
       - field: 'Value'
-        notStartsWith: 'a'
-      - field: 'Value'
-        notStartsWith: 'e'
-        caseSensitive: true
-    - field: 'Value'
-      notStartsWith:
-      - 'a'
-      - 'e'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        notStartsWith: 'a'
-        convert: true
+        notStartsWith:
+          - 'a'
+          - 'e'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            notStartsWith: 'a'
+            convert: true
 
 ---
 # Synopsis: Test endsWith
@@ -360,22 +384,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            endsWith: 'c'
+          - field: 'Value'
+            endsWith: 'g'
+            caseSensitive: true
       - field: 'Value'
-        endsWith: 'c'
-      - field: 'Value'
-        endsWith: 'g'
-        caseSensitive: true
-    - field: 'Value'
-      endsWith:
-      - 'c'
-      - 'g'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        endsWith: 'l'
-        convert: true
+        endsWith:
+          - 'c'
+          - 'g'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            endsWith: 'l'
+            convert: true
 
 ---
 # Synopsis: Test notEndsWith
@@ -386,22 +410,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            notEndsWith: 'c'
+          - field: 'Value'
+            notEndsWith: 'g'
+            caseSensitive: true
       - field: 'Value'
-        notEndsWith: 'c'
-      - field: 'Value'
-        notEndsWith: 'g'
-        caseSensitive: true
-    - field: 'Value'
-      notEndsWith:
-      - 'c'
-      - 'g'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        notEndsWith: 'l'
-        convert: true
+        notEndsWith:
+          - 'c'
+          - 'g'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            notEndsWith: 'l'
+            convert: true
 
 ---
 # Synopsis: Test contains
@@ -412,22 +436,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            contains: 'ab'
+          - field: 'Value'
+            contains: 'bc'
+            caseSensitive: true
       - field: 'Value'
-        contains: 'ab'
-      - field: 'Value'
-        contains: 'bc'
-        caseSensitive: true
-    - field: 'Value'
-      contains:
-      - 'ab'
-      - 'bc'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        contains: 'l'
-        convert: true
+        contains:
+          - 'ab'
+          - 'bc'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            contains: 'l'
+            convert: true
 
 ---
 # Synopsis: Test notContains
@@ -438,22 +462,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            notContains: 'ab'
+          - field: 'Value'
+            notContains: 'bc'
+            caseSensitive: true
       - field: 'Value'
-        notContains: 'ab'
-      - field: 'Value'
-        notContains: 'bc'
-        caseSensitive: true
-    - field: 'Value'
-      notContains:
-      - 'ab'
-      - 'bc'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        notContains: 'l'
-        convert: true
+        notContains:
+          - 'ab'
+          - 'bc'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            notContains: 'l'
+            convert: true
 
 ---
 # Synopsis: Test like
@@ -464,22 +488,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            like: 'ab*'
+          - field: 'Value'
+            like: '*f*'
+            caseSensitive: true
       - field: 'Value'
-        like: 'ab*'
-      - field: 'Value'
-        like: '*f*'
-        caseSensitive: true
-    - field: 'Value'
-      like:
-      - 'ab*'
-      - '*f*'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        like: '12*'
-        convert: true
+        like:
+          - 'ab*'
+          - '*f*'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            like: '12*'
+            convert: true
 
 ---
 # Synopsis: Test notLike
@@ -490,22 +514,22 @@ metadata:
 spec:
   if:
     allOf:
-    - anyOf:
+      - anyOf:
+          - field: 'Value'
+            notLike: 'ab*'
+          - field: 'Value'
+            notLike: '*f*'
+            caseSensitive: true
       - field: 'Value'
-        notLike: 'ab*'
-      - field: 'Value'
-        notLike: '*f*'
-        caseSensitive: true
-    - field: 'Value'
-      notLike:
-      - 'ab*'
-      - '*f*'
-    - anyOf:
-      - field: 'OtherValue'
-        exists: false
-      - field: 'OtherValue'
-        notLike: '12*'
-        convert: true
+        notLike:
+          - 'ab*'
+          - '*f*'
+      - anyOf:
+          - field: 'OtherValue'
+            exists: false
+          - field: 'OtherValue'
+            notLike: '12*'
+            convert: true
 
 ---
 # Synopsis: Test isString
@@ -789,8 +813,8 @@ spec:
   if:
     field: 'Value'
     setOf:
-    - 'cluster-autoscaler'
-    - 'kube-apiserver'
+      - 'cluster-autoscaler'
+      - 'kube-apiserver'
     caseSensitive: true
 
 ---
@@ -803,8 +827,8 @@ spec:
   if:
     field: 'Value'
     subset:
-    - 'cluster-autoscaler'
-    - 'kube-apiserver'
+      - 'cluster-autoscaler'
+      - 'kube-apiserver'
     caseSensitive: true
     unique: true
 
@@ -840,8 +864,8 @@ spec:
   if:
     field: '.'
     hasSchema:
-    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
-    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+      - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+      - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
 
 ---
 # Synopsis: Test hasSchema ignoring scheme
@@ -853,8 +877,8 @@ spec:
   if:
     field: '.'
     hasSchema:
-    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
-    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+      - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+      - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
     ignoreScheme: true
 
 ---
@@ -867,8 +891,8 @@ spec:
   if:
     field: '.'
     hasSchema:
-    - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
-    - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
+      - https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#
+      - https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#
     caseSensitive: true
 
 ---
@@ -925,13 +949,13 @@ metadata:
 spec:
   if:
     allOf:
-    - field: 'integerValue'
-      hasDefault: 100
-    - field: 'boolValue'
-      hasDefault: true
-    - field: 'stringValue'
-      hasDefault: 'testValue'
-      caseSensitive: true
+      - field: 'integerValue'
+        hasDefault: 100
+      - field: 'boolValue'
+        hasDefault: true
+      - field: 'stringValue'
+        hasDefault: 'testValue'
+        caseSensitive: true
 
 #region With type tests
 
@@ -1015,7 +1039,7 @@ spec:
   if:
     name: '.'
     in:
-    - 'TargetObject1'
+      - 'TargetObject1'
 
 ---
 # Synopsis: Test notIn with name
@@ -1027,7 +1051,7 @@ spec:
   if:
     name: '.'
     notIn:
-    - 'TargetObject1'
+      - 'TargetObject1'
 
 ---
 # Synopsis: Test startsWith with name
@@ -1039,7 +1063,7 @@ spec:
   if:
     name: '.'
     startsWith:
-    - '1'
+      - '1'
 
 ---
 # Synopsis: Test endsWith with name
@@ -1051,7 +1075,7 @@ spec:
   if:
     name: '.'
     endsWith:
-    - '1'
+      - '1'
 
 ---
 # Synopsis: Test contains with name
@@ -1063,7 +1087,7 @@ spec:
   if:
     name: '.'
     contains:
-    - '.1.'
+      - '.1.'
 
 ---
 # Synopsis: Test isString with name
@@ -1165,7 +1189,7 @@ spec:
   if:
     source: 'Template'
     withinPath:
-      - "deployments/path/"
+      - 'deployments/path/'
 
 ---
 # Synopsis: Test withinPath with field
@@ -1177,8 +1201,8 @@ spec:
   if:
     field: 'FullName'
     withinPath:
-      - "policy/"
-      - "security/"
+      - 'policy/'
+      - 'security/'
 
 ---
 # Synopsis: Test withinPath with source and case sensitive
@@ -1190,7 +1214,7 @@ spec:
   if:
     source: 'Template'
     withinPath:
-      - "Deployments/Path/"
+      - 'Deployments/Path/'
     caseSensitive: true
 
 ---
@@ -1203,8 +1227,8 @@ spec:
   if:
     field: 'FullName'
     withinPath:
-      - "POLICY/"
-      - "SECURITY/"
+      - 'POLICY/'
+      - 'SECURITY/'
     caseSensitive: true
 
 ---
@@ -1217,7 +1241,7 @@ spec:
   if:
     source: 'Template'
     notWithinPath:
-      - "deployments/path/"
+      - 'deployments/path/'
 
 ---
 # Synopsis: Test notWithinPath with field
@@ -1229,8 +1253,8 @@ spec:
   if:
     field: 'FullName'
     notWithinPath:
-      - "policy/"
-      - "security/"
+      - 'policy/'
+      - 'security/'
 
 ---
 # Synopsis: Test notWithinPath with source and case sensitive
@@ -1242,7 +1266,7 @@ spec:
   if:
     source: 'Template'
     notWithinPath:
-      - "Deployments/Path/"
+      - 'Deployments/Path/'
     caseSensitive: true
 
 ---
@@ -1255,8 +1279,8 @@ spec:
   if:
     field: 'FullName'
     notWithinPath:
-      - "POLICY/"
-      - "SECURITY/"
+      - 'POLICY/'
+      - 'SECURITY/'
     caseSensitive: true
 
 ---
@@ -1269,7 +1293,7 @@ spec:
   if:
     scope: .
     equals:
-    - /scope1
+      - /scope1
 
 ---
 # Synopsis: Test scope property with startsWith.
@@ -1281,8 +1305,8 @@ spec:
   if:
     scope: .
     startsWith:
-    - /scope1/
-    - /scope2/
+      - /scope1/
+      - /scope2/
 
 ---
 # Synopsis: Test scope property with hasValue.


### PR DESCRIPTION
## PR Summary

- Added support for case sensitivity matching with `match` and `notMatch` expressions.

Fixes #1480

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
