### PR TITLE
Pre-release v3.0.0-B0267

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -27,6 +27,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v3.0.0-B0267 (pre-release)
+
 What's changed since pre-release v3.0.0-B0203:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v3.0.0-B0203:

- New features:
  - Added option to configure the severity level that PSRule will break the pipeline at by @BernieWhite.
    [#1508](https://github.com/microsoft/PSRule/issues/1508)
    - Previously only rules with the severity level `Error` would break the pipeline.
    - With this update rules with the severity level `Error` that fail will break the pipeline by default.
    - The `Execution.Break` option can be set to `Never`, `OnError`, `OnWarning`, or `OnInformation`.
    - If a rule fails with a severity level equal or higher than the configured level the pipeline will break.
- General improvements:
  - **Breaking change**: Improve scope handling for correctly handling cases with multiple module by @BernieWhite.
    [#1215](https://github.com/microsoft/PSRule/issues/1215)
    - As a result of this change:
      - The `binding` property can no longer be used within baselines.
      - Custom inline script blocks can no longer be used for custom binding.
    - Use module configuration or workspace to configure binding options instead.
  - Added support for native logging within emitters by @BernieWhite.
    [#1837](https://github.com/microsoft/PSRule/issues/1837)
- Engineering:
  - Bump xunit to v2.9.0.
    [#1869](https://github.com/microsoft/PSRule/pull/1869)
  - Bump xunit.runner.visualstudio to v2.8.2.
    [#1869](https://github.com/microsoft/PSRule/pull/1869)
  - Bump System.Drawing.Common to v8.0.8.
    [#1887](https://github.com/microsoft/PSRule/pull/1887)
  - Bump YamlDotNet to v15.3.0.
    [#1856](https://github.com/microsoft/PSRule/pull/1856)
  - Bump Microsoft.CodeAnalysis.Common to v4.10.0.
    [#1854](https://github.com/microsoft/PSRule/pull/1854)
  - Bump Pester to v5.6.1.
    [#1872](https://github.com/microsoft/PSRule/pull/1872)
  - Bump PSScriptAnalyzer to v1.22.0.
    [#1858](https://github.com/microsoft/PSRule/pull/1858)
  - Bump BenchmarkDotNet from 0.13.12 to 0.14.0.
    [#1886](https://github.com/microsoft/PSRule/pull/1886)
- Bug fixes:
  - Fixed CLI exception the term Find-Module is not recognized by @BernieWhite.
    [#1860](https://github.com/microsoft/PSRule/issues/1860)
  - Fixed aggregation of reasons with `$Assert.AnyOf()` by @BernieWhite.
    [#1829](https://github.com/microsoft/PSRule/issues/1829)
  - Added `Problem` to validate sets of `OutputOutcome` by @nightroman
    [#2542](https://github.com/microsoft/PSRule/issues/2542)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
