### PR TITLE
Pre-release v3.0.0-B0351

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -27,6 +27,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v3.0.0-B0351 (pre-release)
+
 What's changed since pre-release v3.0.0-B0342:
 
 - General improvements:
@@ -35,6 +37,8 @@ What's changed since pre-release v3.0.0-B0342:
     - The lock file now includes an integrity hash to ensures the restored module matches originally added module.
 
 ## v3.0.0-B0342 (pre-release)
+
+<!-- vscode:version 2024.12.2 -->
 
 What's changed since pre-release v3.0.0-B0340:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,12 +82,8 @@ nav:
     #   - Configuring rule defaults: setup/configuring-rules.md
     #   - Configuring expansion: setup/configuring-expansion.md
   - Updates:
-      # - December 2024: updates/v3.0.md
-      - Change log:
-          - v3: 'CHANGELOG-v3.md'
-          - v2: https://microsoft.github.io/PSRule/stable/CHANGELOG-v2/
-          - v1: https://microsoft.github.io/PSRule/stable/CHANGELOG-v1/
-          - v0: https://microsoft.github.io/PSRule/stable/CHANGELOG-v0/
+      # - January 2025: updates/v3.0.md
+      - Change log: 'CHANGELOG-v3.md'
       - Upgrade notes: upgrade-notes.md
       - Deprecations: deprecations.md
       - Changes and versioning: versioning.md
@@ -167,6 +163,7 @@ plugins:
         'authoring/writing-rules.md': 'authoring/testing-infrastructure.md'
         'install-instructions.md': 'setup/index.md'
         'install.md': 'setup/index.md'
+        'changelog.md': 'CHANGELOG-v3.md'
 
 hooks:
   - docs/hooks/old_hooks.py


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v3.0.0-B0342:

- General improvements:
  - Added an integrity hash to lock file by @BernieWhite.
    [#2664](https://github.com/microsoft/PSRule/issues/2664)
    - The lock file now includes an integrity hash to ensures the restored module matches originally added module.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

