### PR TITLE
Add `Problem` to validate sets of `OutputOutcome`, fix #2542

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -67,6 +67,8 @@ What's changed since pre-release v3.0.0-B0203:
     [#1860](https://github.com/microsoft/PSRule/issues/1860)
   - Fixed aggregation of reasons with `$Assert.AnyOf()` by @BernieWhite.
     [#1829](https://github.com/microsoft/PSRule/issues/1829)
+  - Added `Problem` to validate sets of `OutputOutcome` by @nightroman
+    [#2542](https://github.com/microsoft/PSRule/issues/2542)
 
 ## v3.0.0-B0203 (pre-release)
 

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1309,7 +1309,7 @@ function New-PSRuleOption {
 
         # Sets the Output.Outcome option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Processed', 'All')]
+        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Problem', 'Processed', 'All')]
         [Alias('Outcome')]
         [PSRule.Rules.RuleOutcome]$OutputOutcome = 'Processed',
 
@@ -1612,7 +1612,7 @@ function Set-PSRuleOption {
 
         # Sets the Output.Outcome option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Processed', 'All')]
+        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Problem', 'Processed', 'All')]
         [Alias('Outcome')]
         [PSRule.Rules.RuleOutcome]$OutputOutcome = 'Processed',
 
@@ -2376,7 +2376,7 @@ function SetOptions {
 
         # Sets the Output.Outcome option
         [Parameter(Mandatory = $False)]
-        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Processed', 'All')]
+        [ValidateSet('None', 'Fail', 'Pass', 'Error', 'Problem', 'Processed', 'All')]
         [Alias('Outcome')]
         [PSRule.Rules.RuleOutcome]$OutputOutcome = 'Processed',
 


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/microsoft/PSRule/issues/2542

Added valid and documented value `Problem` to validate sets of the parameter `OutputOutcome` to three functions.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v3.md) has been updated with change under unreleased section