### PR TITLE
Added outcome argument for CLI #1706

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -29,6 +29,9 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v3.0.0-B0093:
 
+- General improvements:
+  - Added `--outcome` argument for CLI to support filtering output by @bernieWhite.
+    [#1706](https://github.com/microsoft/PSRule/issues/1706)
 - Engineering:
   - Bump xunit to v2.6.3.
     [#1699](https://github.com/microsoft/PSRule/pull/1699)

--- a/docs/concepts/cli.md
+++ b/docs/concepts/cli.md
@@ -8,6 +8,22 @@
 
 Run rule analysis.
 
+### `--outcome`
+
+Allows filtering of results by outcome.
+The supported values are:
+
+- `Pass` - Results that passed.
+- `Fail` - Results that did not pass.
+- `Error` - Results that failed to be evaluted correctly due to an error.
+- `Processed` - All results that were processed.
+  This aggregated outcome includes `Pass`, `Fail`, or `Error` results.
+- `Problem` - Processed results that did not pass.
+  This aggregated outcome includes `Fail`, or `Error` results.
+
+To specify multiple values, specify the parameter multiple times.
+For example: `--outcome Pass --Outcome Fail`.
+
 ## `module add`
 
 Add one or more modules to the lock file.

--- a/src/PSRule.Tool/AnalyzerOptions.cs
+++ b/src/PSRule.Tool/AnalyzerOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using PSRule.Rules;
+
 namespace PSRule.Tool
 {
     internal sealed class AnalyzerOptions
@@ -12,6 +14,8 @@ namespace PSRule.Tool
         public string Option { get; set; }
 
         public string Baseline { get; set; }
+
+        public RuleOutcome? Outcome { get; set; }
 
         public string[] InputPath { get; set; }
 

--- a/src/PSRule.Tool/ClientHelper.cs
+++ b/src/PSRule.Tool/ClientHelper.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License.
 
 using System.Collections;
-using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.Diagnostics;
 using System.Management.Automation;
-using Microsoft.CodeAnalysis.Sarif;
 using PSRule.Configuration;
 using PSRule.Data;
 using PSRule.Pipeline;
@@ -58,6 +55,9 @@ namespace PSRule.Tool
 
             if (operationOptions.Path != null)
                 option.Include.Path = operationOptions.Path;
+
+            if (operationOptions.Outcome != null && operationOptions.Outcome.Value != Rules.RuleOutcome.None)
+                option.Output.Outcome = operationOptions.Outcome;
 
             // Build command
             var builder = CommandLineBuilder.Assert(operationOptions.Module, option, host, file);

--- a/src/PSRule.Tool/Resources/CmdStrings.Designer.cs
+++ b/src/PSRule.Tool/Resources/CmdStrings.Designer.cs
@@ -61,11 +61,29 @@ namespace PSRule.Tool.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specific baseline to use..
+        /// </summary>
+        internal static string Analyze_Baseline_Description {
+            get {
+                return ResourceManager.GetString("Analyze_Baseline_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Run rule analysis..
         /// </summary>
         internal static string Analyze_Description {
             get {
                 return ResourceManager.GetString("Analyze_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies the rule results to show in output. By default, Pass/ Fail/ Error results are shown..
+        /// </summary>
+        internal static string Analyze_Outcome_Description {
+            get {
+                return ResourceManager.GetString("Analyze_Outcome_Description", resourceCulture);
             }
         }
         

--- a/src/PSRule.Tool/Resources/CmdStrings.resx
+++ b/src/PSRule.Tool/Resources/CmdStrings.resx
@@ -117,8 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Analyze_Baseline_Description" xml:space="preserve">
+    <value>The specific baseline to use.</value>
+  </data>
   <data name="Analyze_Description" xml:space="preserve">
     <value>Run rule analysis.</value>
+  </data>
+  <data name="Analyze_Outcome_Description" xml:space="preserve">
+    <value>Specifies the rule results to show in output. By default, Pass/ Fail/ Error results are shown.</value>
   </data>
   <data name="Cmd_Description" xml:space="preserve">
     <value>PSRule CLI</value>

--- a/src/PSRule.Types/Data/SemanticVersion.cs
+++ b/src/PSRule.Types/Data/SemanticVersion.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Diagnostics;
-using YamlDotNet.Core.Tokens;
 
 namespace PSRule.Data
 {

--- a/src/PSRule/Configuration/PSRuleOption.cs
+++ b/src/PSRule/Configuration/PSRuleOption.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics;
-using System.Globalization;
 using System.Management.Automation;
 using Newtonsoft.Json;
 using PSRule.Converters.Yaml;


### PR DESCRIPTION
## PR Summary

- Added `--outcome` argument for CLI to support filtering output.

Fixes #1706

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v3.md) has been updated with change under unreleased section
