### PR TITLE
Pre-release v3.0.0-B0275

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -27,6 +27,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v3.0.0-B0275 (pre-release)
+
 What's changed since pre-release v3.0.0-B0267:
 
 - New features:


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v3.0.0-B0267:

- New features:
  - Allow CLI upgrade command to upgrade a single module by @BernieWhite.
    [#2551](https://github.com/microsoft/PSRule/issues/2551)
    - A single or specific modules can be upgraded by name when using `module upgrade`.
    - By default, all modules are upgraded.
  - Allow CLI to install pre-release modules by @BernieWhite.
    [#2550](https://github.com/microsoft/PSRule/issues/2550)
    - Add and upgrade pre-release modules with `--prerelease`.
    - Pre-release modules will be restored from the lock file with `module restore`.
- General improvements:
  - **Breaking change**: Empty version comparison only accepts stable versions by default by @BernieWhite.
    [#2557](https://github.com/microsoft/PSRule/issues/2557)
    - `version` and `apiVersion` assertions only accept stable versions by default for all cases.
    - Pre-release versions can be accepted by setting `includePrerelease` to `true`.
- Bug fixes:
  - Fixed CLI upgrade uses pre-release module by @BernieWhite.
    [#2549](https://github.com/microsoft/PSRule/issues/2549)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
