### PR TITLE
Fixes includeLocal for default baseline #1506

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -52,6 +52,9 @@ What's changed since pre-release v2.9.0-B0033:
     [#1540](https://github.com/microsoft/PSRule/pull/1540)
   - Bump Microsoft.CodeAnalysis.Common to v4.6.0.
     [#1534](https://github.com/microsoft/PSRule/pull/1534)
+- Bug fixes:
+  - Fixed include local not automatically being enabled for default module baseline by @BernieWhite.
+    [#1506](https://github.com/microsoft/PSRule/issues/1506)
 
 ## v2.9.0-B0033 (pre-release)
 

--- a/src/PSRule/Definitions/Rules/RuleFilter.cs
+++ b/src/PSRule/Definitions/Rules/RuleFilter.cs
@@ -15,12 +15,12 @@ namespace PSRule.Definitions.Rules
     /// </summary>
     internal sealed class RuleFilter : IResourceFilter
     {
-        private readonly string[] _Include;
-        private readonly string[] _Excluded;
-        private readonly Hashtable _Tag;
-        private readonly ResourceLabels _Labels;
-        private readonly bool _IncludeLocal;
-        private readonly WildcardPattern _WildcardMatch;
+        internal readonly string[] Include;
+        internal readonly string[] Excluded;
+        internal readonly Hashtable Tag;
+        internal readonly ResourceLabels Labels;
+        internal readonly bool IncludeLocal;
+        internal readonly WildcardPattern WildcardMatch;
 
         /// <summary>
         /// Filter rules by id or tag.
@@ -32,19 +32,19 @@ namespace PSRule.Definitions.Rules
         /// <param name="labels">Only accept rules that have these labels.</param>
         public RuleFilter(string[] include, Hashtable tag, string[] exclude, bool? includeLocal, ResourceLabels labels)
         {
-            _Include = include == null || include.Length == 0 ? null : include;
-            _Excluded = exclude == null || exclude.Length == 0 ? null : exclude;
-            _Tag = tag ?? null;
-            _Labels = labels ?? null;
-            _IncludeLocal = includeLocal ?? RuleOption.Default.IncludeLocal.Value;
-            _WildcardMatch = null;
+            Include = include == null || include.Length == 0 ? null : include;
+            Excluded = exclude == null || exclude.Length == 0 ? null : exclude;
+            Tag = tag ?? null;
+            Labels = labels ?? null;
+            IncludeLocal = includeLocal ?? RuleOption.Default.IncludeLocal.Value;
+            WildcardMatch = null;
 
             if (include != null && include.Length > 0 && WildcardPattern.ContainsWildcardCharacters(include[0]))
             {
                 if (include.Length > 1)
                     throw new NotSupportedException(PSRuleResources.MatchSingleName);
 
-                _WildcardMatch = new WildcardPattern(include[0]);
+                WildcardMatch = new WildcardPattern(include[0]);
             }
         }
 
@@ -63,17 +63,17 @@ namespace PSRule.Definitions.Rules
         public bool Match(IResource resource)
         {
             var ids = resource.GetIds();
-            return !IsExcluded(ids) && (_IncludeLocal && resource.IsLocalScope() || IsIncluded(ids, resource.Tags, resource.Labels));
+            return !IsExcluded(ids) && (IncludeLocal && resource.IsLocalScope() || IsIncluded(ids, resource.Tags, resource.Labels));
         }
 
         private bool IsExcluded(IEnumerable<ResourceId> ids)
         {
-            if (_Excluded == null)
+            if (Excluded == null)
                 return false;
 
             foreach (var id in ids)
             {
-                if (Contains(id, _Excluded))
+                if (Contains(id, Excluded))
                     return true;
             }
             return false;
@@ -83,7 +83,7 @@ namespace PSRule.Definitions.Rules
         {
             foreach (var id in ids)
             {
-                if (_Include == null || Contains(id, _Include) || MatchWildcard(id.Name))
+                if (Include == null || Contains(id, Include) || MatchWildcard(id.Name))
                     return TagEquals(tag) && LabelEquals(labels);
             }
             return false;
@@ -91,13 +91,13 @@ namespace PSRule.Definitions.Rules
 
         private bool TagEquals(ResourceTags tag)
         {
-            if (_Tag == null)
+            if (Tag == null)
                 return true;
 
-            if (tag == null || _Tag.Count > tag.Count)
+            if (tag == null || Tag.Count > tag.Count)
                 return false;
 
-            foreach (DictionaryEntry entry in _Tag)
+            foreach (DictionaryEntry entry in Tag)
             {
                 if (!tag.Contains(entry.Key, entry.Value))
                     return false;
@@ -107,13 +107,13 @@ namespace PSRule.Definitions.Rules
 
         private bool LabelEquals(ResourceLabels labels)
         {
-            if (_Labels == null)
+            if (Labels == null)
                 return true;
 
-            if (labels == null || _Labels.Count > labels.Count)
+            if (labels == null || Labels.Count > labels.Count)
                 return false;
 
-            foreach (var taxon in _Labels)
+            foreach (var taxon in Labels)
             {
                 if (!labels.Contains(taxon.Key, taxon.Value))
                     return false;
@@ -133,7 +133,7 @@ namespace PSRule.Definitions.Rules
 
         private bool MatchWildcard(string name)
         {
-            return _WildcardMatch != null && _WildcardMatch.IsMatch(name);
+            return WildcardMatch != null && WildcardMatch.IsMatch(name);
         }
     }
 }

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -994,7 +994,7 @@ function Get-PSRuleHelp {
         [Parameter(Position = 0, Mandatory = $False)]
         [Alias('n')]
         [SupportsWildcards()]
-        [String]$Name,
+        [String[]]$Name,
 
         # A path to check documentation for.
         [Parameter(Mandatory = $False)]
@@ -1053,16 +1053,13 @@ function Get-PSRuleHelp {
         if ($isDeviceGuard) {
             $Option.Execution.LanguageMode = [PSRule.Configuration.LanguageMode]::ConstrainedLanguage;
         }
-        if ($PSBoundParameters.ContainsKey('Name')) {
-            $Option.Rule.Include = $Name;
-        }
         if ($PSBoundParameters.ContainsKey('Culture')) {
             $Option.Output.Culture = $Culture;
         }
 
         $hostContext = [PSRule.Pipeline.PSHostContext]::new($PSCmdlet, $ExecutionContext);
-        $builder = [PSRule.Pipeline.PipelineBuilder]::GetHelp($sourceFiles, $Option, $hostContext);;
-
+        $builder = [PSRule.Pipeline.PipelineBuilder]::GetHelp($sourceFiles, $Option, $hostContext);
+        $builder.Name($Name);
         if ($Online) {
             $builder.Online();
         }

--- a/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
+++ b/src/PSRule/Pipeline/GetRuleHelpPipeline.cs
@@ -26,6 +26,11 @@ namespace PSRule.Pipeline
         /// Open or show online help for a rule if it exists.
         /// </summary>
         void Online();
+
+        /// <summary>
+        /// Filter by name.
+        /// </summary>
+        void Name(string[] name);
     }
 
     internal sealed class GetRuleHelpPipelineBuilder : PipelineBuilderBase, IHelpPipelineBuilder

--- a/tests/PSRule.Tests/OptionContextTests.cs
+++ b/tests/PSRule.Tests/OptionContextTests.cs
@@ -1,11 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using PSRule.Configuration;
+using PSRule.Definitions;
+using PSRule.Definitions.Rules;
 using PSRule.Pipeline;
 
 namespace PSRule
 {
+    /// <summary>
+    /// Tests for <see cref="OptionContext"/>.
+    /// </summary>
     public sealed class OptionContextTests
     {
         [Fact]
@@ -23,7 +29,124 @@ namespace PSRule
             Assert.Equal(new string[] { "en-ZZ" }, testScope.Culture);
         }
 
+        [Fact]
+        public void Order()
+        {
+            // Create option context
+            var builder = new OptionContextBuilder(GetOption());
+            var optionContext = builder.Build();
+
+            var localScope = new Runtime.LanguageScope(null, null);
+            optionContext.UpdateLanguageScope(localScope);
+
+            var ruleFilter = localScope.GetFilter(ResourceKind.Rule) as RuleFilter;
+            Assert.NotNull(ruleFilter);
+            Assert.True(ruleFilter.IncludeLocal);
+
+            // With explict baseline
+            builder = new OptionContextBuilder(GetOption());
+            optionContext = builder.Build();
+            optionContext.Add(new OptionContext.BaselineScope(OptionContext.ScopeType.Explicit, new string[] {"abc" }, null, null));
+            optionContext.UpdateLanguageScope(localScope);
+            ruleFilter = localScope.GetFilter(ResourceKind.Rule) as RuleFilter;
+            Assert.NotNull(ruleFilter);
+            Assert.False(ruleFilter.IncludeLocal);
+
+            // With include from parameters
+            builder = new OptionContextBuilder(GetOption(), include: new string[] { "abc" });
+            optionContext = builder.Build();
+            optionContext.UpdateLanguageScope(localScope);
+            ruleFilter = localScope.GetFilter(ResourceKind.Rule) as RuleFilter;
+            Assert.NotNull(ruleFilter);
+            Assert.False(ruleFilter.IncludeLocal);
+
+            builder = new OptionContextBuilder(GetOption());
+            optionContext = builder.Build();
+            optionContext.Add(new OptionContext.BaselineScope(OptionContext.ScopeType.Workspace, new string[] { "abc" }, null, null));
+            optionContext.UpdateLanguageScope(localScope);
+            ruleFilter = localScope.GetFilter(ResourceKind.Rule) as RuleFilter;
+            Assert.NotNull(ruleFilter);
+            Assert.True(ruleFilter.IncludeLocal);
+        }
+
         #region Helper methods
+
+        internal sealed class MockScope : Runtime.ILanguageScope
+        {
+            internal RuleFilter RuleFilter;
+
+            public MockScope(string name)
+            {
+                Name = name;
+            }
+
+            public string Name { get; }
+
+            public IBindingOption Binding => throw new System.NotImplementedException();
+
+            public string[] Culture => throw new System.NotImplementedException();
+
+            public void AddService(string name, object service)
+            {
+                
+            }
+
+            public void Configure(Dictionary<string, object> configuration)
+            {
+                
+            }
+
+            public void Dispose()
+            {
+                
+            }
+
+            public IResourceFilter GetFilter(ResourceKind kind)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public object GetService(string name)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryConfigurationValue(string key, out object value)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetName(object o, out string name, out string path)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetScope(object o, out string[] scope)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public bool TryGetType(object o, out string type, out string path)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            public void WithBinding(IBindingOption bindingOption)
+            {
+                
+            }
+
+            public void WithCulture(string[] strings)
+            {
+                
+            }
+
+            public void WithFilter(IResourceFilter resourceFilter)
+            {
+                if (resourceFilter is RuleFilter ruleFilter)
+                    RuleFilter = ruleFilter;
+            }
+        }
 
         private static PSRuleOption GetOption(string[] culture = null)
         {

--- a/tests/PSRule.Tests/PipelineTests.cs
+++ b/tests/PSRule.Tests/PipelineTests.cs
@@ -346,6 +346,7 @@ namespace PSRule
         private static PSRuleOption GetOption(string path = null, ExecutionActionPreference ruleExcludedAction = ExecutionActionPreference.None)
         {
             var option = path == null ? new PSRuleOption() : PSRuleOption.FromFile(path);
+            option.Rule.IncludeLocal = false;
             option.Execution.RuleExcluded = ruleExcludedAction;
             return option;
         }

--- a/tests/PSRule.Tool.Tests/PSRule.Tool.Tests.csproj
+++ b/tests/PSRule.Tool.Tests/PSRule.Tool.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <ProjectGuid>{d3488ce2-779f-4474-b38a-f894a4b689f7}</ProjectGuid>
+    <ProjectGuid>{DA46C891-08F1-4D01-9F98-1F8BB10CAFEC}</ProjectGuid>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
     <RootNamespace>PSRule.Tool</RootNamespace>


### PR DESCRIPTION
## PR Summary

- Fixed include local not automatically being enabled for default module baseline.

Fixes #1506

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/PSRule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
