### PR TITLE
Added support for overriding rule severity level #1180

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ The following conceptual topics exist in the `PSRule` module:
   - [Output.Path](https://aka.ms/ps-rule/options#outputpath)
   - [Output.SarifProblemsOnly](https://aka.ms/ps-rule/options#outputsarifproblemsonly)
   - [Output.Style](https://aka.ms/ps-rule/options#outputstyle)
+  - [Override.Level](https://aka.ms/ps-rule/options#overridelevel)
   - [Repository.BaseRef](https://aka.ms/ps-rule/options#repositorybaseref)
   - [Repository.Url](https://aka.ms/ps-rule/options#repositoryurl)
   - [Requires](https://aka.ms/ps-rule/options#requires)

--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -27,6 +27,12 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+- New features:
+  - Added support for overriding rule severity level by @BernieWhite.
+    [#1180](https://github.com/microsoft/PSRule/issues/1180)
+    - Baselines now accept a new `spec.overrides.level` property which configures severity level overrides.
+    - Options now accept a new `overrides.level` properties which configures severity level overrides.
+    - For example, a rule that generates an `Error` can be overridden to `Warning`.
 - General improvements:
   - Automatically restore missing modules when running CLI by @BernieWhite.
     [#2552](https://github.com/microsoft/PSRule/issues/2552)

--- a/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Baseline.md
@@ -14,6 +14,7 @@ A baseline includes a set of rule and configuration options that are used for ev
 The following baseline options can be configured:
 
 - [Configuration](about_PSRule_Options.md#configuration)
+- [Override.Level](about_PSRule_Options.md#overridelevel)
 - [Rule.Include](about_PSRule_Options.md#ruleinclude)
 - [Rule.IncludeLocal](about_PSRule_Options.md#ruleincludelocal)
 - [Rule.Exclude](about_PSRule_Options.md#ruleexclude)
@@ -48,8 +49,9 @@ metadata:
   annotations: { }
 spec:
   # One or more baseline options
-  rule: { }
   configuration: { }
+  override: {}
+  rule: { }
 ```
 
 For example:
@@ -100,8 +102,9 @@ To define a JSON baseline spec use the following structure:
       "annotations": {}
     },
     "spec": {
+      "configuration": {},
+      "override": {},
       "rule": {},
-      "configuration": {}
     }
   }
 ]

--- a/docs/concepts/PSRule/en-US/about_PSRule_Options.md
+++ b/docs/concepts/PSRule/en-US/about_PSRule_Options.md
@@ -68,6 +68,7 @@ The following workspace options are available for use:
 Additionally the following baseline options can be included:
 
 - [Configuration](#configuration)
+- [Override.Level](#overridelevel)
 - [Rule.Baseline](#rulebaseline)
 - [Rule.Include](#ruleinclude)
 - [Rule.IncludeLocal](#ruleincludelocal)
@@ -3012,6 +3013,52 @@ variables:
   value: 2
 ```
 
+### Override.Level
+
+This option is used to override the severity level of one or more rules.
+When specified, the severity level of the rule will be set to the value specified.
+Use this option to change the severity level of a rule to be different then originally defined by the author.
+
+The following severity levels are available:
+
+- `Error` - A serious problem that must be addressed before going forward.
+- `Warning` - A problem that should be addressed.
+- `Information` - A minor problem or an opportunity to improve the code.
+
+This option can be specified using:
+
+```powershell
+# PowerShell: Using the OverrideLevel parameter
+$option = New-PSRuleOption -OverrideLevel @{ 'rule1' = 'Information' };
+```
+
+```powershell
+# PowerShell: Using the OVerride.Level hashtable key
+$option = New-PSRuleOption -Option @{ 'Override.Level.rule1' = 'Information' };
+```
+
+```powershell
+# PowerShell: Using the OverrideLevel parameter to set YAML
+Set-PSRuleOption -OverrideLevel @{ 'rule1' = 'Information' };
+```
+
+```yaml
+# YAML: Using the override/level property
+override:
+  level:
+    rule1: Information
+```
+
+```bash
+# Bash: Using environment variable
+export PSRULE_OVERRIDE_LEVEL_RULE1='Information'
+```
+
+```powershell
+# PowerShell: Using environment variable
+$env:PSRULE_OVERRIDE_LEVEL_RULE1 = 'Information';
+```
+
 ### Repository.BaseRef
 
 This option is used for specify the base branch for pull requests.
@@ -3464,6 +3511,12 @@ output:
   sarifProblemsOnly: false
   style: GitHubActions
 
+# Overrides the severity level for rules
+override:
+  level:
+    Rule1: Error
+    Rule2: Warning
+
 # Configure rule suppression
 suppression:
   storageAccounts.UseHttps:
@@ -3570,6 +3623,9 @@ output:
   outcome: Processed
   sarifProblemsOnly: true
   style: Detect
+
+override:
+  level: { }
 
 # Configure rule suppression
 suppression: { }

--- a/docs/concepts/options.md
+++ b/docs/concepts/options.md
@@ -1,0 +1,26 @@
+# Options
+
+Options are used to customize how rules are evaluated and the resulting output.
+You can set options in multiple ways, including:
+
+- Parameters
+- Environment variables
+- Configuration files
+
+Rules or modules could also have a defaults configured by the rule or module author.
+
+## Option precedence
+
+When setting options, you may have a situation where an option is set to different values.
+For example, you may set an option in a configuration file and also set the same option as a parameter.
+
+When this happens, PSRule will use the option with the highest precedence.
+
+Option precedence is as follows:
+
+1. Parameters
+2. Explicit baselines
+3. Environment variables
+4. Configuration files
+5. Default baseline
+6. Module defaults

--- a/docs/concepts/sarif-format.md
+++ b/docs/concepts/sarif-format.md
@@ -1,0 +1,19 @@
+# SARIF Output
+
+PSRule uses a JSON structured output format called the
+
+SARIF format to report results.
+The SARIF format is a standard format for the output of static analysis tools.
+The format is designed to be easily consumed by other tools and services.
+
+## Runs
+
+When running PSRule executed a run will be generated in `runs` containing details about PSRule and configuration details.
+
+## Invocation
+
+The `invocation` property reports runtime information about how the run started.
+
+### RuleConfigurationOverrides
+
+When a rule has been overridden in configuration this invocation property will contain any level overrides.

--- a/schemas/PSRule-language.schema.json
+++ b/schemas/PSRule-language.schema.json
@@ -209,6 +209,39 @@
             }
           },
           "additionalProperties": false
+        },
+        "override": {
+          "type": "object",
+          "title": "Overrides",
+          "description": "Specifies additional rule overrides.",
+          "properties": {
+            "level": {
+              "type": "object",
+              "title": "Override severity level",
+              "description": "Overrides the severity level defined by the rule to the level specified. A rule can be configured with one of the following: Error, Warning, Information.",
+              "markdownDescription": "Overrides the severity level defined by the rule to the level specified.\n\nA rule can be configured with one of the following: `Error`, `Warning`, `Information`.\n\n[See help](https://microsoft.github.io/PSRule/v3/concepts/PSRule/en-US/about_PSRule_Options/#overridelevel)",
+              "additionalProperties": {
+                "type": "string",
+                "title": "Override level by rule",
+                "description": "Specify the new severity level of the rule. Choose one of the following supported values: Error, Warning, Information.",
+                "markdownDescription": "Specify the new severity level of the rule.\n\nChoose one of the following supported values: `Error`, `Warning`, `Information`.\n\n[See help](https://microsoft.github.io/PSRule/v3/concepts/PSRule/en-US/about_PSRule_Options/#overridelevel)",
+                "enum": [
+                  "Error",
+                  "Warning",
+                  "Information"
+                ]
+              },
+              "defaultSnippets": [
+                {
+                  "label": "Override level",
+                  "body": {
+                    "${1:Rule}": "Error"
+                  }
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": false

--- a/schemas/PSRule-options.schema.json
+++ b/schemas/PSRule-options.schema.json
@@ -928,6 +928,39 @@
       },
       "additionalProperties": false
     },
+    "override-option": {
+      "type": "object",
+      "title": "Overrides",
+      "description": "Specifies additional rule overrides.",
+      "properties": {
+        "level": {
+          "type": "object",
+          "title": "Override severity level",
+          "description": "Overrides the severity level defined by the rule to the level specified. A rule can be configured with one of the following: Error, Warning, Information.",
+          "markdownDescription": "Overrides the severity level defined by the rule to the level specified.\n\nA rule can be configured with one of the following: `Error`, `Warning`, `Information`.\n\n[See help](https://microsoft.github.io/PSRule/v3/concepts/PSRule/en-US/about_PSRule_Options/#overridelevel)",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Override level by rule",
+            "description": "Specify the new severity level of the rule. Choose one of the following supported values: Error, Warning, Information.",
+            "markdownDescription": "Specify the new severity level of the rule.\n\nChoose one of the following supported values: `Error`, `Warning`, `Information`.\n\n[See help](https://microsoft.github.io/PSRule/v3/concepts/PSRule/en-US/about_PSRule_Options/#overridelevel)",
+            "enum": [
+              "Error",
+              "Warning",
+              "Information"
+            ]
+          },
+          "defaultSnippets": [
+            {
+              "label": "Override level",
+              "body": {
+                "${1:Rule}": "Error"
+              }
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "options": {
       "properties": {
         "baseline": {
@@ -981,6 +1014,10 @@
         "output": {
           "type": "object",
           "$ref": "#/definitions/output-option"
+        },
+        "override": {
+          "type": "object",
+          "$ref": "#/definitions/override-option"
         },
         "repository": {
           "type": "object",

--- a/src/PSRule.Types/Converters/TypeConverter.cs
+++ b/src/PSRule.Types/Converters/TypeConverter.cs
@@ -265,6 +265,20 @@ internal static class TypeConverter
         return false;
     }
 
+    /// <summary>
+    /// Try to get the environment variable as a enum of type <typeparamref name="T"/>.
+    /// </summary>
+    public static bool TryEnum<T>(object o, bool convert, out T? value) where T : struct, Enum
+    {
+        if (o is T t || convert && o is string s && Enum.TryParse(s, ignoreCase: true, out t))
+        {
+            value = t;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
     private static bool TryGetValue(object o, string propertyName, out object? value)
     {
         value = null;

--- a/src/PSRule.Types/Data/EnumMap.cs
+++ b/src/PSRule.Types/Data/EnumMap.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using PSRule.Converters;
+
+namespace PSRule.Data;
+
+/// <summary>
+/// A mapping of string to string arrays.
+/// </summary>
+public sealed class EnumMap<T> : KeyMap<T> where T : struct, Enum
+{
+    /// <summary>
+    /// Create an empty <see cref="EnumMap{T}"/> instance.
+    /// </summary>
+    public EnumMap()
+        : base() { }
+
+    /// <summary>
+    /// Create an instance by copying an existing <see cref="EnumMap{T}"/>.
+    /// </summary>
+    internal EnumMap(EnumMap<T> map)
+        : base(map) { }
+
+    /// <summary>
+    /// Create an instance by copying mapped keys from a string dictionary.
+    /// </summary>
+    internal EnumMap(IDictionary<string, T> map)
+        : base(map) { }
+
+    /// <summary>
+    /// Create an instance by copying mapped keys from a <seealso cref="Hashtable"/>.
+    /// </summary>
+    /// <param name="map"></param>
+    internal EnumMap(Hashtable map)
+        : base(map) { }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="hashtable"></param>
+    public static implicit operator EnumMap<T>(Hashtable hashtable)
+    {
+        return new EnumMap<T>(hashtable);
+    }
+
+    /// <summary>
+    /// Convert a hashtable into a <see cref="EnumMap{T}"/> instance.
+    /// </summary>
+    public static EnumMap<T> FromHashtable(Hashtable hashtable)
+    {
+        return new EnumMap<T>(hashtable);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="o"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    protected override bool TryConvertValue(object o, out T value)
+    {
+        value = default;
+        if (TypeConverter.TryEnum<T>(o, convert: true, out var result) && result != null)
+        {
+            value = result.Value;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/PSRule.Types/Data/KeyMap.cs
+++ b/src/PSRule.Types/Data/KeyMap.cs
@@ -1,0 +1,186 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+
+namespace PSRule.Data;
+
+/// <summary>
+/// A mapping of string to string arrays.
+/// </summary>
+public abstract class KeyMap<T> : IEnumerable<KeyValuePair<string, T>>
+{
+    private readonly Dictionary<string, T> _Map;
+
+    /// <summary>
+    /// Create an empty <see cref="StringArrayMap"/> instance.
+    /// </summary>
+    protected KeyMap()
+    {
+        _Map = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Create an instance by copying an existing <see cref="StringArrayMap"/>.
+    /// </summary>
+    protected KeyMap(KeyMap<T> map)
+    {
+        _Map = new Dictionary<string, T>(map._Map, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Create an instance by copying mapped keys from a string dictionary.
+    /// </summary>
+    protected KeyMap(IDictionary<string, T> map)
+    {
+        _Map = new Dictionary<string, T>(map, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Create an instance by copying mapped keys from a <seealso cref="Hashtable"/>.
+    /// </summary>
+    /// <param name="map"></param>
+    protected KeyMap(Hashtable map)
+        : this()
+    {
+        if (map != null) FromDictionary(map.IndexByString());
+    }
+
+    /// <summary>
+    /// The number of mapped keys.
+    /// </summary>
+    public int Count => _Map.Count;
+
+    /// <summary>
+    /// Get or set mapping for a specified key.
+    /// </summary>
+    public T? this[string key]
+    {
+        get
+        {
+            return !string.IsNullOrEmpty(key) && _Map.TryGetValue(key, out var value) ? value : GetValueDefault();
+        }
+        set
+        {
+            if (!string.IsNullOrEmpty(key) && value != null)
+                _Map[key] = value;
+        }
+    }
+
+    /// <summary>
+    /// Try to get a mapping by key.
+    /// </summary>
+    /// <param name="key">The key.</param>
+    /// <param name="value">Returns an array of mapped keys.</param>
+    /// <returns>Returns <c>true</c> if the key was found. Otherwise <c>false</c> is returned.</returns>
+    public bool TryGetValue(string key, out T value)
+    {
+        return _Map.TryGetValue(key, out value);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    public void Add(string key, T value)
+    {
+        _Map.Add(key, value);
+    }
+
+    /// <inheritdoc/>
+    public IEnumerator<KeyValuePair<string, T>> GetEnumerator()
+    {
+        return ((IEnumerable<KeyValuePair<string, T>>)_Map).GetEnumerator();
+    }
+
+    /// <inheritdoc/>
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Convert the instance into a dictionary.
+    /// </summary>
+    /// <returns></returns>
+    public IDictionary<string, T> ToDictionary()
+    {
+        return _Map;
+    }
+
+    /// <summary>
+    /// Get the default for the type.
+    /// </summary>
+    protected virtual T? GetValueDefault()
+    {
+        return default;
+    }
+
+    /// <summary>
+    /// Convert the type.
+    /// </summary>
+    protected virtual bool TryConvertValue(object o, out T? value)
+    {
+        value = default;
+        if (o is T t)
+        {
+            value = t;
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Load a key map from an existing dictionary.
+    /// </summary>
+    internal void FromDictionary(IDictionary<string, object> dictionary, string? prefix = null, Func<string, string>? format = null)
+    {
+        foreach (var kv in dictionary)
+        {
+            if (TryKeyPrefix(kv.Key, prefix, out var suffix) && TryConvertValue(kv.Value, out var value) && value != null)
+            {
+                if (format != null)
+                    suffix = format(suffix);
+
+                _Map[suffix] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Load values from environment variables into the option.
+    /// Keys that appear in both will replaced by environment variable values.
+    /// </summary>
+    /// <exception cref="ArgumentNullException">Is raised if the environment helper is null.</exception>
+    internal void FromEnvironment(string? prefix = null, Func<string, string>? format = null)
+    {
+        foreach (var kv in Environment.GetByPrefix(prefix))
+        {
+            if (TryKeyPrefix(kv.Key, prefix, out var suffix) && TryConvertValue(kv.Value, out var value) && value != null)
+            {
+                if (format != null)
+                    suffix = format(suffix);
+
+                _Map[suffix] = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Try a key prefix.
+    /// </summary>
+    private static bool TryKeyPrefix(string key, string? prefix, out string suffix)
+    {
+        suffix = key;
+        if (prefix == null || prefix.Length == 0)
+            return true;
+
+        if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            suffix = key.Substring(prefix.Length);
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/PSRule.Types/Data/WildcardMap.cs
+++ b/src/PSRule.Types/Data/WildcardMap.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Data;
+
+/// <summary>
+/// 
+/// </summary>
+/// <typeparam name="T"></typeparam>
+public sealed class WildcardMap<T>
+{
+    private readonly Dictionary<string, T> _Map;
+    private List<KeyValuePair<string, T>>? _Wildcard;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public WildcardMap()
+    {
+        _Map = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="values"></param>
+    public WildcardMap(IEnumerable<KeyValuePair<string, T>> values)
+    {
+        _Map = new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+        Load(values);
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    public bool TryGetValue(string key, out T? value)
+    {
+        value = default;
+        if (string.IsNullOrEmpty(key)) return false;
+        if (_Map.TryGetValue(key, out value)) return true;
+
+        for (var i = 0; _Wildcard != null && i < _Wildcard.Count; i++)
+        {
+            if (key.Length > _Wildcard[i].Key.Length && key.StartsWith(_Wildcard[i].Key))
+            {
+                value = _Wildcard[i].Value;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void Load(IEnumerable<KeyValuePair<string, T>> dictionary)
+    {
+        Dictionary<string, T>? wildcardIndex = null;
+        foreach (var kv in dictionary)
+        {
+            var index = kv.Key.IndexOf('*');
+
+            // Simple keys
+            if (index < 0)
+            {
+                _Map[kv.Key] = kv.Value;
+            }
+            // Wildcard keys
+            else
+            {
+                var key = kv.Key.Substring(0, index);
+                wildcardIndex ??= new Dictionary<string, T>(StringComparer.OrdinalIgnoreCase);
+                wildcardIndex[key] = kv.Value;
+            }
+        }
+
+        if (wildcardIndex != null)
+        {
+            _Wildcard = new List<KeyValuePair<string, T>>();
+            foreach (var kv in wildcardIndex.OrderByDescending(s => s.Key))
+                _Wildcard.Add(kv);
+        }
+    }
+}

--- a/src/PSRule.Types/Definitions/Rules/SeverityLevel.cs
+++ b/src/PSRule.Types/Definitions/Rules/SeverityLevel.cs
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
 namespace PSRule.Definitions.Rules;
 
 /// <summary>
 /// If the rule fails, how serious is the result.
 /// </summary>
+[JsonConverter(typeof(StringEnumConverter))]
 public enum SeverityLevel
 {
     /// <summary>

--- a/src/PSRule.Types/Environment.cs
+++ b/src/PSRule.Types/Environment.cs
@@ -312,14 +312,14 @@ public static class Environment
     /// <summary>
     /// Try to get any environment variable with a specific prefix.
     /// </summary>
-    public static IEnumerable<KeyValuePair<string, object>> GetByPrefix(string prefix)
+    public static IEnumerable<KeyValuePair<string, object>> GetByPrefix(string? prefix)
     {
         var env = System.Environment.GetEnvironmentVariables();
         var enumerator = env.GetEnumerator();
         while (enumerator.MoveNext())
         {
             var key = enumerator.Key.ToString();
-            if (key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            if (prefix == null || key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
                 yield return new KeyValuePair<string, object>(key, enumerator.Value);
         }
     }

--- a/src/PSRule.Types/Options/IOverrideOption.cs
+++ b/src/PSRule.Types/Options/IOverrideOption.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using PSRule.Data;
+using PSRule.Definitions.Rules;
+
+namespace PSRule.Options;
+
+/// <summary>
+/// Options that configure additional rule overrides.
+/// </summary>
+/// <remarks>
+/// See <see href="https://aka.ms/ps-rule/options"/>.
+/// </remarks>
+public interface IOverrideOption
+{
+    /// <summary>
+    /// A mapping of rule severity levels to override.
+    /// </summary>
+    EnumMap<SeverityLevel>? Level { get; }
+}

--- a/src/PSRule.Types/Options/OverrideOption.cs
+++ b/src/PSRule.Types/Options/OverrideOption.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.ComponentModel;
+using PSRule.Data;
+using PSRule.Definitions.Rules;
+
+namespace PSRule.Options;
+
+/// <summary>
+/// Options that configure additional rule overrides.
+/// </summary>
+/// <remarks>
+/// See <see href="https://aka.ms/ps-rule/options"/>.
+/// </remarks>
+public sealed class OverrideOption : IEquatable<OverrideOption>, IOption
+{
+    private const string ENVIRONMENT_LEVEL_KEY_PREFIX = "PSRULE_OVERRIDE_LEVEL_";
+    private const string DICTIONARY_LEVEL_KEY_PREFIX = "Override.Level.";
+
+    internal static readonly OverrideOption Default = new()
+    {
+    };
+
+    /// <summary>
+    /// Create an option instance.
+    /// </summary>
+    public OverrideOption()
+    {
+        Level = null;
+    }
+
+    /// <summary>
+    /// Create an option instance based on an existing object.
+    /// </summary>
+    /// <param name="option">The existing object to copy.</param>
+    public OverrideOption(OverrideOption option)
+    {
+        if (option == null)
+            return;
+
+        Level = option.Level;
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj)
+    {
+        return obj is OverrideOption option && Equals(option);
+    }
+
+    /// <inheritdoc/>
+    public bool Equals(OverrideOption other)
+    {
+        return other != null &&
+            Level == other.Level;
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        unchecked // Overflow is fine
+        {
+            var hash = 17;
+            hash = hash * 23 + (Level != null ? Level.GetHashCode() : 0);
+            return hash;
+        }
+    }
+
+    /// <summary>
+    /// Combines two option instances into a new merged instance.
+    /// The new instance uses any non-null values from <paramref name="o1"/>.
+    /// Any null values from <paramref name="o1"/> are replaced with <paramref name="o2"/>.
+    /// </summary>
+    public static OverrideOption Combine(OverrideOption o1, OverrideOption o2)
+    {
+        var result = new OverrideOption(o1)
+        {
+            Level = o1?.Level ?? o2?.Level,
+        };
+        return result;
+    }
+
+    /// <inheritdoc/>
+    [DefaultValue(null)]
+    public EnumMap<SeverityLevel>? Level { get; set; }
+
+    /// <summary>
+    /// Load from environment variables.
+    /// </summary>
+    internal void Load()
+    {
+        var level = Level ?? [];
+        level.FromEnvironment(prefix: ENVIRONMENT_LEVEL_KEY_PREFIX);
+        Level = level.Count > 0 ? level : null;
+    }
+
+    /// <summary>
+    /// Load from a dictionary.
+    /// </summary>
+    public void Import(IDictionary<string, object> index)
+    {
+        var level = Level ?? [];
+        level.FromDictionary(index, prefix: DICTIONARY_LEVEL_KEY_PREFIX);
+        Level = level.Count > 0 ? level : null;
+    }
+}

--- a/src/PSRule/Commands/NewRuleDefinitionCommand.cs
+++ b/src/PSRule/Commands/NewRuleDefinitionCommand.cs
@@ -131,13 +131,18 @@ internal sealed class NewRuleDefinitionCommand : LanguageBlock
             displayName: Name,
             moduleName: source.Module
         );
+        context.LanguageScope.TryGetOverride(id, out var propertyOverride);
 
 #pragma warning disable CA2000 // Dispose objects before losing scope, needs to be passed to pipeline
         var block = new RuleBlock(
             source: source,
             id: id,
             @ref: ResourceHelper.GetIdNullable(source.Module, Ref, ResourceIdKind.Ref),
-            level: level,
+            @default: new RuleProperties
+            {
+                Level = level
+            },
+            @override: propertyOverride,
             info: info,
             condition: ps,
             tag: tag,

--- a/src/PSRule/Common/BaselineJsonSerializationMapper.cs
+++ b/src/PSRule/Common/BaselineJsonSerializationMapper.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using PSRule.Configuration;
 using PSRule.Definitions;
 using PSRule.Definitions.Baselines;
+using PSRule.Options;
 
 namespace PSRule;
 
@@ -48,7 +49,7 @@ internal static class BaselineJsonSerializationMapper
         MapPropertyName(writer, propertyName);
         writer.WriteStartObject();
         MapProperty(writer, serializer, nameof(baselineSpec.Configuration), baselineSpec.Configuration);
-        MapProperty(writer, nameof(baselineSpec.Convention), baselineSpec.Convention);
+        MapProperty(writer, serializer, nameof(baselineSpec.Override), baselineSpec.Override);
         MapProperty(writer, serializer, nameof(baselineSpec.Rule), baselineSpec.Rule);
         writer.WriteEndObject();
     }
@@ -149,6 +150,20 @@ internal static class BaselineJsonSerializationMapper
         MapPropertyName(writer, propertyName);
         writer.WriteStartObject();
         MapProperty(writer, nameof(value.Include), value.Include);
+        writer.WriteEndObject();
+    }
+
+    /// <summary>
+    /// Map a OverrideOption property.
+    /// </summary>
+    private static void MapProperty(JsonWriter writer, JsonSerializer serializer, string propertyName, OverrideOption value)
+    {
+        if (value == null)
+            return;
+
+        MapPropertyName(writer, propertyName);
+        writer.WriteStartObject();
+        MapProperty(writer, serializer, nameof(value.Level), value.Level?.ToDictionary());
         writer.WriteEndObject();
     }
 

--- a/src/PSRule/Common/BaselineYamlSerializationMapper.cs
+++ b/src/PSRule/Common/BaselineYamlSerializationMapper.cs
@@ -5,6 +5,7 @@ using System.Management.Automation;
 using PSRule.Configuration;
 using PSRule.Definitions;
 using PSRule.Definitions.Baselines;
+using PSRule.Options;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 
@@ -51,7 +52,7 @@ internal static class BaselineYamlSerializationMapper
         MapPropertyName(emitter, propertyName);
         emitter.Emit(new MappingStart());
         MapProperty(emitter, nameof(baselineSpec.Configuration), baselineSpec.Configuration);
-        MapProperty(emitter, nameof(baselineSpec.Convention), baselineSpec.Convention);
+        MapProperty(emitter, nameof(baselineSpec.Override), baselineSpec.Override);
         MapProperty(emitter, nameof(baselineSpec.Rule), baselineSpec.Rule);
         emitter.Emit(new MappingEnd());
     }
@@ -152,6 +153,20 @@ internal static class BaselineYamlSerializationMapper
         MapPropertyName(emitter, propertyName);
         emitter.Emit(new MappingStart());
         MapProperty(emitter, propertyName, value.Include);
+        emitter.Emit(new MappingEnd());
+    }
+
+    /// <summary>
+    /// Map a OverrideOption property.
+    /// </summary>
+    private static void MapProperty(IEmitter emitter, string propertyName, OverrideOption value)
+    {
+        if (value == null)
+            return;
+
+        MapPropertyName(emitter, propertyName);
+        emitter.Emit(new MappingStart());
+        MapProperty(emitter, nameof(value.Level), value.Level?.ToDictionary());
         emitter.Emit(new MappingEnd());
     }
 

--- a/src/PSRule/Configuration/BaselineOption.cs
+++ b/src/PSRule/Configuration/BaselineOption.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using PSRule.Definitions.Baselines;
+using PSRule.Options;
 
 namespace PSRule.Configuration;
 
@@ -32,7 +33,7 @@ public class BaselineOption
 
         public ConfigurationOption Configuration { get; set; }
 
-        public ConventionOption Convention { get; set; }
+        public OverrideOption Override { get; set; }
 
         public RuleOption Rule { get; set; }
     }
@@ -104,6 +105,7 @@ public class BaselineOption
         // Rule.Tag - currently not supported
 
         // Process configuration values
+        option.Override.Load();
         option.Configuration.Load();
     }
 
@@ -128,6 +130,7 @@ public class BaselineOption
             option.Rule.Tag = tag;
 
         // Process configuration values
+        option.Override.Import(properties);
         option.Configuration.Load(properties);
     }
 }

--- a/src/PSRule/Definitions/Baselines/BaselineSpec.cs
+++ b/src/PSRule/Definitions/Baselines/BaselineSpec.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
+using PSRule.Options;
 
 namespace PSRule.Definitions.Baselines;
 
@@ -18,4 +19,7 @@ public sealed class BaselineSpec : Spec, IBaselineV1Spec
 
     /// <inheritdoc/>
     public RuleOption Rule { get; set; }
+
+    /// <inheritdoc/>
+    public OverrideOption Override { get; set; }
 }

--- a/src/PSRule/Definitions/Baselines/IBaselineV1Spec.cs
+++ b/src/PSRule/Definitions/Baselines/IBaselineV1Spec.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
+using PSRule.Options;
 
 namespace PSRule.Definitions.Baselines;
 
@@ -16,12 +17,12 @@ internal interface IBaselineV1Spec
     ConfigurationOption Configuration { get; set; }
 
     /// <summary>
-    /// Options that configure conventions.
-    /// </summary>
-    ConventionOption Convention { get; set; }
-
-    /// <summary>
     /// Options for that affect which rules are executed by including and filtering discovered rules.
     /// </summary>
     RuleOption Rule { get; set; }
+
+    /// <summary>
+    /// Options that configure additional rule overrides.
+    /// </summary>
+    OverrideOption Override { get; set; }
 }

--- a/src/PSRule/Definitions/Rules/RuleOverride.cs
+++ b/src/PSRule/Definitions/Rules/RuleOverride.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Definitions.Rules;
+
+/// <summary>
+/// Any overrides for the rule.
+/// </summary>
+public sealed class RuleOverride
+{
+    /// <summary>
+    /// If the rule fails, how serious is the result.
+    /// </summary>
+    public SeverityLevel? Level { get; set; }
+}

--- a/src/PSRule/Definitions/Rules/RuleProperties.cs
+++ b/src/PSRule/Definitions/Rules/RuleProperties.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.Definitions.Rules;
+
+/// <summary>
+/// Any rule properties.
+/// </summary>
+public sealed class RuleProperties
+{
+    /// <summary>
+    /// If the rule fails, how serious is the result.
+    /// </summary>
+    public SeverityLevel Level { get; set; }
+}

--- a/src/PSRule/Definitions/Rules/SeverityLevelExtensions.cs
+++ b/src/PSRule/Definitions/Rules/SeverityLevelExtensions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using PSRule.Definitions.Rules;
-
-namespace PSRule;
+namespace PSRule.Definitions.Rules;
 
 internal static class SeverityLevelExtensions
 {

--- a/src/PSRule/PSRule.psm1
+++ b/src/PSRule/PSRule.psm1
@@ -1326,6 +1326,10 @@ function New-PSRuleOption {
         [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
         [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Detect,
 
+        # Sets the OverrideLevel option
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$OverrideLevel,
+
         # Sets the Repository.BaseRef option
         [Parameter(Mandatory = $False)]
         [String]$RepositoryBaseRef,
@@ -1628,6 +1632,10 @@ function Set-PSRuleOption {
         [Parameter(Mandatory = $False)]
         [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
         [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Detect,
+
+        # Sets the OverrideLevel option
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$OverrideLevel,
 
         # Sets the Repository.BaseRef option
         [Parameter(Mandatory = $False)]
@@ -2393,6 +2401,10 @@ function SetOptions {
         [ValidateSet('Client', 'Plain', 'AzurePipelines', 'GitHubActions', 'VisualStudioCode', 'Detect')]
         [PSRule.Configuration.OutputStyle]$OutputStyle = [PSRule.Configuration.OutputStyle]::Detect,
 
+        # Sets the OverrideLevel option
+        [Parameter(Mandatory = $False)]
+        [Hashtable]$OverrideLevel,
+
         # Sets the Repository.BaseRef option
         [Parameter(Mandatory = $False)]
         [String]$RepositoryBaseRef,
@@ -2641,6 +2653,11 @@ function SetOptions {
         # Sets option Output.Style
         if ($PSBoundParameters.ContainsKey('OutputStyle')) {
             $Option.Output.Style = $OutputStyle;
+        }
+
+        # Sets option Override.Level
+        if ($PSBoundParameters.ContainsKey('OverrideLevel')) {
+            $Option.Override.Level = $OverrideLevel;
         }
 
         # Sets option Repository.BaseRef

--- a/src/PSRule/Pipeline/Formatters/AzurePipelinesFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/AzurePipelinesFormatter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
-using PSRule.Definitions.Rules;
 using PSRule.Rules;
 
 namespace PSRule.Pipeline.Formatters;
@@ -51,13 +50,13 @@ internal sealed class AzurePipelinesFormatter : AssertFormatterBase, IAssertForm
     {
         base.FailDetail(record);
         var message = GetFailMessage(record);
-        if (record.Level == SeverityLevel.Error)
+        if (record.Level == Definitions.Rules.SeverityLevel.Error)
             Error(message);
 
-        if (record.Level == SeverityLevel.Warning)
+        if (record.Level == Definitions.Rules.SeverityLevel.Warning)
             Warning(message);
 
-        if (record.Level != SeverityLevel.Information)
+        if (record.Level != Definitions.Rules.SeverityLevel.Information)
             LineBreak();
     }
 }

--- a/src/PSRule/Pipeline/Formatters/GitHubActionsFormatter.cs
+++ b/src/PSRule/Pipeline/Formatters/GitHubActionsFormatter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
-using PSRule.Definitions.Rules;
 using PSRule.Rules;
 
 namespace PSRule.Pipeline.Formatters;
@@ -53,13 +52,13 @@ internal sealed class GitHubActionsFormatter : AssertFormatterBase, IAssertForma
     {
         base.FailDetail(record);
         var message = GetFailMessage(record);
-        if (record.Level == SeverityLevel.Error)
+        if (record.Level == Definitions.Rules.SeverityLevel.Error)
             Error(message);
 
-        if (record.Level == SeverityLevel.Warning)
+        if (record.Level == Definitions.Rules.SeverityLevel.Warning)
             Warning(message);
 
-        if (record.Level == SeverityLevel.Information)
+        if (record.Level == Definitions.Rules.SeverityLevel.Information)
             Information(message);
 
         LineBreak();

--- a/src/PSRule/Pipeline/OptionContext.cs
+++ b/src/PSRule/Pipeline/OptionContext.cs
@@ -51,6 +51,8 @@ internal sealed class OptionContext
 
     public OutputOption Output { get; set; }
 
+    public OverrideOption Override { get; set; }
+
     public RepositoryOption Repository { get; set; }
 
     public RequiresOption Requires { get; set; }

--- a/src/PSRule/Pipeline/OptionContextBuilder.cs
+++ b/src/PSRule/Pipeline/OptionContextBuilder.cs
@@ -150,6 +150,7 @@ internal sealed class OptionContextBuilder
         context.Input = InputOption.Combine(context.Input, optionScope.Input);
         context.Logging = LoggingOption.Combine(context.Logging, optionScope.Logging);
         context.Output = OutputOption.Combine(context.Output, optionScope.Output);
+        context.Override = OverrideOption.Combine(context.Override, optionScope.Override);
         context.Repository = RepositoryOption.Combine(context.Repository, optionScope.Repository);
         context.Requires = RequiresOption.Combine(context.Requires, optionScope.Requires);
         context.Rule = RuleOption.Combine(context.Rule, optionScope.Rule);

--- a/src/PSRule/Pipeline/OptionScope.cs
+++ b/src/PSRule/Pipeline/OptionScope.cs
@@ -69,6 +69,8 @@ internal class OptionScope
 
     public OutputOption Output { get; set; }
 
+    public OverrideOption Override { get; set; }
+
     public RepositoryOption Repository { get; set; }
 
     public RequiresOption Requires { get; set; }
@@ -109,6 +111,7 @@ internal class OptionScope
             Input = option.Input,
             Logging = option.Logging,
             Output = option.Output,
+            Override = option.Override,
             Repository = option.Repository,
             Requires = option.Requires,
             Rule = option.Rule,
@@ -146,7 +149,8 @@ internal class OptionScope
                 Tag = spec.Rule?.Tag,
                 Labels = spec.Rule?.Labels,
                 IncludeLocal = type == ScopeType.Explicit ? false : null
-            }
+            },
+            Override = spec.Override
         };
     }
 

--- a/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
@@ -3,6 +3,7 @@
 
 using PSRule.Configuration;
 using PSRule.Definitions.Baselines;
+using PSRule.Definitions.Rules;
 using YamlDotNet.Core;
 using YamlDotNet.Core.Events;
 using YamlDotNet.Serialization;
@@ -29,6 +30,7 @@ internal sealed class YamlOutputWriter : SerializationOutputWriter<object>
             .WithTypeConverter(new PSObjectYamlTypeConverter())
             .WithTypeConverter(new FieldMapYamlTypeConverter())
             .WithTypeConverter(new InfoStringYamlTypeConverter())
+            .WithTypeConverter(new EnumMapYamlTypeConverter<SeverityLevel>())
             .WithNamingConvention(CamelCaseNamingConvention.Instance)
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitDefaults)
             .Build();

--- a/src/PSRule/Pipeline/PipelineBuilderBase.cs
+++ b/src/PSRule/Pipeline/PipelineBuilderBase.cs
@@ -93,6 +93,7 @@ internal abstract class PipelineBuilderBase : IPipelineBuilder
         Option.Output.Outcome ??= OutputOption.Default.Outcome;
         Option.Output.Banner ??= OutputOption.Default.Banner;
         Option.Output.Style = GetStyle(option.Output.Style ?? OutputOption.Default.Style.Value);
+        Option.Override = new OverrideOption(option.Override);
         Option.Repository = GetRepository(option.Repository);
         return this;
     }

--- a/src/PSRule/Rules/RuleBlock.cs
+++ b/src/PSRule/Rules/RuleBlock.cs
@@ -23,7 +23,7 @@ internal delegate RuleConditionResult RuleCondition();
 [DebuggerDisplay("{Id} @{Source.Path}")]
 internal sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable, IResource, IRuleV1
 {
-    internal RuleBlock(ISourceFile source, ResourceId id, ResourceId? @ref, SeverityLevel level, RuleHelpInfo info, ICondition condition, IResourceTags tag, ResourceId[] alias, ResourceId[] dependsOn, Hashtable configuration, ISourceExtent extent, ResourceFlags flags, IResourceLabels labels)
+    internal RuleBlock(ISourceFile source, ResourceId id, ResourceId? @ref, RuleProperties @default, RuleOverride @override, RuleHelpInfo info, ICondition condition, IResourceTags tag, ResourceId[] alias, ResourceId[] dependsOn, Hashtable configuration, ISourceExtent extent, ResourceFlags flags, IResourceLabels labels)
     {
         Source = source;
         Name = id.Name;
@@ -33,7 +33,9 @@ internal sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable
         Ref = @ref;
         Alias = alias;
 
-        Level = level;
+        Default = @default;
+        Override = @override;
+        Level = Override != null && Override.Level.HasValue && Override.Level != SeverityLevel.None ? Override.Level.Value : Default.Level;
         Info = info;
         Condition = condition;
         Tag = tag;
@@ -105,6 +107,14 @@ internal sealed class RuleBlock : ILanguageBlock, IDependencyTarget, IDisposable
     [JsonIgnore]
     [YamlIgnore]
     public ResourceFlags Flags { get; }
+
+    [JsonIgnore]
+    [YamlIgnore]
+    public RuleProperties Default { get; }
+
+    [JsonIgnore]
+    [YamlIgnore]
+    public RuleOverride Override { get; }
 
     ResourceId[] IDependencyTarget.DependsOn => DependsOn;
 

--- a/src/PSRule/Rules/RuleRecord.cs
+++ b/src/PSRule/Rules/RuleRecord.cs
@@ -14,6 +14,8 @@ using YamlDotNet.Serialization;
 
 namespace PSRule.Rules;
 
+#nullable enable
+
 /// <summary>
 /// A detailed format for rule results.
 /// </summary>
@@ -25,7 +27,7 @@ public sealed class RuleRecord : IDetailedRuleResultV2
 
     internal readonly ResultDetail _Detail;
 
-    internal RuleRecord(string runId, ResourceId ruleId, string @ref, TargetObject targetObject, string targetName, string targetType, IResourceTags tag, RuleHelpInfo info, Hashtable field, SeverityLevel level, ISourceExtent extent, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None)
+    internal RuleRecord(string runId, ResourceId ruleId, string @ref, TargetObject targetObject, string targetName, string targetType, IResourceTags tag, RuleHelpInfo info, Hashtable field, RuleProperties @default, ISourceExtent extent, RuleOutcome outcome = RuleOutcome.None, RuleOutcomeReason reason = RuleOutcomeReason.None, RuleOverride? @override = null)
     {
         _TargetObject = targetObject;
         RunId = runId;
@@ -39,8 +41,11 @@ public sealed class RuleRecord : IDetailedRuleResultV2
         OutcomeReason = reason;
         Info = info;
         Source = targetObject.Source.GetSourceInfo();
-        Level = level;
         Extent = extent;
+        Default = @default;
+        Override = @override;
+        Level = Override?.Level ?? Default.Level;
+
         _Detail = new ResultDetail();
         if (tag != null)
             Tag = tag.ToHashtable();
@@ -59,7 +64,7 @@ public sealed class RuleRecord : IDetailedRuleResultV2
     /// A unique identifier for the rule.
     /// </summary>
     /// <remarks>
-    /// An additional opaque identifer may also be provided by by <see cref="Ref"/>.
+    /// An additional opaque identifier may also be provided by by <see cref="Ref"/>.
     /// </remarks>
     [JsonIgnore]
     [YamlIgnore]
@@ -106,14 +111,14 @@ public sealed class RuleRecord : IDetailedRuleResultV2
     /// </summary>
     [JsonIgnore]
     [YamlIgnore]
-    public string Recommendation => Info.Recommendation?.Text ?? Info.Synopsis?.Text;
+    public string? Recommendation => Info.Recommendation?.Text ?? Info.Synopsis?.Text;
 
     /// <summary>
     /// The reason for the failed condition.
     /// </summary>
     [DefaultValue(null)]
     [JsonProperty(PropertyName = "reason")]
-    public string[] Reason => _Detail.Count > 0 ? _Detail.GetReasonStrings() : null;
+    public string[]? Reason => _Detail.Count > 0 ? _Detail.GetReasonStrings() : null;
 
     /// <summary>
     /// A name to identify the target object.
@@ -190,6 +195,20 @@ public sealed class RuleRecord : IDetailedRuleResultV2
     public IResultDetailV2 Detail => _Detail;
 
     /// <summary>
+    /// Any default properties for the rule.
+    /// </summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public RuleProperties Default { get; set; }
+
+    /// <summary>
+    /// Any overrides for the rule.
+    /// </summary>
+    [JsonIgnore]
+    [YamlIgnore]
+    public RuleOverride? Override { get; }
+
+    /// <summary>
     /// Determine if the rule is successful or skipped.
     /// </summary>
     public bool IsSuccess()
@@ -221,3 +240,5 @@ public sealed class RuleRecord : IDetailedRuleResultV2
         return Source != null && Source.Length > 0;
     }
 }
+
+#nullable restore

--- a/src/PSRule/Runtime/ILanguageScope.cs
+++ b/src/PSRule/Runtime/ILanguageScope.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Definitions;
+using PSRule.Definitions.Rules;
 using PSRule.Pipeline;
 using PSRule.Runtime.Binding;
 
@@ -67,6 +68,11 @@ internal interface ILanguageScope : IDisposable
     /// Try to bind the name of the object.
     /// </summary>
     bool TryGetName(object o, out string? name, out string? path);
+
+    /// <summary>
+    /// Try to get a rule override by resource ID.
+    /// </summary>
+    bool TryGetOverride(ResourceId id, out RuleOverride? propertyOverride);
 }
 
 #nullable restore

--- a/src/PSRule/Runtime/RunspaceContext.cs
+++ b/src/PSRule/Runtime/RunspaceContext.cs
@@ -596,9 +596,10 @@ internal sealed class RunspaceContext : IDisposable, ILogger, IScriptResourceDis
             targetType: Binding?.TargetType,
             tag: ruleBlock.Tag,
             info: ruleBlock.Info,
-            field: Binding?.Field,
-            level: ruleBlock.Level,
-            extent: ruleBlock.Extent
+            field: Binding.Field,
+            @default: ruleBlock.Default,
+            extent: ruleBlock.Extent,
+            @override: ruleBlock.Override
         );
 
         Writer?.EnterScope(ruleBlock.Name);

--- a/tests/PSRule.Tests/AssertFormatterTests.cs
+++ b/tests/PSRule.Tests/AssertFormatterTests.cs
@@ -392,7 +392,10 @@ public sealed class AssertFormatterTests
             tag: new ResourceTags(),
             info: new RuleHelpInfo("Test", "Test rule", null),
             field: null,
-            level: SeverityLevel.Error,
+            @default: new RuleProperties
+            {
+                Level = SeverityLevel.Error
+            },
             extent: null,
             outcome: RuleOutcome.Pass,
             reason: RuleOutcomeReason.Processed
@@ -414,7 +417,10 @@ public sealed class AssertFormatterTests
             tag: new ResourceTags(),
             info: new RuleHelpInfo("Test1", "Test rule", null),
             field: null,
-            level: level,
+            @default: new RuleProperties
+            {
+                Level = level
+            },
             extent: null,
             outcome: RuleOutcome.Fail,
             reason: RuleOutcomeReason.Processed
@@ -430,7 +436,10 @@ public sealed class AssertFormatterTests
             tag: new ResourceTags(),
             info: new RuleHelpInfo("Test2", "Test rule", null),
             field: null,
-            level: level,
+            @default: new RuleProperties
+            {
+                Level = level
+            },
             extent: null,
             outcome: RuleOutcome.Fail,
             reason: RuleOutcomeReason.Processed

--- a/tests/PSRule.Tests/BaseTests.cs
+++ b/tests/PSRule.Tests/BaseTests.cs
@@ -10,6 +10,8 @@ using PSRule.Pipeline.Emitters;
 
 namespace PSRule;
 
+#nullable enable
+
 /// <summary>
 /// A base class for all tests.
 /// </summary>
@@ -22,7 +24,12 @@ public abstract class BaseTests
         return new PSRuleOption();
     }
 
-    internal TestWriter GetTestWriter(PSRuleOption option = default)
+    protected virtual PSRuleOption GetOption(string path)
+    {
+        return PSRuleOption.FromFile(path);
+    }
+
+    internal TestWriter GetTestWriter(PSRuleOption? option = default)
     {
         return new TestWriter(option ?? GetOption());
     }
@@ -63,3 +70,5 @@ public abstract class BaseTests
 
     #endregion Helper methods
 }
+
+#nullable restore

--- a/tests/PSRule.Tests/Baseline.Rule.jsonc
+++ b/tests/PSRule.Tests/Baseline.Rule.jsonc
@@ -79,6 +79,11 @@
             "low"
           ]
         }
+      },
+      "override": {
+        "level": {
+          "rule1": "Warning"
+        }
       }
     }
   },

--- a/tests/PSRule.Tests/Baseline.Rule.yaml
+++ b/tests/PSRule.Tests/Baseline.Rule.yaml
@@ -1,4 +1,3 @@
-
 ---
 # Synopsis: This is an example baseline
 apiVersion: github.com/microsoft/PSRule/v1
@@ -11,14 +10,14 @@ spec:
   # Additional comment
   rule:
     include:
-    # Additional comment
-    - 'WithBaseline'
-    # Additional comment
+      # Additional comment
+      - 'WithBaseline'
+      # Additional comment
   configuration:
     key1: value1
     key2:
-    - value1: abc
-    - value2: def
+      - value1: abc
+      - value2: def
 
 ---
 # Synopsis: This is an example baseline
@@ -29,7 +28,7 @@ metadata:
 spec:
   rule:
     include:
-    - ''
+      - ''
   configuration:
     key1: value1
 
@@ -54,9 +53,11 @@ spec:
   rule:
     tag:
       severity:
-      - 'high'
-      - 'low'
-
+        - 'high'
+        - 'low'
+  override:
+    level:
+      rule1: Warning
 ---
 # Synopsis: This is an example obsolete baseline
 apiVersion: github.com/microsoft/PSRule/v1
@@ -65,7 +66,7 @@ metadata:
   name: TestBaseline5
   annotations:
     obsolete: true
-spec: { }
+spec: {}
 
 ---
 # Synopsis: An example of a baseline with labels defined
@@ -76,4 +77,4 @@ metadata:
 spec:
   rule:
     labels:
-      framework.v1/control: [ 'c-1', 'c-2' ]
+      framework.v1/control: ['c-1', 'c-2']

--- a/tests/PSRule.Tests/BaselineTests.cs
+++ b/tests/PSRule.Tests/BaselineTests.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using PSRule.Definitions;
 using PSRule.Definitions.Baselines;
+using PSRule.Definitions.Rules;
 using PSRule.Host;
 using PSRule.Pipeline;
 using PSRule.Pipeline.Output;
@@ -49,6 +50,7 @@ public sealed class BaselineTests : ContextBaseTests
         // TestBaseline4
         Assert.Equal("TestBaseline4", baseline[3].Name);
         Assert.Null(baseline[3].Info.Synopsis.Text);
+        Assert.Equal(SeverityLevel.Warning, baseline[3].Spec.Override.Level["rule1"]);
 
         // TestBaseline5
         Assert.Equal("TestBaseline5", baseline[4].Name);
@@ -90,6 +92,7 @@ public sealed class BaselineTests : ContextBaseTests
         // TestBaseline4
         Assert.Equal("TestBaseline4", baseline[3].Name);
         Assert.Null(baseline[3].Info.Synopsis.Text);
+        Assert.Equal(SeverityLevel.Warning, baseline[3].Spec.Override.Level["rule1"]);
 
         // TestBaseline5
         Assert.Equal("TestBaseline5", baseline[4].Name);
@@ -153,6 +156,13 @@ public sealed class BaselineTests : ContextBaseTests
         Assert.Equal("value1", actual[0]["spec"]["configuration"]["key1"]);
         Assert.Equal("abc", actual[0]["spec"]["configuration"]["key2"][0]["value1"]);
         Assert.Equal("def", actual[0]["spec"]["configuration"]["key2"][1]["value2"]);
+
+        // TestBaseline4
+        Assert.Equal("github.com/microsoft/PSRule/v1", actual[3]["apiVersion"]);
+        Assert.Equal("Baseline", actual[3]["kind"]);
+        Assert.Equal("TestBaseline4", actual[3]["metadata"]["name"]);
+        Assert.NotNull(actual[3]["spec"]);
+        Assert.Equal("Warning", actual[3]["spec"]["override"]["level"]["rule1"]);
     }
 
     [Fact]
@@ -171,6 +181,13 @@ public sealed class BaselineTests : ContextBaseTests
         Assert.Equal("value1", actual?[0]["spec"]?["configuration"]?["key1"]);
         Assert.Equal("abc", actual?[0]["spec"]?["configuration"]?["key2"]?[0]?["value1"]);
         Assert.Equal("def", actual?[0]["spec"]?["configuration"]?["key2"]?[1]?["value2"]);
+
+        // TestBaseline4
+        Assert.Equal("github.com/microsoft/PSRule/v1", actual?[3]["apiVersion"]);
+        Assert.Equal("Baseline", actual?[3]["kind"]);
+        Assert.Equal("TestBaseline4", actual?[3]["metadata"]?["name"]);
+        Assert.NotNull(actual?[3]["spec"]);
+        Assert.Equal("Warning", actual?[3]["spec"]?["override"]?["level"]?["rule1"]);
     }
 
     #region Helper methods

--- a/tests/PSRule.Tests/MockLanguageScope.cs
+++ b/tests/PSRule.Tests/MockLanguageScope.cs
@@ -76,6 +76,16 @@ internal sealed class MockLanguageScope : ILanguageScope
         throw new NotImplementedException();
     }
 
+    public bool TryGetOverride(ResourceId id, out RuleOverride propertyOverride)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool TryGetScope(object o, out string[] scope)
+    {
+        throw new NotImplementedException();
+    }
+
     public bool TryGetType(object o, out string type, out string path)
     {
         throw new NotImplementedException();

--- a/tests/PSRule.Tests/PSRule.Options.Tests.ps1
+++ b/tests/PSRule.Tests/PSRule.Options.Tests.ps1
@@ -2145,6 +2145,39 @@ Describe 'New-PSRuleOption' -Tag 'Option','New-PSRuleOption' {
         }
     }
 
+    Context 'Read Override.Level' {
+        It 'from default' {
+            $option = New-PSRuleOption -Default;
+            $option.Override.Level | Should -BeNullOrEmpty;
+        }
+
+        It 'from Hashtable' {
+            $option = New-PSRuleOption -Option @{ 'Override.Level.rule1' = 'Information' };
+            $option.Override.Level['rule1'] | Should -Be 'Information';
+        }
+
+        It 'from YAML' {
+            $option = New-PSRuleOption -Option (Join-Path -Path $here -ChildPath 'PSRule.Tests.yml');
+            $option.Override.Level['rule1'] | Should -Be 'Information';
+        }
+
+        It 'from Environment' {
+            try {
+                $Env:PSRULE_OVERRIDE_LEVEL_RULE1 = 'Information';
+                $option = New-PSRuleOption;
+                $option.Override.Level['rule1'] | Should -Be 'Information';
+            }
+            finally {
+                Remove-Item 'Env:PSRULE_OVERRIDE_LEVEL_RULE1' -Force;
+            }
+        }
+
+        It 'from parameter' {
+            $option = New-PSRuleOption -OverrideLevel @{ rule1 = 'Information' } -Path $emptyOptionsFilePath;
+            $option.Override.Level['rule1'] | Should -Be 'Information';
+        }
+    }
+
     Context 'Read Repository.BaseRef' {
         It 'from default' {
             $option = New-PSRuleOption -Default;

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -149,6 +149,9 @@
     <None Update="PSRule.Tests14.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="PSRule.Tests17.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="PSRule.Tests2.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/PSRule.Tests/PSRule.Tests.yml
+++ b/tests/PSRule.Tests/PSRule.Tests.yml
@@ -22,6 +22,11 @@ emitter:
     include:
       - .csproj
 
+override:
+  level:
+    rule1: Information
+    Group.*: Error
+
 # Configure baseline
 rule:
   include:

--- a/tests/PSRule.Tests/PSRule.Tests14.yml
+++ b/tests/PSRule.Tests/PSRule.Tests14.yml
@@ -2,14 +2,14 @@
 
 suppression:
   YAML.RuleWithAlias1:
-  - 'TestObject1'
+    - 'TestObject1'
   PSRZZ.0001:
-  - 'TestObject1'
+    - 'TestObject1'
   JSON.AlternativeName:
-  - 'TestObject2'
+    - 'TestObject2'
   YAML.AlternativeName:
-  - 'TestObject2'
+    - 'TestObject2'
   .\PSRZZ.0003:
-  - 'TestObject3'
+    - 'TestObject3'
   '.\PS.AlternativeName':
-  - 'TestObject3'
+    - 'TestObject3'

--- a/tests/PSRule.Tests/PSRule.Tests17.yml
+++ b/tests/PSRule.Tests/PSRule.Tests17.yml
@@ -1,0 +1,4 @@
+# These are options for unit tests
+
+override:
+  level:

--- a/tests/PSRule.Tests/PSRule.Tests2.yml
+++ b/tests/PSRule.Tests/PSRule.Tests2.yml
@@ -3,39 +3,41 @@
 # Configure binding
 binding:
   targetName:
-  - ResourceName
-  - AlternateName
+    - ResourceName
+    - AlternateName
   targetType:
-  - ResourceType
-  - kind
+    - ResourceType
+    - kind
 
 # Configure conventions
 convention:
   include:
-  - 'Convention1'
-  - 'Convention2'
+    - 'Convention1'
+    - 'Convention2'
 
 # Configure input
 input:
   targetType:
-  - virtualMachine
-  - virtualNetwork
+    - virtualMachine
+    - virtualNetwork
 
 # Configure output
 output:
   banner: 1
   culture:
-  - 'en-CC'
-  - 'en-DD'
+    - 'en-CC'
+    - 'en-DD'
+
+override: {}
 
 # Configure required module versions
-requires: { }
+requires: {}
 
 # Configure baseline
 rule:
   include:
-  - rule1
-  - rule2
+    - rule1
+    - rule2
   exclude:
-  - rule3
-  - rule4
+    - rule3
+    - rule4

--- a/tests/PSRule.Tests/PSRuleOptionTests.cs
+++ b/tests/PSRule.Tests/PSRuleOptionTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Management.Automation;
 using PSRule.Configuration;
+using PSRule.Definitions.Rules;
 using PSRule.Pipeline;
 
 namespace PSRule;
@@ -87,6 +88,28 @@ public sealed class PSRuleOptionTests : ContextBaseTests
         Assert.Equal(new string[] { ".\\TestBaseline1" }, latest);
     }
 
+    [Fact]
+    public void FromFile_WhenOverrideIsDefined_ShouldDeserializeLevel()
+    {
+        var option = GetOption();
+        var actual = option.Override.Level;
+        Assert.True(actual.TryGetValue("rule1", out var level));
+        Assert.Equal(SeverityLevel.Information, level);
+
+        Assert.True(actual.TryGetValue("Group.*", out level));
+        Assert.Equal(SeverityLevel.Error, level);
+    }
+
+    [Theory]
+    [InlineData("PSRule.Tests2.yml")]
+    [InlineData("PSRule.Tests17.yml")]
+    public void FromFile_WhenOverrideIsPartiallyDefined_ShouldDeserializeWithoutError(string path)
+    {
+        var option = GetOption(GetSourcePath(path));
+        var actual = option.Override.Level;
+        Assert.Null(actual);
+    }
+
     #region Helper methods
 
     private Runtime.Configuration GetConfigurationHelper(PSRuleOption option)
@@ -108,7 +131,7 @@ public sealed class PSRuleOptionTests : ContextBaseTests
 
     protected sealed override PSRuleOption GetOption()
     {
-        return PSRuleOption.FromFile(GetSourcePath("PSRule.Tests.yml"));
+        return GetOption(GetSourcePath("PSRule.Tests.yml"));
     }
 
     #endregion Helper methods

--- a/tests/PSRule.Tests/ResourceMapTests.cs
+++ b/tests/PSRule.Tests/ResourceMapTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using PSRule.Data;
+using PSRule.Definitions.Rules;
+
+namespace PSRule;
+
+public sealed class ResourceMapTests
+{
+    [Fact]
+    public void Get()
+    {
+        var map = new WildcardMap<SeverityLevel>();
+        Assert.False(map.TryGetValue("Rule1", out _));
+
+        map = new WildcardMap<SeverityLevel>(new Dictionary<string, SeverityLevel>
+        {
+            { "Rule1", SeverityLevel.Warning },
+            { "Rule2", SeverityLevel.Error },
+            { "Rules.1", SeverityLevel.Error },
+            { "Rules.*", SeverityLevel.Information },
+            { "Rules.z*", SeverityLevel.Warning },
+            { "Rules.2", SeverityLevel.Error },
+        });
+
+        Assert.True(map.TryGetValue("Rule1", out var level));
+        Assert.Equal(SeverityLevel.Warning, level);
+        Assert.True(map.TryGetValue("Rule2", out level));
+        Assert.Equal(SeverityLevel.Error, level);
+        Assert.True(map.TryGetValue("Rules.1", out level));
+        Assert.Equal(SeverityLevel.Error, level);
+        Assert.True(map.TryGetValue("Rules.2", out level));
+        Assert.Equal(SeverityLevel.Error, level);
+        Assert.True(map.TryGetValue("Rules.3", out level));
+        Assert.Equal(SeverityLevel.Information, level);
+        Assert.True(map.TryGetValue("Rules.zzzz", out level));
+        Assert.Equal(SeverityLevel.Warning, level);
+        Assert.False(map.TryGetValue("Rules.", out _));
+        Assert.False(map.TryGetValue("Rules", out _));
+    }
+}


### PR DESCRIPTION
## PR Summary

- Added support for overriding rule severity level.
  - Baselines now accept a new `spec.overrides.level` property which configures severity level overrides.
  - Options now accept a new `overrides.level` properties which configures severity level overrides.
  - For example, a rule that generates an `Error` can be overridden to `Warning`.

Fixes #1180

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v3.md) has been updated with change under unreleased section
