### PR TITLE
Updates for vscode #2636 #2635 #2615

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,8 @@
     "./schemas/PSRule-options.schema.json": [
       "/tests/PSRule.Tests/PSRule.*.yml",
       "/docs/scenarios/*/ps-rule.yaml",
-      "/ps-rule.yaml"
+      "/ps-rule.yaml",
+      "/ps-rule-ci.yaml"
     ],
     "./schemas/PSRule-language.schema.json": [
       "/**/**.Rule.yaml",

--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -29,9 +29,18 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v3.0.0-B0315:
 
+- New features:
+  - VSCode extension set to use Microsoft verified name by @BernieWhite.
+    [#2636](https://github.com/microsoft/PSRule/issues/2636)
 - General improvements:
   - Expose format options to emitters by @BernieWhite.
     [#1838](https://github.com/microsoft/PSRule/issues/1838)
+  - Added support for overriding options path from the default in VSCode by @BernieWhite.
+    [#2635](https://github.com/microsoft/PSRule/issues/2635)
+- Engineering:
+  - Migrated VSCode extension into PSRule repository by @BernieWhite.
+    [#2615](https://github.com/microsoft/PSRule/issues/2615)
+    - VSCode extension will now sit side-by-side with the other core PSRule components.
 - Bug fixes:
   - Fixes path filtering of ignored files includes prefixed files by @BernieWhite.
     [#2624](https://github.com/microsoft/PSRule/issues/2624)

--- a/docs/updates/v3_0.md
+++ b/docs/updates/v3_0.md
@@ -7,7 +7,7 @@ version: 3.0
 
 ### New home and identity
 
-The Visual Studio Code (VSCode) extension for PSRule now lives side-by-side with the majority of the PSRule code base in `https://github.com/microsoft/PSRule`.
+The Visual Studio Code (VSCode) extension for PSRule now lives side-by-side with core components of [PSRule on GitHub][1].
 
 As part of this change we are now publishing the extension as a **verified** Microsoft extension with the ID `ps-rule.code`.
 
@@ -15,6 +15,8 @@ We hope this will not only help the community to log issues and get help on the 
 but also streamline how we deliver updates in the future.
 
 Bringing together the code base is the first step in building an all improved rich experience in VSCode for PSRule.
+
+  [1]: https://github.com/microsoft/PSRule
 
 ### Runtime integration
 

--- a/ps-rule-ci.yaml
+++ b/ps-rule-ci.yaml
@@ -13,6 +13,10 @@ output:
   culture:
     - en-US
 
+include:
+  module:
+    - PSRule.Rules.MSFT.OSS
+
 format:
   powershell_data:
     type: []

--- a/src/PSRule.CommandLine/StringExtensions.cs
+++ b/src/PSRule.CommandLine/StringExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.CommandLine;
+
+/// <summary>
+/// String extension methods.
+/// </summary>
+public static class StringExtensions
+{
+    private const char QUOTE = '"';
+    private const char APOSTROPHE = '\'';
+
+    /// <summary>
+    /// Remove paired single and double quotes from the start and end of a string.
+    /// </summary>
+    public static string? TrimQuotes(this string? value)
+    {
+        if (string.IsNullOrEmpty(value) || value.Length < 2)
+            return value;
+
+        if (value[0] == QUOTE && value[value.Length - 1] == QUOTE)
+            return value.Substring(1, value.Length - 2);
+
+        return value[0] == APOSTROPHE && value[value.Length - 1] == APOSTROPHE ? value.Substring(1, value.Length - 2) : value;
+    }
+}

--- a/src/PSRule.EditorServices/ClientBuilder.cs
+++ b/src/PSRule.EditorServices/ClientBuilder.cs
@@ -315,9 +315,14 @@ internal sealed class ClientBuilder
 
     private ClientContext GetClientContext(InvocationContext invocation)
     {
-        var option = invocation.ParseResult.GetValueForOption(_Global_Option);
+        var option = invocation.ParseResult.GetValueForOption(_Global_Option).TrimQuotes();
         var verbose = invocation.ParseResult.GetValueForOption(_Global_Verbose);
         var debug = invocation.ParseResult.GetValueForOption(_Global_Debug);
+
+        if (!string.IsNullOrEmpty(option))
+        {
+            option = Environment.GetRootedPath(option);
+        }
 
         option ??= Path.Combine(Environment.GetWorkingPath(), "ps-rule.yaml");
 

--- a/src/PSRule.Types/Environment.cs
+++ b/src/PSRule.Types/Environment.cs
@@ -106,7 +106,7 @@ public static class Environment
     /// <param name="normalize">When set to <c>true</c> the returned path uses forward slashes instead of backslashes.</param>
     /// <param name="basePath">The base path to use. When <c>null</c> of unspecified, the current working path will be used.</param>
     /// <returns>A absolute path.</returns>
-    internal static string GetRootedPath(string? path, bool normalize = false, string? basePath = null)
+    public static string GetRootedPath(string? path, bool normalize = false, string? basePath = null)
     {
         basePath ??= GetWorkingPath();
         if (string.IsNullOrEmpty(path))


### PR DESCRIPTION
## PR Summary

- VSCode extension set to use Microsoft verified name.
- Added support for overriding options path from the default in VSCode.
- Migrated VSCode extension into PSRule repository.

Fixes #2636
Fixes #2635 
Fixes #2615

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v3.md) has been updated with change under unreleased section
