### PR TITLE
Fixed aggregation of reasons with $Assert.AnyOf() #1829

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -65,6 +65,8 @@ What's changed since pre-release v3.0.0-B0203:
 - Bug fixes:
   - Fixed CLI exception the term Find-Module is not recognized by @BernieWhite.
     [#1860](https://github.com/microsoft/PSRule/issues/1860)
+  - Fixed aggregation of reasons with `$Assert.AnyOf()` by @BernieWhite.
+    [#1829](https://github.com/microsoft/PSRule/issues/1829)
 
 ## v3.0.0-B0203 (pre-release)
 

--- a/src/PSRule/Runtime/Assert.cs
+++ b/src/PSRule/Runtime/Assert.cs
@@ -146,7 +146,7 @@ public sealed class Assert
             if (results[i].Result)
                 return Pass();
             else
-                result.AddReason(result);
+                result.AddReason(results[i]);
         }
         return result;
     }

--- a/src/PSRule/Runtime/AssertResult.cs
+++ b/src/PSRule/Runtime/AssertResult.cs
@@ -19,7 +19,7 @@ public sealed class AssertResult : IEquatable<bool>
         Result = value;
         if (!Result)
         {
-            _Reason = new List<ResultReason>();
+            _Reason = [];
             AddReason(operand, reason, args);
         }
     }
@@ -60,7 +60,7 @@ public sealed class AssertResult : IEquatable<bool>
     /// <summary>
     /// Add a reason.
     /// </summary>
-    /// <param name="operand">Indentifies the operand that was the reason for the failure.</param>
+    /// <param name="operand">Identifies the operand that was the reason for the failure.</param>
     /// <param name="text">The text of a reason to add. This text should already be localized for the currently culture.</param>
     /// <param name="args">Replacement arguments for the format string.</param>
     internal void AddReason(IOperand operand, string text, params object[] args)

--- a/tests/PSRule.Tests/AssertTests.cs
+++ b/tests/PSRule.Tests/AssertTests.cs
@@ -104,16 +104,75 @@ public sealed class AssertTests
         Assert.False(assert.AllOf().Result);
     }
 
+    /// <summary>
+    /// Tests for <see cref="Runtime.Assert.AnyOf"/>.
+    /// </summary>
+    [Fact]
+    public void AnyOf()
+    {
+        SetContext();
+        var assert = GetAssertionHelper();
+        var actual1 = assert.Create(false, "Test reason 1");
+        var actual2 = assert.Create(true, "Test reason 2");
+        var actual3 = assert.Fail("Fail reason");
+
+        // Pass cases with no reasons.
+        var result = assert.AnyOf(actual2, actual3);
+        Assert.True(result.Result);
+        Assert.Empty(result.GetReason());
+        Assert.True(assert.AnyOf(actual2).Result);
+        Assert.True(assert.AnyOf(actual3, actual2, actual1).Result);
+
+        // Check reasons are returned.
+        result = assert.AnyOf(actual1, actual3);
+        Assert.False(result.Result);
+        Assert.Equal("Test reason 1 Fail reason", result.ToString());
+        Assert.Equal<string>(["Test reason 1", "Fail reason"], result.GetReason());
+
+        // Empty fail case.
+        Assert.False(assert.AnyOf().Result);
+    }
+
+    /// <summary>
+    /// Tests for <see cref="Runtime.Assert.AllOf"/>.
+    /// </summary>
+    [Fact]
+    public void AllOf()
+    {
+        SetContext();
+        var assert = GetAssertionHelper();
+        var actual1 = assert.Create(false, "Test reason 1");
+        var actual2 = assert.Create(true, "Test reason 2");
+        var actual3 = assert.Fail("Fail reason");
+
+        // Fail cases.
+        var result = assert.AllOf(actual2, actual3);
+        Assert.False(result.Result);
+        Assert.Equal("Fail reason", result.ToString());
+        Assert.Equal("Fail reason", result.GetReason()[0]);
+
+        result = assert.AllOf(actual1, actual2, actual3);
+        Assert.Equal("Test reason 1 Fail reason", result.ToString());
+        Assert.Equal<string>(["Test reason 1", "Fail reason"], result.GetReason());
+
+        // Pass cases.
+        Assert.True(assert.AllOf(actual2, actual2).Result);
+        Assert.True(assert.AllOf(actual2).Result);
+
+        // Empty fail case.
+        Assert.False(assert.AllOf().Result);
+    }
+
     [Fact]
     public void WithinRollupBlock()
     {
         SetContext();
         var assert = GetAssertionHelper();
-        var actual1 = RuleConditionHelper.Create(new object[] { PSObject.AsPSObject(assert.Create(true, "Test reason")), PSObject.AsPSObject(assert.Create(false, "Test reason")) });
+        var actual1 = RuleConditionHelper.Create([PSObject.AsPSObject(assert.Create(true, "Test reason")), PSObject.AsPSObject(assert.Create(false, "Test reason"))]);
         Assert.True(actual1.AnyOf());
         Assert.False(actual1.AllOf());
 
-        var actual2 = RuleConditionHelper.Create(new object[] { assert.Create(true, "Test reason"), assert.Create(false, "Test reason") });
+        var actual2 = RuleConditionHelper.Create([assert.Create(true, "Test reason"), assert.Create(false, "Test reason")]);
         Assert.True(actual2.AnyOf());
         Assert.False(actual2.AllOf());
     }


### PR DESCRIPTION
## PR Summary

- Fixed aggregation of reasons with `$Assert.AnyOf()`.

Fixes #1829 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v3.md) has been updated with change under unreleased section
