### PR TITLE
Pre-release v3.0.0-B0315

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -27,6 +27,10 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v3.0.0-B0315 (pre-release)
+
+What's changed since pre-release v3.0.0-B0275:
+
 - New features:
   - Added support for overriding rule severity level by @BernieWhite.
     [#1180](https://github.com/microsoft/PSRule/issues/1180)


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v3.0.0-B0275:

- New features:
  - Added support for overriding rule severity level by @BernieWhite.
    [#1180](https://github.com/microsoft/PSRule/issues/1180)
    - Baselines now accept a new `spec.overrides.level` property which configures severity level overrides.
    - Options now accept a new `overrides.level` properties which configures severity level overrides.
    - For example, a rule that generates an `Error` can be overridden to `Warning`.
- General improvements:
  - Automatically restore missing modules when running CLI by @BernieWhite.
    [#2552](https://github.com/microsoft/PSRule/issues/2552)
    - Modules are automatically restored unless `--no-restore` is used with the `run` command.
- Engineering:
  - Bump YamlDotNet to v16.2.0.
    [#2596](https://github.com/microsoft/PSRule/pull/2596)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
