### PR TITLE
Pre-release v2.9.0-B0013

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -30,6 +30,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.9.0-B0013 (pre-release)
+
 What's changed since release v2.8.1:
 
 - General improvements:

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -10,6 +10,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 **Important notes**:
 
+- Several options have been renamed and the old names will be removed in v3.
+  See [deprecations][2] for details.
 - Several properties of rule and language block elements will be removed from v3.
   See [deprecations][2] for details.
 

--- a/docs/commands/PSRule/en-US/New-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/New-PSRuleOption.md
@@ -25,16 +25,20 @@ New-PSRuleOption [[-Path] <String>] [-Configuration <ConfigurationOption>]
  [-InconclusiveWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>]
  [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
  [-SuppressionGroupExpired <ExecutionActionPreference>] [-ExecutionRuleExcluded <ExecutionActionPreference>]
- [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
- [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
- [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
- [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
- [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-ExecutionAliasReference <ExecutionActionPreference>]
+ [-ExecutionRuleInconclusive <ExecutionActionPreference>]
+ [-ExecutionInvariantCulture <ExecutionActionPreference>]
+ [-ExecutionUnprocessedObject <ExecutionActionPreference>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>]
+ [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
+ [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
+ [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromOption
@@ -49,16 +53,20 @@ New-PSRuleOption [-Option] <PSRuleOption> [-Configuration <ConfigurationOption>]
  [-InconclusiveWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>]
  [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
  [-SuppressionGroupExpired <ExecutionActionPreference>] [-ExecutionRuleExcluded <ExecutionActionPreference>]
- [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
- [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
- [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
- [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
- [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-ExecutionAliasReference <ExecutionActionPreference>]
+ [-ExecutionRuleInconclusive <ExecutionActionPreference>]
+ [-ExecutionInvariantCulture <ExecutionActionPreference>]
+ [-ExecutionUnprocessedObject <ExecutionActionPreference>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>]
+ [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
+ [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
+ [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ### FromDefault
@@ -72,16 +80,20 @@ New-PSRuleOption [-Default] [-Configuration <ConfigurationOption>] [-SuppressTar
  [-InconclusiveWarning <Boolean>] [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>]
  [-NotProcessedWarning <Boolean>] [-SuppressedRuleWarning <Boolean>]
  [-SuppressionGroupExpired <ExecutionActionPreference>] [-ExecutionRuleExcluded <ExecutionActionPreference>]
- [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-IncludeModule <String[]>] [-IncludePath <String[]>]
- [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
- [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>]
- [-InputTargetType <String[]>] [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>]
- [-LoggingLimitVerbose <String[]>] [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>]
- [-OutputAs <ResultFormat>] [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>]
- [-OutputEncoding <OutputEncoding>] [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>]
- [-OutputJobSummaryPath <String>] [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>]
- [-OutputPath <String>] [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>]
- [-RepositoryBaseRef <String>] [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
+ [-ExecutionRuleSuppressed <ExecutionActionPreference>] [-ExecutionAliasReference <ExecutionActionPreference>]
+ [-ExecutionRuleInconclusive <ExecutionActionPreference>]
+ [-ExecutionInvariantCulture <ExecutionActionPreference>]
+ [-ExecutionUnprocessedObject <ExecutionActionPreference>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-InputIgnoreRepositoryCommon <Boolean>] [-InputIgnoreObjectSource <Boolean>]
+ [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputTargetType <String[]>]
+ [-InputPathIgnore <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
+ [-LoggingRuleFail <OutcomeLogStream>] [-LoggingRulePass <OutcomeLogStream>] [-OutputAs <ResultFormat>]
+ [-OutputBanner <BannerFormat>] [-OutputCulture <String[]>] [-OutputEncoding <OutputEncoding>]
+ [-OutputFooter <FooterFormat>] [-OutputFormat <OutputFormat>] [-OutputJobSummaryPath <String>]
+ [-OutputJsonIndent <Int32>] [-OutputOutcome <RuleOutcome>] [-OutputPath <String>]
+ [-OutputSarifProblemsOnly <Boolean>] [-OutputStyle <OutputStyle>] [-RepositoryBaseRef <String>]
+ [-RepositoryUrl <String>] [-RuleIncludeLocal <Boolean>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -458,6 +470,78 @@ Aliases: ExecutionSuppressedRuleWarning
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionAliasReference
+
+Sets the `Execution.AliasReference` option.
+Determines how to handle when an alias to a resource is used.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionInvariantCulture
+
+Sets the `Execution.InvariantCulture` option.
+Determines how to report when an invariant culture is used.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionRuleInconclusive
+
+Sets the `Execution.RuleInconclusive` option.
+Determines how to handle rules that generate inconclusive results.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionUnprocessedObject
+
+Sets the `Execution.UnprocessedObject` option.
+Determines how to report objects that are not processed by any rule.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/PSRule/en-US/Set-PSRuleOption.md
+++ b/docs/commands/PSRule/en-US/Set-PSRuleOption.md
@@ -22,7 +22,11 @@ Set-PSRuleOption [[-Path] <String>] [-Option <PSRuleOption>] [-PassThru] [-Force
  [-InvariantCultureWarning <Boolean>] [-InitialSessionState <SessionState>] [-NotProcessedWarning <Boolean>]
  [-SuppressedRuleWarning <Boolean>] [-SuppressionGroupExpired <ExecutionActionPreference>]
  [-ExecutionRuleExcluded <ExecutionActionPreference>] [-ExecutionRuleSuppressed <ExecutionActionPreference>]
- [-IncludeModule <String[]>] [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
+ [-ExecutionAliasReference <ExecutionActionPreference>]
+ [-ExecutionRuleInconclusive <ExecutionActionPreference>]
+ [-ExecutionInvariantCulture <ExecutionActionPreference>]
+ [-ExecutionUnprocessedObject <ExecutionActionPreference>] [-IncludeModule <String[]>]
+ [-IncludePath <String[]>] [-Format <InputFormat>] [-InputIgnoreGitPath <Boolean>]
  [-InputIgnoreObjectSource <Boolean>] [-InputIgnoreRepositoryCommon <Boolean>]
  [-InputIgnoreUnchangedPath <Boolean>] [-ObjectPath <String>] [-InputPathIgnore <String[]>]
  [-InputTargetType <String[]>] [-LoggingLimitDebug <String[]>] [-LoggingLimitVerbose <String[]>]
@@ -345,6 +349,78 @@ Aliases: ExecutionSuppressedRuleWarning
 Required: False
 Position: Named
 Default value: True
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionAliasReference
+
+Sets the `Execution.AliasReference` option.
+Determines how to handle when an alias to a resource is used.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionInvariantCulture
+
+Sets the `Execution.InvariantCulture` option.
+Determines how to report when an invariant culture is used.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionRuleInconclusive
+
+Sets the `Execution.RuleInconclusive` option.
+Determines how to handle rules that generate inconclusive results.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExecutionUnprocessedObject
+
+Sets the `Execution.UnprocessedObject` option.
+Determines how to report objects that are not processed by any rule.
+See about_PSRule_Options for more information.
+
+```yaml
+Type: ExecutionActionPreference
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
## PR Summary

What's changed since release v2.8.1:

- General improvements:
  - **Important change**: Rename of execution options by @BernieWhite.
    [#1456](https://github.com/microsoft/PSRule/issues/1456)
    - Renamed options allow configuration of output level as `Ignore`, `Warn`, `Error`, or `Debug`.
    - `Execution.AliasReferenceWarning` is replaced with `Execution.AliasReference`.
    - `Execution.InconclusiveWarning` is replaced with `Execution.RuleInconclusive`.
    - `Execution.InvariantCultureWarning` is replaced with `Execution.InvariantCulture`.
    - `Execution.NotProcessedWarning` is replaced with `Execution.UnprocessedObject`.
    - Deprecated `AliasReferenceWarning` option, which will be removed in v3.
    - Deprecated `InconclusiveWarning` option, which will be removed in v3.
    - Deprecated `InvariantCultureWarning` option, which will be removed in v3.
    - Deprecated `NotProcessedWarning` option, which will be removed in v3.
  - Improved schema display names by @BernieWhite.
    [#1488](https://github.com/microsoft/PSRule/issues/1488)
- Engineering:
  - Bump Pester to v5.4.1.
    [#1510](https://github.com/microsoft/PSRule/pull/1510)
  - Bump Microsoft.CodeAnalysis.Common to v4.5.0.
    [#1455](https://github.com/microsoft/PSRule/pull/1455)
- Bug fixes:
  - Fixed tool output on access denied to path by @BernieWhite.
    [#1490](https://github.com/microsoft/PSRule/issues/1490)
  - Fixed tool exit code on error or failure by @BernieWhite.
    [#1491](https://github.com/microsoft/PSRule/issues/1491)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
