### PR TITLE
Pre-release v2.9.0-B0033

### DIFF
--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -35,6 +35,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v2.9.0-B0068 (pre-release)
+
 What's changed since pre-release v2.9.0-B0033:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v2.9.0-B0033:

- New features:
  - **Experimental**: Added support for baseline groups by @BernieWhite.
    [#1541](https://github.com/microsoft/PSRule/issues/1541)
    - Baseline groups allow you to reference a baseline by a friendly name.
    - Update the baseline group to point to a new baseline.
    - Currently only a single baseline can be referenced by a baseline group.
- General improvements:
  - Added style and improved handling for restore command by @BernieWhite.
    [#1152](https://github.com/microsoft/PSRule/issues/1152)
- Engineering:
  - Bump Microsoft.NET.Test.Sdk to v17.6.2.
    [#1544](https://github.com/microsoft/PSRule/pull/1544)
  - Bump Microsoft.CodeAnalysis.Common to v4.6.0.
    [#1534](https://github.com/microsoft/PSRule/pull/1534)
- Bug fixes:
  - Fixed include local not automatically being enabled for default module baseline by @BernieWhite.
    [#1506](https://github.com/microsoft/PSRule/issues/1506)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
