### PR TITLE
Bump tooling to .NET 7 #1631

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -93,6 +93,7 @@
     "NOTCOUNT",
     "proxied",
     "PSRULE",
+    "pwsh",
     "quickstart",
     "runspace",
     "runspaces",

--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -44,6 +44,8 @@ What's changed since release v2.9.0:
     [#1521](https://github.com/microsoft/PSRule/issues/1521)
     - Added support for `.bicepparam`, `.tsp`, `.tsx`, `.editorconfig`, `.ipynb`, and `.toml` files.
 - Engineering:
+  - Bump development tools to .NET 7.0 SDK by @BernieWhite.
+    [#1631](https://github.com/microsoft/PSRule/issues/1631)
   - Bump Microsoft.CodeAnalysis.NetAnalyzers to v7.0.4.
     [#1602](https://github.com/microsoft/PSRule/pull/1602)
   - Bump Microsoft.CodeAnalysis.Common to v4.7.0.

--- a/docs/install-instructions.md
+++ b/docs/install-instructions.md
@@ -91,17 +91,17 @@ You can also use this option to install on CI workers that are not natively supp
 The following platforms are supported:
 
 - Windows PowerShell 5.1 with .NET Framework 4.7.2 or greater.
-- PowerShell 7.2 or greater on MacOS, Linux, and Windows.
+- PowerShell 7.3 or greater on MacOS, Linux, and Windows.
 
 ### Installing PowerShell
 
 PowerShell 7.x can be installed on MacOS, Linux, and Windows but is not installed by default.
-For a list of platforms that PowerShell 7.2 is supported on and install instructions see [Get PowerShell][3].
+For a list of platforms that PowerShell 7.3 is supported on and install instructions see [Get PowerShell][3].
 
 !!! Note
     If you are using Windows PowerShell you may need to bootstrap NuGet before you can install modules.
     The NuGet package provider is not installed in Windows PowerShell be default.
-    For instructions see [Bootstraping NuGet][6].
+    For instructions see [Bootstrapping NuGet][6].
 
   [3]: https://github.com/PowerShell/PowerShell#get-powershell
   [6]: https://learn.microsoft.com/powershell/scripting/gallery/how-to/getting-support/bootstrapping-nuget
@@ -199,9 +199,9 @@ The following PowerShell modules will be automatically install if the required v
 
 These additional modules are only required for building PSRule.
 
-Additionally .NET SDK v6 is required.
+Additionally .NET SDK v7 is required.
 .NET will not be automatically downloaded and installed.
-To download and install the latest SDK see [Download .NET 6][dotnet].
+To download and install the latest SDK see [Download .NET 7.0][dotnet].
 
 ### Limited access networks
 
@@ -238,9 +238,9 @@ After downloading the modules, copy the module directories to devices with restr
 !!! Note
     If you are using Windows PowerShell you may need to bootstrap NuGet before you can install modules.
     The NuGet package provider is not installed in Windows PowerShell be default.
-    For instructions see [Bootstraping NuGet][6].
+    For instructions see [Bootstrapping NuGet][6].
 
 *[CI]: continuous integration
 
 [module]: https://www.powershellgallery.com/packages/PSRule
-[dotnet]: https://dotnet.microsoft.com/download/dotnet/6.0
+[dotnet]: https://dotnet.microsoft.com/download/dotnet/7.0

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -29,6 +29,19 @@ To resolve any issue caused by this change, you can:
   [1]: https://aka.ms/ps-rule/options#bindingtargetname
   [2]: https://aka.ms/ps-rule/options#suppression
 
+### Using PowerShell 7.3 or later
+
+From _v3.0.0_, PSRule requires:
+
+- Windows PowerShell 5.1 for running as a PowerShell module. OR
+- PowerShell 7.3 or later for development, building locally, or running as a PowerShell module.
+
+Support for Windows PowerShell 5.1 is deprecated and will be removed in a future release of PSRule (v4).
+We recommend upgrading to PowerShell 7.3 or later.
+
+At the time of writing, PowerShell 7.3 is the most recent version of PowerShell.
+PowerShell 7.4 is expected, and PSRule v4 will aim to support the latest version of PowerShell as the minimum requirement.
+
 ## Upgrading to v2.0.0
 
 ### Resources naming restrictions

--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -104,7 +104,7 @@ task BuildDotNet {
     }
     exec {
         # Build library
-        dotnet build src/PSRule.Tool -c $Configuration -f net6.0 -p:version=$Build
+        dotnet build src/PSRule.Tool -c $Configuration -f net7.0 -p:version=$Build
         dotnet build src/PSRule.SDK -c $Configuration -f netstandard2.0 -p:version=$Build
         dotnet publish src/PSRule -c $Configuration -f netstandard2.0 -o $(Join-Path -Path $PWD -ChildPath out/modules/PSRule) -p:version=$Build
     }
@@ -327,7 +327,7 @@ task Rules {
 
 task Benchmark {
     if ($Benchmark -or $BuildTask -eq 'Benchmark') {
-        dotnet run --project src/PSRule.Benchmark -f net6.0 -c Release -- benchmark --output $PWD;
+        dotnet run --project src/PSRule.Benchmark -f net7.0 -c Release -- benchmark --output $PWD;
     }
 }
 

--- a/src/PSRule.Benchmark/PSRule.Benchmark.csproj
+++ b/src/PSRule.Benchmark/PSRule.Benchmark.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\PSRule.Common.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{3ec0912f-bfc7-4b53-a1a1-0ba993c6282e}</ProjectGuid>
     <EnableNuget>false</EnableNuget>
@@ -24,7 +24,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.7" />
+    <PackageReference Include="System.Management.Automation" Version="7.3.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PSRule.Tool/PSRule.Tool.csproj
+++ b/src/PSRule.Tool/PSRule.Tool.csproj
@@ -5,7 +5,7 @@
     <PackageId>Microsoft.PSRule.Tool</PackageId>
     <RootNamespace>PSRule.Tool</RootNamespace>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <StartupObject>PSRule.Tool.Program</StartupObject>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -16,7 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.7" />
+    <PackageReference Include="System.Management.Automation" Version="7.3.7" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ProjectGuid>{d3488ce2-779f-4474-b38a-f894a4b689f7}</ProjectGuid>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
@@ -11,7 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.2.6" />
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.3.7" />
+    <PackageReference Include="System.Management.Automation" Version="7.3.7" />
     <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/PSRule.Tool.Tests/PSRule.Tool.Tests.csproj
+++ b/tests/PSRule.Tool.Tests/PSRule.Tool.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <ProjectGuid>{DA46C891-08F1-4D01-9F98-1F8BB10CAFEC}</ProjectGuid>
     <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## PR Summary

Updated development tooling for .NET 7 and bumped supported PowerShell version to 7.3.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
