### PR TITLE
Add vNext announcement in docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -64,6 +64,9 @@
     "editor.formatOnSave": false,
     "editor.tabSize": 4
   },
+  "[html]": {
+    "editor.formatOnSave": false,
+  },
   "files.associations": {
     "**/.azure-pipelines/*.yaml": "azure-pipelines",
     "**/.azure-pipelines/jobs/*.yaml": "azure-pipelines",

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -44,3 +44,10 @@
 
   {% include "partials/giscus.html" %}
 {% endblock %}
+
+{% block announce %}
+  You are viewing the next version PSRule.
+  <a href="{{ '../' ~ base_url }}"> 
+    <strong>Click here to go to latest stable version.</strong>
+  </a>
+{% endblock %}


### PR DESCRIPTION
## PR Summary

Add an announcement banner to let visitors know they are viewing the vNext version.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
