### PR TITLE
Rename and improvement of logging options #1456

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ PSRule works great and integrates with popular continuous integration (CI) syste
 - [Maintainers](#maintainers)
 - [License](#license)
 
-### Features of PSRule include:
+### Features of PSRule include
 
 - [DevOps][2] - Built to support DevOps culture and tools.
 - [Extensible][3] - Define tests using YAML, JSON, or PowerShell format.
@@ -290,15 +290,19 @@ The following conceptual topics exist in the `PSRule` module:
   - [Binding.UseQualifiedName](https://aka.ms/ps-rule/options#bindingusequalifiedname)
   - [Configuration](https://aka.ms/ps-rule/options#configuration)
   - [Convention.Include](https://aka.ms/ps-rule/options#conventioninclude)
+  - [Execution.AliasReference](https://aka.ms/ps-rule/options#executionaliasreference)
   - [Execution.AliasReferenceWarning](https://aka.ms/ps-rule/options#executionaliasreferencewarning)
   - [Execution.DuplicateResourceId](https://aka.ms/ps-rule/options#executionduplicateresourceid)
   - [Execution.LanguageMode](https://aka.ms/ps-rule/options#executionlanguagemode)
   - [Execution.InconclusiveWarning](https://aka.ms/ps-rule/options#executioninconclusivewarning)
+  - [Execution.InvariantCulture](https://aka.ms/ps-rule/options#executioninvariantculture)
   - [Execution.InvariantCultureWarning](https://aka.ms/ps-rule/options#executioninvariantculturewarning)
   - [Execution.InitialSessionState](https://aka.ms/ps-rule/options#executioninitialsessionstate)
   - [Execution.NotProcessedWarning](https://aka.ms/ps-rule/options#executionnotprocessedwarning)
+  - [Execution.RuleInconclusive](https://aka.ms/ps-rule/options#executionruleinconclusive)
   - [Execution.SuppressedRuleWarning](https://aka.ms/ps-rule/options#executionsuppressedrulewarning)
   - [Execution.SuppressionGroupExpired](https://aka.ms/ps-rule/options#executionsuppressiongroupexpired)
+  - [Execution.UnprocessedObject](https://aka.ms/ps-rule/options#executionunprocessedobject)
   - [Include.Module](https://aka.ms/ps-rule/options#includemodule)
   - [Include.Path](https://aka.ms/ps-rule/options#includepath)
   - [Input.Format](https://aka.ms/ps-rule/options#inputformat)

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -33,6 +33,17 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 What's changed since release v2.8.1:
 
 - General improvements:
+  - **Important change**: Rename of execution options by @BernieWhite.
+    [#1456](https://github.com/microsoft/PSRule/issues/1456)
+    - Renamed options allow configuration of output level as `Ignore`, `Warn`, `Error`, or `Debug`.
+    - `Execution.AliasReferenceWarning` is replaced with `Execution.AliasReference`.
+    - `Execution.InconclusiveWarning` is replaced with `Execution.RuleInconclusive`.
+    - `Execution.InvariantCultureWarning` is replaced with `Execution.InvariantCulture`.
+    - `Execution.NotProcessedWarning` is replaced with `Execution.UnprocessedObject`.
+    - Deprecated `AliasReferenceWarning` option, which will be removed in v3.
+    - Deprecated `InconclusiveWarning` option, which will be removed in v3.
+    - Deprecated `InvariantCultureWarning` option, which will be removed in v3.
+    - Deprecated `NotProcessedWarning` option, which will be removed in v3.
   - Improved schema display names by @BernieWhite.
     [#1488](https://github.com/microsoft/PSRule/issues/1488)
 - Engineering:

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -14,15 +14,19 @@ This topic describes what options are available, when to and how to use them.
 The following workspace options are available for use:
 
 - [Convention.Include](#conventioninclude)
+- [Execution.AliasReference](#executionaliasreference)
 - [Execution.AliasReferenceWarning](#executionaliasreferencewarning)
 - [Execution.DuplicateResourceId](#executionduplicateresourceid)
 - [Execution.LanguageMode](#executionlanguagemode)
 - [Execution.InconclusiveWarning](#executioninconclusivewarning)
+- [Execution.InvariantCulture](#executioninvariantculture)
 - [Execution.InvariantCultureWarning](#executioninvariantculturewarning)
 - [Execution.InitialSessionState](#executioninitialsessionstate)
 - [Execution.NotProcessedWarning](#executionnotprocessedwarning)
+- [Execution.RuleInconclusive](#executionruleinconclusive)
 - [Execution.SuppressedRuleWarning](#executionsuppressedrulewarning)
 - [Execution.SuppressionGroupExpired](#executionsuppressiongroupexpired)
+- [Execution.UnprocessedObject](#executionunprocessedobject)
 - [Include.Module](#includemodule)
 - [Include.Path](#includepath)
 - [Input.Format](#inputformat)
@@ -673,7 +677,68 @@ variables:
   value: 'Convention1;Convention2'
 ```
 
+### Execution.AliasReference
+
+Determines how to handle when an alias to a resource is used.
+By defaut, a warning is generated, however this behaviour can be modified by this option.
+
+This option replaces `AliasReferenceWarning`.
+You do not need to configure both options.
+If `AliasReferenceWarning` is configured, it will override `AliasReference` with `Warn` or `Ignore` until removal in PSRule v3.
+
+The following preferences are available:
+
+- `None` (0) - No preference.
+  Inherits the default of `Warn`.
+- `Ignore` (1) - Continue to execute silently.
+- `Warn` (2) - Continue to execute but log a warning.
+  This is the default.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+```powershell
+# PowerShell: Using the ExecutionAliasReference parameter
+$option = New-PSRuleOption -ExecutionAliasReference 'Error';
+```
+
+```powershell
+# PowerShell: Using the Execution.AliasReference hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.AliasReference' = 'Error' };
+```
+
+```powershell
+# PowerShell: Using the ExecutionAliasReference parameter to set YAML
+Set-PSRuleOption -ExecutionAliasReference 'Error';
+```
+
+```yaml
+# YAML: Using the execution/aliasReference property
+execution:
+  aliasReference: Error
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_ALIASREFERENCE=Error
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_ALIASREFERENCE: Error
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_ALIASREFERENCE
+  value: Error
+```
+
 ### Execution.AliasReferenceWarning
+
+This option has been deprecated and will be removed from v3 in favor of `aliasReference`.
+Use `aliasReference` instead.
 
 Rules may define one or more aliases.
 These aliases are alternative names to identify the rule.
@@ -828,6 +893,9 @@ variables:
 
 ### Execution.InconclusiveWarning
 
+This option has been deprecated and will be removed from v3 in favor of `ruleInconclusive`.
+Use `ruleInconclusive` instead.
+
 When defining rules, it is possible not return a valid `$True` or `$False` result within the definition script block.
 
 Rule authors should not intentionally avoid returning a result, however a possible cause for not returning a result may be a rule logic error.
@@ -882,7 +950,68 @@ variables:
   value: false
 ```
 
+### Execution.InvariantCulture
+
+Determines how to report when an invariant culture is used.
+By defaut, a warning is generated, however this behaviour can be modified by this option.
+
+This option replaces `InvariantCultureWarning`.
+You do not need to configure both options.
+If `InvariantCultureWarning` is configured, it will override `InvariantCulture` with `Warn` or `Ignore` until removal in PSRule v3.
+
+The following preferences are available:
+
+- `None` (0) - No preference.
+  Inherits the default of `Warn`.
+- `Ignore` (1) - Continue to execute silently.
+- `Warn` (2) - Continue to execute but log a warning.
+  This is the default.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+```powershell
+# PowerShell: Using the ExecutionInvariantCulture parameter
+$option = New-PSRuleOption -ExecutionInvariantCulture 'Error';
+```
+
+```powershell
+# PowerShell: Using the Execution.InvariantCulture hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.InvariantCulture' = 'Error' };
+```
+
+```powershell
+# PowerShell: Using the ExecutionInvariantCulture parameter to set YAML
+Set-PSRuleOption -ExecutionInvariantCulture 'Error';
+```
+
+```yaml
+# YAML: Using the execution/invariantCulture property
+execution:
+  invariantCulture: Error
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_INVARIANTCULTURE=Error
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_INVARIANTCULTURE: Error
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_INVARIANTCULTURE
+  value: Error
+```
+
 ### Execution.InvariantCultureWarning
+
+This option has been deprecated and will be removed from v3 in favor of `invariantCulture`.
+Use `invariantCulture` instead.
 
 When evaluating rules inside a CI host, if invariant culture is used, a warning is shown by default.
 You can suppress this warning if you set the culture with `-Culture` or the `Output.Culture` option.
@@ -979,6 +1108,9 @@ variables:
 
 ### Execution.NotProcessedWarning
 
+This option has been deprecated and will be removed from v3 in favor of `unprocessedObject`.
+Use `unprocessedObject` instead.
+
 When evaluating rules, it is possible to incorrectly select a path with rules that use pre-conditions that do not accept the pipeline object.
 In this case the object has not been processed by any rule.
 
@@ -1026,6 +1158,64 @@ env:
 variables:
 - name: PSRULE_EXECUTION_NOTPROCESSEDWARNING
   value: false
+```
+
+### Execution.RuleInconclusive
+
+Determines how to handle rules that generate inconclusive results.
+By defaut, a warning is generated, however this behaviour can be modified by this option.
+
+This option replaces `InconclusiveWarning`.
+You do not need to configure both options.
+If `InconclusiveWarning` is configured, it will override `RuleInconclusive` with `Warn` or `Ignore` until removal in PSRule v3.
+
+The following preferences are available:
+
+- `None` (0) - No preference.
+  Inherits the default of `Warn`.
+- `Ignore` (1) - Continue to execute silently.
+- `Warn` (2) - Continue to execute but log a warning.
+  This is the default.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+```powershell
+# PowerShell: Using the ExecutionRuleInconclusive parameter
+$option = New-PSRuleOption -ExecutionRuleInconclusive 'Error';
+```
+
+```powershell
+# PowerShell: Using the Execution.RuleInconclusive hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.RuleInconclusive' = 'Error' };
+```
+
+```powershell
+# PowerShell: Using the ExecutionRuleInconclusive parameter to set YAML
+Set-PSRuleOption -ExecutionRuleInconclusive 'Error';
+```
+
+```yaml
+# YAML: Using the execution/ruleInconclusive property
+execution:
+  ruleInconclusive: Error
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_RULEINCONCLUSIVE=Error
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_RULEINCONCLUSIVE: Error
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_RULEINCONCLUSIVE
+  value: Error
 ```
 
 ### Execution.SuppressedRuleWarning
@@ -1248,6 +1438,64 @@ env:
 # Azure Pipelines: Using environment variable
 variables:
 - name: PSRULE_EXECUTION_RULESUPPRESSED
+  value: Error
+```
+
+### Execution.UnprocessedObject
+
+Determines how to report objects that are not processed by any rule.
+By defaut, a warning is generated, however this behaviour can be modified by this option.
+
+This option replaces `NotProcessedWarning`.
+You do not need to configure both options.
+If `NotProcessedWarning` is configured, it will override `UnprocessedObject` with `Warn` or `Ignore` until removal in PSRule v3.
+
+The following preferences are available:
+
+- `None` (0) - No preference.
+  Inherits the default of `Warn`.
+- `Ignore` (1) - Continue to execute silently.
+- `Warn` (2) - Continue to execute but log a warning.
+  This is the default.
+- `Error` (3) - Abort and throw an error.
+- `Debug` (4) - Continue to execute but log a debug message.
+
+```powershell
+# PowerShell: Using the ExecutionUnprocessedObject parameter
+$option = New-PSRuleOption -ExecutionUnprocessedObject 'Error';
+```
+
+```powershell
+# PowerShell: Using the Execution.UnprocessedObject hashtable key
+$option = New-PSRuleOption -Option @{ 'Execution.UnprocessedObject' = 'Error' };
+```
+
+```powershell
+# PowerShell: Using the ExecutionUnprocessedObject parameter to set YAML
+Set-PSRuleOption -ExecutionUnprocessedObject 'Error';
+```
+
+```yaml
+# YAML: Using the execution/unprocessedObject property
+execution:
+  unprocessedObject: Error
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_EXECUTION_UNPROCESSEDOBJECT=Error
+```
+
+```yaml
+# GitHub Actions: Using environment variable
+env:
+  PSRULE_EXECUTION_UNPROCESSEDOBJECT: Error
+```
+
+```yaml
+# Azure Pipelines: Using environment variable
+variables:
+- name: PSRULE_EXECUTION_UNPROCESSEDOBJECT
   value: Error
 ```
 
@@ -3256,13 +3504,14 @@ convention:
 
 # Configure execution options
 execution:
-  aliasReferenceWarning: true
+  aliasReference: Warn
   duplicateResourceId: Error
+  invariantCulture: Warn
   languageMode: FullLanguage
-  inconclusiveWarning: true
-  notProcessedWarning: true
-  suppressedRuleWarning: true
+  ruleInconclusive: Warn
+  ruleSuppressed: Warn
   suppressionGroupExpired: Warn
+  unprocessedObject: Warn
 
 # Configure include options
 include:

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -26,6 +26,18 @@ The following execution options have been deprecated and will be removed from _v
 - `Execution.SuppressedRuleWarning` is replaced with `Execution.RuleSuppressed`.
   Set `Execution.RuleSuppressed` to `Warn` to log a warning from _v2.8.0_.
   If both options are set, `Execution.SuppressedRuleWarning` takes precedence until _v3_.
+- `Execution.AliasReferenceWarning` is replaced with `Execution.AliasReference`.
+  Set `Execution.AliasReference` to `Warn` to log a warning from _v2.9.0_.
+  If both options are set, `Execution.AliasReferenceWarning` takes precedence until _v3_.
+- `Execution.InconclusiveWarning` is replaced with `Execution.RuleInconclusive`.
+  Set `Execution.RuleInconclusive` to `Warn` to log a warning from _v2.9.0_.
+  If both options are set, `Execution.InconclusiveWarning` takes precedence until _v3_.
+- `Execution.InvariantCultureWarning` is replaced with `Execution.InvariantCulture`.
+  Set `Execution.InvariantCulture` to `Warn` to log a warning from _v2.9.0_.
+  If both options are set, `Execution.InvariantCultureWarning` takes precedence until _v3_.
+- `Execution.NotProcessedWarning` is replaced with `Execution.UnprocessedObject`.
+  Set `Execution.UnprocessedObject` to `Warn` to log a warning from _v2.9.0_.
+  If both options are set, `Execution.NotProcessedWarning` takes precedence until _v3_.
 
 !!! Tip
     You do not need to configure both options.

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -283,10 +283,11 @@
       "properties": {
         "aliasReferenceWarning": {
           "type": "boolean",
-          "title": "Warn on resource aliases",
+          "title": "Warn on resource aliases | DEPRECATED",
           "description": "Enable or disable warnings when an alias to a resource is used. The default is true.",
           "markdownDescription": "Enable or disable warnings when an alias to a resource is used. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionaliasreferencewarning)",
-          "default": true
+          "default": true,
+          "deprecated": true
         },
         "duplicateResourceId": {
           "type": "string",
@@ -314,17 +315,19 @@
         },
         "inconclusiveWarning": {
           "type": "boolean",
-          "title": "Warn on inconclusive rules",
+          "title": "Warn on inconclusive rules | DEPRECATED",
           "description": "Enable or disable warnings for inconclusive rules. The default is true.",
           "markdownDescription": "Enable or disable warnings for inconclusive rules. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executioninconclusivewarning)",
-          "default": true
+          "default": true,
+          "deprecated": true
         },
         "invariantCultureWarning": {
           "type": "boolean",
-          "title": "Warn on invariant culture",
+          "title": "Warn on invariant culture | DEPRECATED",
           "description": "Enable or disable warning when invariant culture is used. The default is true.",
           "markdownDescription": "Enable or disable warning when invariant culture is used. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executioninvariantculturewarning)",
-          "default": true
+          "default": true,
+          "deprecated": true
         },
         "initialSessionState": {
           "type": "string",
@@ -339,10 +342,11 @@
         },
         "notProcessedWarning": {
           "type": "boolean",
-          "title": "Warn on unprocessed objects",
+          "title": "Warn on unprocessed objects | DEPRECATED",
           "description": "Enable or disable warnings for objects that are not processed by any rule. The default is true.",
           "markdownDescription": "Enable or disable warnings for objects that are not processed by any rule. The default is `true`. [See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionnotprocessedwarning)",
-          "default": true
+          "default": true,
+          "deprecated": true
         },
         "suppressedRuleWarning": {
           "type": "boolean",
@@ -369,7 +373,7 @@
           "type": "string",
           "title": "Rule excluded",
           "description": "Determines how to handle excluded rules. Regardless of the value, excluded rules are ignored. By default, rules are excluded silently. When set to Error, an error is thrown. When set to Warn, a warning is generated. When set to Debug, a message is written to the debug log.",
-          "markdownDescription": "Determines how to handle excluded rules.\n\nRegardless of the value, excluded rules are ignored. By default, rules are excluded silently.\n\n- When set to `Error`, an error is thrown.\n- When set to `Warn`, a warning is generated.\n- When set to `Debug`, a message is written to the debug log.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionruleexecluded)",
+          "markdownDescription": "Determines how to handle excluded rules.\n\nRegardless of the value, excluded rules are ignored. By default, rules are excluded silently.\n\n- When set to `Error`, an error is thrown.\n- When set to `Warn`, a warning is generated.\n- When set to `Debug`, a message is written to the debug log.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionruleexcluded)",
           "enum": [
             "Ignore",
             "Warn",
@@ -383,6 +387,58 @@
           "title": "Rule suppressed",
           "description": "Determines how to handle suppressed rules. Regardless of the value, a suppressed rule is ignored. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed. This option replaces suppressedRuleWarning. You do not need to configure both options. If suppressedRuleWarning is configured, it will override ruleSuppressed with Warn or Ignore until removal in PSRule v3.",
           "markdownDescription": "Determines how to handle suppressed rules.\n\nRegardless of the value, a suppressed rule is ignored. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\nThis option replaces `suppressedRuleWarning`. You do not need to configure both options. If `suppressedRuleWarning` is configured, it will override `ruleSuppressed` with `Warn` or `Ignore` until removal in PSRule v3.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionrulesuppressed)",
+          "enum": [
+            "Ignore",
+            "Warn",
+            "Error",
+            "Debug"
+          ],
+          "default": "Warn"
+        },
+        "aliasReference": {
+          "type": "string",
+          "title": "Alias references",
+          "description": "Determines how to handle when an alias to a resource is used. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed. This option replaces aliasReferenceWarning. You do not need to configure both options. If aliasReferenceWarning is configured, it will override aliasReference with Warn or Ignore until removal in PSRule v3.",
+          "markdownDescription": "Determines how to handle when an alias to a resource is used. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\nThis option replaces `aliasReferenceWarning`. You do not need to configure both options. If `aliasReferenceWarning` is configured, it will override `aliasReference` with `Warn` or `Ignore` until removal in PSRule v3.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionaliasreference)",
+          "enum": [
+            "Ignore",
+            "Warn",
+            "Error",
+            "Debug"
+          ],
+          "default": "Warn"
+        },
+        "ruleInconclusive": {
+          "type": "string",
+          "title": "Inconclusive rules",
+          "description": "Determines how to handle rules that generate inconclusive results. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed. This option replaces inconclusiveWarning. You do not need to configure both options. If inconclusiveWarning is configured, it will override ruleInconclusive with Warn or Ignore until removal in PSRule v3.",
+          "markdownDescription": "Determines how to handle rules that generate inconclusive results. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\nThis option replaces `inconclusiveWarning`. You do not need to configure both options. If `inconclusiveWarning` is configured, it will override `ruleInconclusive` with `Warn` or `Ignore` until removal in PSRule v3.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionruleinconclusive)",
+          "enum": [
+            "Ignore",
+            "Warn",
+            "Error",
+            "Debug"
+          ],
+          "default": "Warn"
+        },
+        "invariantCulture": {
+          "type": "string",
+          "title": "Invariant culture",
+          "description": "Determines how to report when an invariant culture is used. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed. This option replaces invariantCultureWarning. You do not need to configure both options. If invariantCultureWarning is configured, it will override invariantCulture with Warn or Ignore until removal in PSRule v3.",
+          "markdownDescription": "Determines how to report when an invariant culture is used. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\nThis option replaces `invariantCultureWarning`. You do not need to configure both options. If `invariantCultureWarning` is configured, it will override `invariantCulture` with `Warn` or `Ignore` until removal in PSRule v3.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executioninvariantculture)",
+          "enum": [
+            "Ignore",
+            "Warn",
+            "Error",
+            "Debug"
+          ],
+          "default": "Warn"
+        },
+        "unprocessedObject": {
+          "type": "string",
+          "title": "Unprocessed object",
+          "description": "Determines how to report objects that are not processed by any rule. By default, a warning is generated. When set to Error, an error is thrown. When set to Debug, a message is written to the debug log. When set to Ignore, no output will be displayed. This option replaces notProcessedWarning. You do not need to configure both options. If notProcessedWarning is configured, it will override unprocessedObject with Warn or Ignore until removal in PSRule v3.",
+          "markdownDescription": "Determines how to report objects that are not processed by any rule. By default, a warning is generated.\n\n- When set to `Error`, an error is thrown.\n- When set to `Debug`, a message is written to the debug log.\n- When set to `Ignore`, no output will be displayed.\n\nThis option replaces `notProcessedWarning`. You do not need to configure both options. If `notProcessedWarning` is configured, it will override `unprocessedObject` with `Warn` or `Ignore` until removal in PSRule v3.\n\n[See help](https://microsoft.github.io/PSRule/v2/concepts/PSRule/en-US/about_PSRule_Options/#executionunprocessedobject)",
           "enum": [
             "Ignore",
             "Warn",

--- a/src/PSRule/Common/RunspaceContextDiagnosticExtensions.cs
+++ b/src/PSRule/Common/RunspaceContextDiagnosticExtensions.cs
@@ -102,18 +102,24 @@ namespace PSRule
 
         internal static void WarnAliasReference(this RunspaceContext context, ResourceKind kind, string resourceId, string targetId, string alias)
         {
-            if (context.Writer == null || !context.Writer.ShouldWriteWarning() || !context.Pipeline.Option.Execution.AliasReferenceWarning.GetValueOrDefault(ExecutionOption.Default.AliasReferenceWarning.Value))
-                return;
+#pragma warning disable CS0618 // Type or member is obsolete
+            var action = context.Pipeline.Option.Execution.AliasReference.GetValueOrDefault(ExecutionOption.Default.AliasReference.Value);
+            if (context.Pipeline.Option.Execution.AliasReferenceWarning.HasValue)
+                action = context.Pipeline.Option.Execution.AliasReferenceWarning.Value ? ExecutionActionPreference.Warn : ExecutionActionPreference.Ignore;
+#pragma warning restore CS0618 // Type or member is obsolete
 
-            context.Writer.WriteWarning(PSRuleResources.AliasReference, kind.ToString(), resourceId, targetId, alias);
+            Throw(context, action, PSRuleResources.AliasReference, kind.ToString(), resourceId, targetId, alias);
         }
 
         internal static void WarnAliasSuppression(this RunspaceContext context, string targetId, string alias)
         {
-            if (context.Writer == null || !context.Writer.ShouldWriteWarning() || !context.Pipeline.Option.Execution.AliasReferenceWarning.GetValueOrDefault(ExecutionOption.Default.AliasReferenceWarning.Value))
-                return;
+#pragma warning disable CS0618 // Type or member is obsolete
+            var action = context.Pipeline.Option.Execution.AliasReference.GetValueOrDefault(ExecutionOption.Default.AliasReference.Value);
+            if (context.Pipeline.Option.Execution.AliasReferenceWarning.HasValue)
+                action = context.Pipeline.Option.Execution.AliasReferenceWarning.Value ? ExecutionActionPreference.Warn : ExecutionActionPreference.Ignore;
+#pragma warning restore CS0618 // Type or member is obsolete
 
-            context.Writer.WriteWarning(PSRuleResources.AliasSuppression, targetId, alias);
+            Throw(context, action, PSRuleResources.AliasSuppression, targetId, alias);
         }
     }
 }

--- a/src/PSRule/Configuration/ExecutionOption.cs
+++ b/src/PSRule/Configuration/ExecutionOption.cs
@@ -16,28 +16,28 @@ namespace PSRule.Configuration
     public sealed class ExecutionOption : IEquatable<ExecutionOption>
     {
         private const LanguageMode DEFAULT_LANGUAGEMODE = Configuration.LanguageMode.FullLanguage;
-        private const bool DEFAULT_INCONCLUSIVEWARNING = true;
-        private const bool DEFAULT_NOTPROCESSEDWARNING = true;
-        private const bool DEFAULT_ALIASREFERENCEWARNING = true;
-        private const bool DEFAULT_INVARIANTCULTUREWARNING = true;
         private const ExecutionActionPreference DEFAULT_DUPLICATERESOURCEID = ExecutionActionPreference.Error;
         private const SessionState DEFAULT_INITIALSESSIONSTATE = SessionState.BuiltIn;
         private const ExecutionActionPreference DEFAULT_SUPPRESSIONGROUPEXPIRED = ExecutionActionPreference.Warn;
         private const ExecutionActionPreference DEFAULT_RULEEXCLUDED = ExecutionActionPreference.Ignore;
         private const ExecutionActionPreference DEFAULT_RULESUPPRESSED = ExecutionActionPreference.Warn;
+        private const ExecutionActionPreference DEFAULT_ALIASREFERENCE = ExecutionActionPreference.Warn;
+        private const ExecutionActionPreference DEFAULT_RULEINCONCLUSIVE = ExecutionActionPreference.Warn;
+        private const ExecutionActionPreference DEFAULT_INVARIANTCULTURE = ExecutionActionPreference.Warn;
+        private const ExecutionActionPreference DEFAULT_UNPROCESSEDOBJECT = ExecutionActionPreference.Warn;
 
         internal static readonly ExecutionOption Default = new()
         {
-            AliasReferenceWarning = DEFAULT_ALIASREFERENCEWARNING,
             DuplicateResourceId = DEFAULT_DUPLICATERESOURCEID,
             LanguageMode = DEFAULT_LANGUAGEMODE,
-            InconclusiveWarning = DEFAULT_INCONCLUSIVEWARNING,
-            InvariantCultureWarning = DEFAULT_INVARIANTCULTUREWARNING,
             InitialSessionState = DEFAULT_INITIALSESSIONSTATE,
-            NotProcessedWarning = DEFAULT_NOTPROCESSEDWARNING,
             SuppressionGroupExpired = DEFAULT_SUPPRESSIONGROUPEXPIRED,
             RuleExcluded = DEFAULT_RULEEXCLUDED,
             RuleSuppressed = DEFAULT_RULESUPPRESSED,
+            AliasReference = DEFAULT_ALIASREFERENCE,
+            RuleInconclusive = DEFAULT_RULEINCONCLUSIVE,
+            InvariantCulture = DEFAULT_INVARIANTCULTURE,
+            UnprocessedObject = DEFAULT_UNPROCESSEDOBJECT,
         };
 
         /// <summary>
@@ -45,6 +45,7 @@ namespace PSRule.Configuration
         /// </summary>
         public ExecutionOption()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             AliasReferenceWarning = null;
             DuplicateResourceId = null;
             LanguageMode = null;
@@ -52,12 +53,15 @@ namespace PSRule.Configuration
             InvariantCultureWarning = null;
             InitialSessionState = null;
             NotProcessedWarning = null;
-#pragma warning disable CS0612 // Type or member is obsolete
             SuppressedRuleWarning = null;
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             SuppressionGroupExpired = null;
             RuleExcluded = null;
             RuleSuppressed = null;
+            AliasReference = null;
+            RuleInconclusive = null;
+            InvariantCulture = null;
+            UnprocessedObject = null;
         }
 
         /// <summary>
@@ -69,6 +73,7 @@ namespace PSRule.Configuration
             if (option == null)
                 return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             AliasReferenceWarning = option.AliasReferenceWarning;
             DuplicateResourceId = option.DuplicateResourceId;
             LanguageMode = option.LanguageMode;
@@ -76,12 +81,15 @@ namespace PSRule.Configuration
             InvariantCultureWarning = option.InvariantCultureWarning;
             InitialSessionState = option.InitialSessionState;
             NotProcessedWarning = option.NotProcessedWarning;
-#pragma warning disable CS0612 // Type or member is obsolete
             SuppressedRuleWarning = option.SuppressedRuleWarning;
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             SuppressionGroupExpired = option.SuppressionGroupExpired;
             RuleExcluded = option.RuleExcluded;
             RuleSuppressed = option.RuleSuppressed;
+            AliasReference = option.AliasReference;
+            RuleInconclusive = option.RuleInconclusive;
+            InvariantCulture = option.InvariantCulture;
+            UnprocessedObject = option.UnprocessedObject;
         }
 
         /// <inheritdoc/>
@@ -93,7 +101,7 @@ namespace PSRule.Configuration
         /// <inheritdoc/>
         public bool Equals(ExecutionOption other)
         {
-#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             return other != null &&
                 AliasReferenceWarning == other.AliasReferenceWarning &&
                 DuplicateResourceId == other.DuplicateResourceId &&
@@ -105,8 +113,12 @@ namespace PSRule.Configuration
                 SuppressedRuleWarning == other.SuppressedRuleWarning &&
                 SuppressionGroupExpired == other.SuppressionGroupExpired &&
                 RuleExcluded == other.RuleExcluded &&
-                RuleSuppressed == other.RuleSuppressed;
-#pragma warning restore CS0612 // Type or member is obsolete
+                RuleSuppressed == other.RuleSuppressed &&
+                AliasReference == other.AliasReference &&
+                RuleInconclusive == other.RuleInconclusive &&
+                InvariantCulture == other.InvariantCulture &&
+                UnprocessedObject == other.UnprocessedObject;
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <inheritdoc/>
@@ -115,6 +127,7 @@ namespace PSRule.Configuration
             unchecked // Overflow is fine
             {
                 var hash = 17;
+#pragma warning disable CS0618 // Type or member is obsolete
                 hash = hash * 23 + (AliasReferenceWarning.HasValue ? AliasReferenceWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (DuplicateResourceId.HasValue ? DuplicateResourceId.Value.GetHashCode() : 0);
                 hash = hash * 23 + (LanguageMode.HasValue ? LanguageMode.Value.GetHashCode() : 0);
@@ -122,12 +135,15 @@ namespace PSRule.Configuration
                 hash = hash * 23 + (InvariantCultureWarning.HasValue ? InvariantCultureWarning.Value.GetHashCode() : 0);
                 hash = hash * 23 + (InitialSessionState.HasValue ? InitialSessionState.Value.GetHashCode() : 0);
                 hash = hash * 23 + (NotProcessedWarning.HasValue ? NotProcessedWarning.Value.GetHashCode() : 0);
-#pragma warning disable CS0612 // Type or member is obsolete
                 hash = hash * 23 + (SuppressedRuleWarning.HasValue ? SuppressedRuleWarning.Value.GetHashCode() : 0);
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
                 hash = hash * 23 + (SuppressionGroupExpired.HasValue ? SuppressionGroupExpired.Value.GetHashCode() : 0);
                 hash = hash * 23 + (RuleExcluded.HasValue ? RuleExcluded.Value.GetHashCode() : 0);
                 hash = hash * 23 + (RuleSuppressed.HasValue ? RuleSuppressed.Value.GetHashCode() : 0);
+                hash = hash * 23 + (AliasReference.HasValue ? AliasReference.Value.GetHashCode() : 0);
+                hash = hash * 23 + (RuleInconclusive.HasValue ? RuleInconclusive.Value.GetHashCode() : 0);
+                hash = hash * 23 + (InvariantCulture.HasValue ? InvariantCulture.Value.GetHashCode() : 0);
+                hash = hash * 23 + (UnprocessedObject.HasValue ? UnprocessedObject.Value.GetHashCode() : 0);
                 return hash;
             }
         }
@@ -138,7 +154,7 @@ namespace PSRule.Configuration
         /// </summary>
         internal static ExecutionOption Combine(ExecutionOption o1, ExecutionOption o2)
         {
-#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             var result = new ExecutionOption(o1)
             {
                 AliasReferenceWarning = o1.AliasReferenceWarning ?? o2.AliasReferenceWarning,
@@ -152,15 +168,19 @@ namespace PSRule.Configuration
                 SuppressionGroupExpired = o1.SuppressionGroupExpired ?? o2.SuppressionGroupExpired,
                 RuleExcluded = o1.RuleExcluded ?? o2.RuleExcluded,
                 RuleSuppressed = o1.RuleSuppressed ?? o2.RuleSuppressed,
+                AliasReference = o1.AliasReference ?? o2.AliasReference,
+                RuleInconclusive = o1.RuleInconclusive ?? o2.RuleInconclusive,
+                InvariantCulture = o1.InvariantCulture ?? o2.InvariantCulture,
+                UnprocessedObject = o1.UnprocessedObject ?? o2.UnprocessedObject,
             };
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
             return result;
         }
 
         /// <summary>
         /// Determines if a warning is raised when an alias to a resource is used.
         /// </summary>
-        [DefaultValue(null)]
+        [DefaultValue(null), Obsolete("Use AliasReference instead. See https://aka.ms/ps-rule/deprecations for more detail.")]
         public bool? AliasReferenceWarning { get; set; }
 
         /// <summary>
@@ -183,13 +203,13 @@ namespace PSRule.Configuration
         /// <summary>
         /// Determines if a warning is raised when a rule does not return pass or fail.
         /// </summary>
-        [DefaultValue(null)]
+        [DefaultValue(null), Obsolete("Use RuleInconclusive instead. See https://aka.ms/ps-rule/deprecations for more detail.")]
         public bool? InconclusiveWarning { get; set; }
 
         /// <summary>
         /// Determines if warning is raised when invariant culture is used.
         /// </summary>
-        [DefaultValue(null)]
+        [DefaultValue(null), Obsolete("Use InvariantCulture instead. See https://aka.ms/ps-rule/deprecations for more detail.")]
         public bool? InvariantCultureWarning { get; set; }
 
         /// <summary>
@@ -202,7 +222,7 @@ namespace PSRule.Configuration
         /// <summary>
         /// Determines if a warning is raised when an object is not processed by any rule.
         /// </summary>
-        [DefaultValue(null)]
+        [DefaultValue(null), Obsolete("Use UnprocessedObject instead. See https://aka.ms/ps-rule/deprecations for more detail.")]
         public bool? NotProcessedWarning { get; set; }
 
         /// <summary>
@@ -224,7 +244,7 @@ namespace PSRule.Configuration
 
         /// <summary>
         /// Determines how to handle rules that are excluded.
-        /// By default, a excluded rules do not generated any output.
+        /// By default, excluded rules do not generated any output.
         /// When set to Error, an error is thrown.
         /// When set to Warn, a warning is generated.
         /// When set to Debug, a message is written to the debug log.
@@ -247,8 +267,72 @@ namespace PSRule.Configuration
         [DefaultValue(null)]
         public ExecutionActionPreference? RuleSuppressed { get; set; }
 
+        /// <summary>
+        /// Determines how to handle when an alias to a resource is used.
+        /// This option replaces <seealso cref="AliasReferenceWarning"/>.
+        /// By default, a warning is generated.
+        /// When set to Error, an error is thrown.
+        /// When set to Debug, a message is written to the debug log.
+        /// When set to Ignore, no output will be displayed.
+        /// </summary>
+        /// <remarks>
+        /// If <seealso cref="AliasReferenceWarning"/> is <c>true</c> this option will be overridden to <c>Warn</c>.
+        /// If <seealso cref="AliasReferenceWarning"/> is <c>false</c> this option will be overridden to <c>Ignore</c>.
+        /// </remarks>
+        [DefaultValue(null)]
+        public ExecutionActionPreference? AliasReference { get; set; }
+
+        /// <summary>
+        /// Determines how to handle rules that generate inconclusive results.
+        /// This option replaces <seealso cref="InconclusiveWarning"/>.
+        /// By default, a warning is generated.
+        /// When set to Error, an error is thrown.
+        /// When set to Debug, a message is written to the debug log.
+        /// When set to Ignore, no output will be displayed.
+        /// </summary>
+        /// <remarks>
+        /// If <seealso cref="InconclusiveWarning"/> is <c>true</c> this option will be overridden to <c>Warn</c>.
+        /// If <seealso cref="InconclusiveWarning"/> is <c>false</c> this option will be overridden to <c>Ignore</c>.
+        /// </remarks>
+        [DefaultValue(null)]
+        public ExecutionActionPreference? RuleInconclusive { get; set; }
+
+        /// <summary>
+        /// Determines how to report when an invariant culture is used.
+        /// This option replaces <seealso cref="InvariantCultureWarning"/>.
+        /// By default, a warning is generated.
+        /// When set to Error, an error is thrown.
+        /// When set to Debug, a message is written to the debug log.
+        /// When set to Ignore, no output will be displayed.
+        /// </summary>
+        /// <remarks>
+        /// If <seealso cref="InvariantCultureWarning"/> is <c>true</c> this option will be overridden to <c>Warn</c>.
+        /// If <seealso cref="InvariantCultureWarning"/> is <c>false</c> this option will be overridden to <c>Ignore</c>.
+        /// </remarks>
+        [DefaultValue(null)]
+        public ExecutionActionPreference? InvariantCulture { get; set; }
+
+        /// <summary>
+        /// Determines how to report objects that are not processed by any rule.
+        /// This option replaces <seealso cref="NotProcessedWarning"/>.
+        /// By default, a warning is generated.
+        /// When set to Error, an error is thrown.
+        /// When set to Debug, a message is written to the debug log.
+        /// When set to Ignore, no output will be displayed.
+        /// </summary>
+        /// <remarks>
+        /// If <seealso cref="NotProcessedWarning"/> is <c>true</c> this option will be overridden to <c>Warn</c>.
+        /// If <seealso cref="NotProcessedWarning"/> is <c>false</c> this option will be overridden to <c>Ignore</c>.
+        /// </remarks>
+        [DefaultValue(null)]
+        public ExecutionActionPreference? UnprocessedObject { get; set; }
+
+        /// <summary>
+        /// Load from environment variables.
+        /// </summary>
         internal void Load(EnvironmentHelper env)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (env.TryBool("PSRULE_EXECUTION_ALIASREFERENCEWARNING", out var bvalue))
                 AliasReferenceWarning = bvalue;
 
@@ -271,9 +355,8 @@ namespace PSRule.Configuration
                 NotProcessedWarning = bvalue;
 
             if (env.TryBool("PSRULE_EXECUTION_SUPPRESSEDRULEWARNING", out bvalue))
-#pragma warning disable CS0612 // Type or member is obsolete
                 SuppressedRuleWarning = bvalue;
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (env.TryEnum("PSRULE_EXECUTION_SUPPRESSIONGROUPEXPIRED", out ExecutionActionPreference suppressionGroupExpired))
                 SuppressionGroupExpired = suppressionGroupExpired;
@@ -283,10 +366,26 @@ namespace PSRule.Configuration
 
             if (env.TryEnum("PSRULE_EXECUTION_RULESUPPRESSED", out ExecutionActionPreference ruleSuppressed))
                 RuleSuppressed = ruleSuppressed;
+
+            if (env.TryEnum("PSRULE_EXECUTION_ALIASREFERENCE", out ExecutionActionPreference aliasReference))
+                AliasReference = aliasReference;
+
+            if (env.TryEnum("PSRULE_EXECUTION_RULEINCONCLUSIVE", out ExecutionActionPreference ruleInconclusive))
+                RuleInconclusive = ruleInconclusive;
+
+            if (env.TryEnum("PSRULE_EXECUTION_INVARIANTCULTURE", out ExecutionActionPreference invariantCulture))
+                InvariantCulture = invariantCulture;
+
+            if (env.TryEnum("PSRULE_EXECUTION_UNPROCESSEDOBJECT", out ExecutionActionPreference unprocessedObject))
+                UnprocessedObject = unprocessedObject;
         }
 
+        /// <summary>
+        /// Load from dictionary.
+        /// </summary>
         internal void Load(Dictionary<string, object> index)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             if (index.TryPopBool("Execution.AliasReferenceWarning", out var bvalue))
                 AliasReferenceWarning = bvalue;
 
@@ -309,9 +408,8 @@ namespace PSRule.Configuration
                 NotProcessedWarning = bvalue;
 
             if (index.TryPopBool("Execution.SuppressedRuleWarning", out bvalue))
-#pragma warning disable CS0612 // Type or member is obsolete
                 SuppressedRuleWarning = bvalue;
-#pragma warning restore CS0612 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
             if (index.TryPopEnum("Execution.SuppressionGroupExpired", out ExecutionActionPreference suppressionGroupExpired))
                 SuppressionGroupExpired = suppressionGroupExpired;
@@ -321,6 +419,18 @@ namespace PSRule.Configuration
 
             if (index.TryPopEnum("Execution.RuleSuppressed", out ExecutionActionPreference ruleSuppressed))
                 RuleSuppressed = ruleSuppressed;
+
+            if (index.TryPopEnum("Execution.AliasReference", out ExecutionActionPreference aliasReference))
+                AliasReference = aliasReference;
+
+            if (index.TryPopEnum("Execution.RuleInconclusive", out ExecutionActionPreference ruleInconclusive))
+                RuleInconclusive = ruleInconclusive;
+
+            if (index.TryPopEnum("Execution.InvariantCulture", out ExecutionActionPreference invariantCulture))
+                InvariantCulture = invariantCulture;
+
+            if (index.TryPopEnum("Execution.UnprocessedObject", out ExecutionActionPreference unprocessedObject))
+                UnprocessedObject = unprocessedObject;
         }
     }
 }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1213,6 +1213,22 @@ function New-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleSuppressed = [PSRule.Configuration.ExecutionActionPreference]::Warn,
 
+        # Sets the Execution.AliasReference option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionAliasReference = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.RuleInconclusive option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleInconclusive = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.InvariantCulture option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionInvariantCulture = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.UnprocessedObject option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionUnprocessedObject = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -1522,6 +1538,22 @@ function Set-PSRuleOption {
         # Sets the Execution.RuleSuppressed option
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleSuppressed = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.AliasReference option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionAliasReference = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.RuleInconclusive option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleInconclusive = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.InvariantCulture option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionInvariantCulture = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.UnprocessedObject option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionUnprocessedObject = [PSRule.Configuration.ExecutionActionPreference]::Warn,
 
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
@@ -2279,6 +2311,22 @@ function SetOptions {
         [Parameter(Mandatory = $False)]
         [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleSuppressed = [PSRule.Configuration.ExecutionActionPreference]::Warn,
 
+        # Sets the Execution.AliasReference option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionAliasReference = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.RuleInconclusive option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionRuleInconclusive = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.InvariantCulture option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionInvariantCulture = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
+        # Sets the Execution.UnprocessedObject option
+        [Parameter(Mandatory = $False)]
+        [PSRule.Configuration.ExecutionActionPreference]$ExecutionUnprocessedObject = [PSRule.Configuration.ExecutionActionPreference]::Warn,
+
         # Sets the Include.Module option
         [Parameter(Mandatory = $False)]
         [String[]]$IncludeModule,
@@ -2499,6 +2547,26 @@ function SetOptions {
         # Sets option Execution.RuleSuppressed
         if ($PSBoundParameters.ContainsKey('ExecutionRuleSuppressed')) {
             $Option.Execution.RuleSuppressed = $ExecutionRuleSuppressed;
+        }
+
+        # Sets option Execution.AliasReference
+        if ($PSBoundParameters.ContainsKey('ExecutionAliasReference')) {
+            $Option.Execution.AliasReference = $ExecutionAliasReference;
+        }
+
+        # Sets option Execution.RuleInconclusive
+        if ($PSBoundParameters.ContainsKey('ExecutionRuleInconclusive')) {
+            $Option.Execution.RuleInconclusive = $ExecutionRuleInconclusive;
+        }
+
+        # Sets option Execution.InvariantCulture
+        if ($PSBoundParameters.ContainsKey('ExecutionInvariantCulture')) {
+            $Option.Execution.InvariantCulture = $ExecutionInvariantCulture;
+        }
+
+        # Sets option Execution.UnprocessedObject
+        if ($PSBoundParameters.ContainsKey('ExecutionUnprocessedObject')) {
+            $Option.Execution.UnprocessedObject = $ExecutionUnprocessedObject;
         }
 
         # Sets option Include.Module

--- a/src/PSRule/Pipeline/InvokeRulePipeline.cs
+++ b/src/PSRule/Pipeline/InvokeRulePipeline.cs
@@ -36,10 +36,18 @@ namespace PSRule.Pipeline
             if (RuleCount == 0)
                 Context.WarnRuleNotFound();
 
-#pragma warning disable CS0612 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
             if (context.Option.Execution.SuppressedRuleWarning.HasValue)
                 Context.WarnDeprecatedOption("Execution.SuppressedRuleWarning");
-#pragma warning restore CS0612 // Type or member is obsolete
+            if (context.Option.Execution.AliasReferenceWarning.HasValue)
+                Context.WarnDeprecatedOption("Execution.AliasReferenceWarning");
+            if (context.Option.Execution.InconclusiveWarning.HasValue)
+                Context.WarnDeprecatedOption("Execution.InconclusiveWarning");
+            if (context.Option.Execution.InvariantCultureWarning.HasValue)
+                Context.WarnDeprecatedOption("Execution.InvariantCultureWarning");
+            if (context.Option.Execution.NotProcessedWarning.HasValue)
+                Context.WarnDeprecatedOption("Execution.NotProcessedWarning");
+#pragma warning restore CS0618 // Type or member is obsolete
 
             _Outcome = outcome;
             _IsSummary = context.Option.Output.As.Value == ResultFormat.Summary;

--- a/src/PSRule/Pipeline/PipelineWriterExtensions.cs
+++ b/src/PSRule/Pipeline/PipelineWriterExtensions.cs
@@ -32,14 +32,6 @@ namespace PSRule.Pipeline
             logger.WriteDebug(new DebugRecord(message));
         }
 
-        internal static void WarnUsingInvariantCulture(this IPipelineWriter writer)
-        {
-            if (writer == null || !writer.ShouldWriteWarning())
-                return;
-
-            writer.WriteWarning(PSRuleResources.UsingInvariantCulture);
-        }
-
         internal static void WarnRulePathNotFound(this IPipelineWriter writer)
         {
             if (writer == null || !writer.ShouldWriteWarning())

--- a/tests/PSRule.Tests/PSRule.Common.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Common.Tests.ps1
@@ -100,7 +100,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
         }
 
         It 'Returns inconclusive' {
-            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $option = @{ 'Execution.RuleInconclusive' = 'Ignore' };
             $result = $testObject | Invoke-PSRule -Path $ruleFilePath -Name 'FromFile3' -Outcome All -Option $option;
             $result | Should -Not -BeNullOrEmpty;
             $result.IsSuccess() | Should -Be $False;
@@ -1213,7 +1213,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show Warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Warn -OutputAs Detail -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Warn -OutputAs Detail -ExecutionInvariantCulture 'Ignore';
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1227,7 +1227,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Ignore -OutputAs Detail -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Ignore -OutputAs Detail -ExecutionInvariantCulture 'Ignore';
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1238,7 +1238,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Warn -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Warn -OutputAs Summary -ExecutionInvariantCulture 'Ignore';
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1250,7 +1250,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Ignore -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -SuppressTargetName @{ FromFile1 = 'TestObject1'; FromFile2 = 'TestObject1'; } -ExecutionRuleSuppressed Ignore -OutputAs Summary -ExecutionInvariantCulture 'Ignore';
 
                 $Null = $testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'FromFile1', 'FromFile2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
     
@@ -1294,7 +1294,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Detail' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Detail -InvariantCultureWarning $False -OutputCulture 'en-US';
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Detail -ExecutionInvariantCulture Ignore -OutputCulture 'en-US';
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1318,7 +1318,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'Show warnings for all rules when rule property is null or empty' {
-                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Detail -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Detail -ExecutionInvariantCulture Ignore -SuppressionGroupExpired Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1330,7 +1330,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -ExecutionRuleSuppressed Ignore -OutputAs Detail -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Ignore -OutputAs Detail -ExecutionInvariantCulture Ignore -SuppressionGroupExpired Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile1', 'FromFile2', 'WithTag2' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1341,7 +1341,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
 
         Context 'Summary' {
             It 'Show warnings' {
-                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Summary -InvariantCultureWarning $False -SuppressionGroupExpired Ignore -OutputCulture 'en-US';
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Summary -ExecutionInvariantCulture Ignore -SuppressionGroupExpired Ignore -OutputCulture 'en-US';
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1359,7 +1359,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'Show warnings for all rules when rule property is null or empty' {
-                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Summary -InvariantCultureWarning $False;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Warn -OutputAs Summary -ExecutionInvariantCulture Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams2 -Option $option -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1373,7 +1373,7 @@ Describe 'Invoke-PSRule' -Tag 'Invoke-PSRule','Common' {
             }
 
             It 'No warnings' {
-                $option = New-PSRuleOption -ExecutionRuleSuppressed Ignore -OutputAs Summary -InvariantCultureWarning $False -SuppressionGroupExpired Ignore;
+                $option = New-PSRuleOption -ExecutionRuleSuppressed Ignore -OutputAs Summary -ExecutionInvariantCulture Ignore -SuppressionGroupExpired Ignore;
 
                 $Null = $testObject | Invoke-PSRule @invokeParams -Option $option -Name 'FromFile3', 'FromFile5', 'WithTag3' -WarningVariable outWarnings -WarningAction SilentlyContinue;
 
@@ -1408,7 +1408,7 @@ Describe 'Test-PSRuleTarget' -Tag 'Test-PSRuleTarget','Common' {
             $result | Should -Be $True;
 
             # Check result with one failing rule
-            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $option = @{ 'Execution.RuleInconclusive' = 'Ignore' };
             $result = $testObject | Test-PSRuleTarget -Path $ruleFilePath -Name 'FromFile1', 'FromFile2', 'FromFile3' -Option $option;
             $result | Should -Not -BeNullOrEmpty;
             $result | Should -BeOfType System.Boolean;
@@ -1632,7 +1632,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             # Check multiple
             $assertParams = @{
                 Path = $ruleFilePath
-                Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain' }
+                Option = @{ 'Execution.RuleInconclusive' = 'Ignore'; 'Output.Style' = 'Plain' }
                 Name = 'FromFile1', 'FromFile2', 'FromFile3'
                 ErrorVariable = 'errorOut'
             }
@@ -1657,7 +1657,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $testOutputPath = (Join-Path -Path $outputPath -ChildPath 'newPath/assert.results.json');
             $assertParams = @{
                 Path = $ruleFilePath
-                Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain'; 'Binding.Field' = @{ extra = 'Name'} }
+                Option = @{ 'Execution.RuleInconclusive' = 'Ignore'; 'Output.Style' = 'Plain'; 'Binding.Field' = @{ extra = 'Name'} }
                 Name = 'FromFile1', 'FromFile2', 'FromFile3'
                 ErrorVariable = 'errorOut'
                 OutputFormat = 'Json'
@@ -1676,7 +1676,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
         It 'With -WarningAction' {
             $assertParams = @{
                 Path = $ruleFilePath
-                Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain' }
+                Option = @{ 'Execution.RuleInconclusive' = 'Ignore'; 'Output.Style' = 'Plain' }
                 Name = 'WithWarning'
             }
             $result = $testObject | Assert-PSRule @assertParams 6>&1 | Out-String;
@@ -1694,7 +1694,7 @@ Describe 'Assert-PSRule' -Tag 'Assert-PSRule','Common' {
             $testOutputPath = (Join-Path -Path $outputPath -ChildPath 'newPath/assert.results2.json');
             $assertParams = @{
                 Path = $ruleFilePath
-                Option = @{ 'Execution.InconclusiveWarning' = $False; 'Output.Style' = 'Plain'; 'Binding.Field' = @{ extra = 'Name'} }
+                Option = @{ 'Execution.RuleInconclusive' = 'Ignore'; 'Output.Style' = 'Plain'; 'Binding.Field' = @{ extra = 'Name'} }
                 Name = 'FromFile2', 'FromFile3', 'WithError', 'WithException'
                 ErrorVariable = 'errorOut'
                 OutputFormat = 'Json'
@@ -1831,7 +1831,7 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         It 'Returns rules in current path' {
             try {
                 Push-Location -Path $searchPath;
-                $result = @(Get-PSRule  -Path $PWD -Option @{ 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule  -Path $PWD -Option @{ 'Execution.InvariantCulture' = 'Ignore' })
                 $result | Should -Not -BeNullOrEmpty;
                 $result.Length | Should -Be 3;
                 $result.RuleName | Should -BeIn 'M1.Rule1', 'M1.Rule2', 'M1.YamlTestName';
@@ -1947,31 +1947,31 @@ Describe 'Get-PSRule' -Tag 'Get-PSRule','Common' {
         It 'Uses rules with include option' {
             Push-Location -Path (Join-Path -Path $here -ChildPath 'rules/')
             try {
-                $result = @(Get-PSRule -Path $PWD -Option @{ 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path $PWD -Option @{ 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 4;
 
-                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 1;
 
-                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/', 'extra/'; 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = 'main/', 'extra/'; 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 2;
 
-                $result = @(Get-PSRule -Option @{ 'Include.Path' = '.'; 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Option @{ 'Include.Path' = '.'; 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 4;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 2;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = @(); 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = @(); 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 1;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/'; 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/'; 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 2;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/', '.ps-rule/'; 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'extra/', '.ps-rule/'; 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 3;
 
-                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCultureWarning' = $False })
+                $result = @(Get-PSRule -Path 'main/' -Option @{ 'Include.Path' = 'main/'; 'Execution.InvariantCulture' = 'Ignore' })
                 $result.Length | Should -Be 1;
             }
             finally {
@@ -2368,7 +2368,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
         BeforeAll {
             # Get a list of rules
             $searchPath = Join-Path -Path $here -ChildPath 'TestModule';
-            $options = @{ 'Execution.InvariantCultureWarning' = $False }
+            $options = @{ 'Execution.InvariantCulture' = 'Ignore' }
         }
 
         It 'Docs from imported module' {
@@ -2429,7 +2429,7 @@ Describe 'Get-PSRuleHelp' -Tag 'Get-PSRuleHelp', 'Common' {
             try {
                 Push-Location $searchPath;
                 { Get-PSRuleHelp -Path $PWD } | Should -Throw "The resource '.\M1.Rule2' is using a duplicate resource identifier. A resource with the identifier '.\M1.Rule2' already exists. Each resource must have a unique name, ref, and aliases. See https://aka.ms/ps-rule/naming for guidance on naming within PSRule.";
-                Get-PSRuleHelp -Path $PWD -Option @{ 'Execution.DuplicateResourceId' = 'Warn'; 'Execution.InvariantCultureWarning' = $False } -WarningVariable outWarn -WarningAction SilentlyContinue;
+                Get-PSRuleHelp -Path $PWD -Option @{ 'Execution.DuplicateResourceId' = 'Warn'; 'Execution.InvariantCulture' = 'Ignore' } -WarningVariable outWarn -WarningAction SilentlyContinue;
                 $warnings = @($outWarn);
                 $warnings.Count | Should -Be 1;
                 $warnings | Should -Be "The resource '.\M1.Rule2' is using a duplicate resource identifier. A resource with the identifier '.\M1.Rule2' already exists. Each resource must have a unique name, ref, and aliases. See https://aka.ms/ps-rule/naming for guidance on naming within PSRule.";

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -625,7 +625,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     Context 'Read Execution.InconclusiveWarning' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
-            $option.Execution.InconclusiveWarning | Should -Be $True;
+            $option.Execution.InconclusiveWarning | Should -Be $Null;
         }
 
         It 'from Hashtable' {
@@ -664,7 +664,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     Context 'Read Execution.NotProcessedWarning' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
-            $option.Execution.NotProcessedWarning | Should -Be $True;
+            $option.Execution.NotProcessedWarning | Should -Be $Null;
         }
 
         It 'from Hashtable' {
@@ -875,10 +875,198 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Execution.AliasReference' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.AliasReference | Should -Be 'Warn';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.AliasReference' = 'error' };
+            $option.Execution.AliasReference | Should -Be 'Error';
+
+            $option = New-PSRuleOption -Option @{ 'Execution.AliasReference' = 'Error' };
+            $option.Execution.AliasReference | Should -Be 'Error';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.AliasReference | Should -Be 'Ignore';
+        }
+
+        It 'from Environment' {
+            try {
+                # With enum
+                $Env:PSRULE_EXECUTION_ALIASREFERENCE = 'error';
+                $option = New-PSRuleOption;
+                $option.Execution.AliasReference | Should -Be 'Error';
+
+                # With enum
+                $Env:PSRULE_EXECUTION_ALIASREFERENCE = 'Error';
+                $option = New-PSRuleOption;
+                $option.Execution.AliasReference | Should -Be 'Error';
+
+                # With int
+                $Env:PSRULE_EXECUTION_ALIASREFERENCE = '3';
+                $option = New-PSRuleOption;
+                $option.Execution.AliasReference | Should -Be 'Error';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_ALIASREFERENCE' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionAliasReference 'Error' -Path $emptyOptionsFilePath;
+            $option.Execution.AliasReference | Should -Be 'Error';
+        }
+    }
+
+    Context 'Read Execution.RuleInconclusive' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.RuleInconclusive | Should -Be 'Warn';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.RuleInconclusive' = 'error' };
+            $option.Execution.RuleInconclusive | Should -Be 'Error';
+
+            $option = New-PSRuleOption -Option @{ 'Execution.RuleInconclusive' = 'Error' };
+            $option.Execution.RuleInconclusive | Should -Be 'Error';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.RuleInconclusive | Should -Be 'Ignore';
+        }
+
+        It 'from Environment' {
+            try {
+                # With enum
+                $Env:PSRULE_EXECUTION_RULEINCONCLUSIVE = 'error';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleInconclusive | Should -Be 'Error';
+
+                # With enum
+                $Env:PSRULE_EXECUTION_RULEINCONCLUSIVE = 'Error';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleInconclusive | Should -Be 'Error';
+
+                # With int
+                $Env:PSRULE_EXECUTION_RULEINCONCLUSIVE = '3';
+                $option = New-PSRuleOption;
+                $option.Execution.RuleInconclusive | Should -Be 'Error';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_RULEINCONCLUSIVE' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionRuleInconclusive 'Error' -Path $emptyOptionsFilePath;
+            $option.Execution.RuleInconclusive | Should -Be 'Error';
+        }
+    }
+
+    Context 'Read Execution.InvariantCulture' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.InvariantCulture | Should -Be 'Warn';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.InvariantCulture' = 'error' };
+            $option.Execution.InvariantCulture | Should -Be 'Error';
+
+            $option = New-PSRuleOption -Option @{ 'Execution.InvariantCulture' = 'Error' };
+            $option.Execution.InvariantCulture | Should -Be 'Error';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.InvariantCulture | Should -Be 'Ignore';
+        }
+
+        It 'from Environment' {
+            try {
+                # With enum
+                $Env:PSRULE_EXECUTION_INVARIANTCULTURE = 'error';
+                $option = New-PSRuleOption;
+                $option.Execution.InvariantCulture | Should -Be 'Error';
+
+                # With enum
+                $Env:PSRULE_EXECUTION_INVARIANTCULTURE = 'Error';
+                $option = New-PSRuleOption;
+                $option.Execution.InvariantCulture | Should -Be 'Error';
+
+                # With int
+                $Env:PSRULE_EXECUTION_INVARIANTCULTURE = '3';
+                $option = New-PSRuleOption;
+                $option.Execution.InvariantCulture | Should -Be 'Error';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_INVARIANTCULTURE' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionInvariantCulture 'Error' -Path $emptyOptionsFilePath;
+            $option.Execution.InvariantCulture | Should -Be 'Error';
+        }
+    }
+
+    Context 'Read Execution.UnprocessedObject' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Execution.UnprocessedObject | Should -Be 'Warn';
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Execution.UnprocessedObject' = 'error' };
+            $option.Execution.UnprocessedObject | Should -Be 'Error';
+
+            $option = New-PSRuleOption -Option @{ 'Execution.UnprocessedObject' = 'Error' };
+            $option.Execution.UnprocessedObject | Should -Be 'Error';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Execution.UnprocessedObject | Should -Be 'Ignore';
+        }
+
+        It 'from Environment' {
+            try {
+                # With enum
+                $Env:PSRULE_EXECUTION_UNPROCESSEDOBJECT = 'error';
+                $option = New-PSRuleOption;
+                $option.Execution.UnprocessedObject | Should -Be 'Error';
+
+                # With enum
+                $Env:PSRULE_EXECUTION_UNPROCESSEDOBJECT = 'Error';
+                $option = New-PSRuleOption;
+                $option.Execution.UnprocessedObject | Should -Be 'Error';
+
+                # With int
+                $Env:PSRULE_EXECUTION_UNPROCESSEDOBJECT = '3';
+                $option = New-PSRuleOption;
+                $option.Execution.UnprocessedObject | Should -Be 'Error';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_EXECUTION_UNPROCESSEDOBJECT' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -ExecutionUnprocessedObject 'Error' -Path $emptyOptionsFilePath;
+            $option.Execution.UnprocessedObject | Should -Be 'Error';
+        }
+    }
+
     Context 'Read Execution.AliasReferenceWarning' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
-            $option.Execution.AliasReferenceWarning | Should -Be $True;
+            $option.Execution.AliasReferenceWarning | Should -Be $Null;
         }
 
         It 'from Hashtable' {
@@ -964,7 +1152,7 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
     Context 'Read Execution.InvariantCultureWarning' {
         It 'from default' {
             $option = New-PSRuleOption -Default;
-            $option.Execution.InvariantCultureWarning | Should -Be $True;
+            $option.Execution.InvariantCultureWarning | Should -Be $Null;
         }
 
         It 'from Hashtable' {

--- a/tests/PSRule.Tests/PSRule.Reason.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Reason.Tests.ps1
@@ -36,7 +36,7 @@ Describe 'PSRule -- Reason keyword' -Tag 'Reason' {
         }
 
         It 'Sets reason' {
-            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $option = @{ 'Execution.RuleInconclusive' = 'Ignore' };
             $result = @($testObject | Invoke-PSRule -Path $ruleFilePath -Option $option -Name 'ReasonTest','ReasonTest2','ReasonTest3' -Outcome All);
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 3;

--- a/tests/PSRule.Tests/PSRule.Recommend.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Recommend.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'PSRule -- Recommend keyword' -Tag 'Recommend' {
         }
 
         It 'Sets result properties' {
-            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $option = @{ 'Execution.RuleInconclusive' = 'Ignore' };
             $result = @($testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'RecommendTest' -Outcome All -WarningVariable outWarning);
             $warningMessages = @($outWarning);
             $result | Should -Not -BeNullOrEmpty;
@@ -45,7 +45,7 @@ Describe 'PSRule -- Recommend keyword' -Tag 'Recommend' {
         }
 
         It 'Uses comment metadata' {
-            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $option = @{ 'Execution.RuleInconclusive' = 'Ignore' };
             $result = @($testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'TestWithDescription', 'TestWithSynopsis' -Outcome All);
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 2;
@@ -54,7 +54,7 @@ Describe 'PSRule -- Recommend keyword' -Tag 'Recommend' {
         }
 
         It 'Uses documentation' {
-            $option = @{ 'Execution.InconclusiveWarning' = $False };
+            $option = @{ 'Execution.RuleInconclusive' = 'Ignore' };
             $result = @($testObject | Invoke-PSRule -Path (Join-Path -Path $here -ChildPath 'FromFile.Rule.ps1') -Option $option -Name 'RecommendTest2' -Culture en-ZZ -Outcome All);
             $result | Should -Not -BeNullOrEmpty;
             $result.Length | Should -Be 1;

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -7,10 +7,10 @@ repository:
 # Configure baseline
 rule:
   include:
-  - rule1
+    - rule1
   includeLocal: true
   exclude:
-  - rule3
+    - rule3
   tag:
     key1: value1
 
@@ -18,48 +18,52 @@ rule:
 configuration:
   option1: option
   option2: 2
-  option3: [ 'option3a', 'option3b' ]
+  option3: ['option3a', 'option3b']
   option4:
-  - location: 'East US'
-    zones: [ "1", "2", "3" ]
-  - location: 'Australia South East'
-    zones: [ ]
+    - location: 'East US'
+      zones: ['1', '2', '3']
+    - location: 'Australia South East'
+      zones: []
   option5:
-  - option5a
-  - option5b
+    - option5a
+    - option5b
 
 # Configure conventions
 convention:
   include:
-  - 'Convention1'
+    - 'Convention1'
 
 # Configure binding
 binding:
   field:
     id:
-    - resourceId
+      - resourceId
   ignoreCase: false
   nameSeparator: '::'
   preferTargetInfo: true
   targetName:
-  - ResourceName
+    - ResourceName
   targetType:
-  - ResourceType
+    - ResourceType
   useQualifiedName: true
 
 # Configure execution options
 execution:
+  aliasReference: Ignore
   aliasReferenceWarning: false
   duplicateResourceId: Warn
   languageMode: ConstrainedLanguage
   inconclusiveWarning: false
+  invariantCulture: Ignore
   invariantCultureWarning: false
   initialSessionState: Minimal
   notProcessedWarning: false
   suppressedRuleWarning: false
   suppressionGroupExpired: Debug
   ruleExcluded: Warn
+  ruleInconclusive: Ignore
   ruleSuppressed: Error
+  unprocessedObject: Ignore
 
 # Configure input options
 input:
@@ -69,17 +73,17 @@ input:
   ignoreRepositoryCommon: false
   objectPath: items
   pathIgnore:
-  - '*.Designer.cs'
+    - '*.Designer.cs'
   targetType:
-  - virtualMachine
+    - virtualMachine
   ignoreUnchangedPath: true
 
 # Configure logging options
 logging:
   limitDebug:
-  - TestRule2
+    - TestRule2
   limitVerbose:
-  - TestRule2
+    - TestRule2
   ruleFail: Warning
   rulePass: Warning
 
@@ -87,7 +91,7 @@ logging:
 output:
   as: Summary
   banner: Minimal
-  culture: [ 'en-CC' ]
+  culture: ['en-CC']
   encoding: UTF7
   footer: RuleCount
   format: Json
@@ -101,6 +105,6 @@ output:
 suppression:
   SuppressionTest1:
     targetName:
-    - TestObject1
-    - TestObject3
-  SuppressionTest2: [ 'TestObject1', 'TestObject3' ]
+      - TestObject1
+      - TestObject3
+  SuppressionTest2: ['TestObject1', 'TestObject3']

--- a/tests/PSRule.Tests/PSRule.Tests10.yml
+++ b/tests/PSRule.Tests/PSRule.Tests10.yml
@@ -5,4 +5,4 @@ output:
   jsonIndent: 1
 
 execution:
-  invariantCultureWarning: false
+  invariantCulture: Ignore

--- a/tests/PSRule.Tests/PSRule.Tests11.yml
+++ b/tests/PSRule.Tests/PSRule.Tests11.yml
@@ -5,4 +5,4 @@ output:
   jsonIndent: 2
 
 execution:
-  invariantCultureWarning: false
+  invariantCulture: Ignore

--- a/tests/PSRule.Tests/PSRule.Tests12.yml
+++ b/tests/PSRule.Tests/PSRule.Tests12.yml
@@ -5,4 +5,4 @@ output:
   jsonIndent: 3
 
 execution:
-  invariantCultureWarning: false
+  invariantCulture: Ignore

--- a/tests/PSRule.Tests/PSRule.Tests13.yml
+++ b/tests/PSRule.Tests/PSRule.Tests13.yml
@@ -5,4 +5,4 @@ output:
   jsonIndent: 4
 
 execution:
-  invariantCultureWarning: false
+  invariantCulture: Ignore

--- a/tests/PSRule.Tests/PSRule.Tests5.yml
+++ b/tests/PSRule.Tests/PSRule.Tests5.yml
@@ -1,5 +1,4 @@
-
 # Options for processing with some rules
 execution:
-  inconclusiveWarning: false
-  invariantCultureWarning: false
+  ruleInconclusive: Ignore
+  invariantCulture: Ignore

--- a/tests/PSRule.Tests/PSRule.Tests9.yml
+++ b/tests/PSRule.Tests/PSRule.Tests9.yml
@@ -5,4 +5,4 @@ output:
   jsonIndent: 0
 
 execution:
-  invariantCultureWarning: false
+  invariantCulture: Ignore

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -175,7 +175,7 @@ namespace PSRule
         {
             PSRuleOption.UseCurrentCulture(CultureInfo.InvariantCulture);
             var option = new PSRuleOption();
-            option.Execution.InvariantCultureWarning = false;
+            option.Execution.InvariantCulture = ExecutionActionPreference.Ignore;
             var context = PipelineContext.New(option, null, null, null, null, null, new OptionContext(), null);
             var writer = new TestWriter(option);
             var pipeline = new GetRulePipeline(context, GetSource(), new PipelineReader(null, null, null), writer, false);


### PR DESCRIPTION
## PR Summary

- **Important change**: Rename of execution options.
  - Renamed options allow configuration of output level as `Ignore`, `Warn`, `Error`, or `Debug`.
  - `Execution.AliasReferenceWarning` is replaced with `Execution.AliasReference`.
  - `Execution.InconclusiveWarning` is replaced with `Execution.RuleInconclusive`.
  - `Execution.InvariantCultureWarning` is replaced with `Execution.InvariantCulture`.
  - `Execution.NotProcessedWarning` is replaced with `Execution.UnprocessedObject`.
  - Deprecated `AliasReferenceWarning` option, which will be removed in v3.
  - Deprecated `InconclusiveWarning` option, which will be removed in v3.
  - Deprecated `InvariantCultureWarning` option, which will be removed in v3.
  - Deprecated `NotProcessedWarning` option, which will be removed in v3.

Fixes #1456 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
