### PR TITLE
Fixed JSON output format returns exception when no results

### DIFF
--- a/docs/CHANGELOG-v3.md
+++ b/docs/CHANGELOG-v3.md
@@ -42,6 +42,8 @@ What's changed since pre-release v3.0.0-B0351:
     [#1842](https://github.com/microsoft/PSRule/issues/1842)
   - Fixed duplicate reasons are reported for the same rule by @BernieWhite.
     [#2553](https://github.com/microsoft/PSRule/issues/2553)
+  - Fixed JSON output format returns exception when no results are produced by @BernieWhite.
+    [#1832](https://github.com/microsoft/PSRule/issues/1832)
 
 ## v3.0.0-B0351 (pre-release)
 

--- a/src/PSRule/Pipeline/Output/JsonOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/JsonOutputWriter.cs
@@ -8,8 +8,12 @@ using PSRule.Definitions.Baselines;
 
 namespace PSRule.Pipeline.Output;
 
+#nullable enable
+
 internal sealed class JsonOutputWriter : SerializationOutputWriter<object>
 {
+    private const string EMPTY_ARRAY = "[]";
+
     internal JsonOutputWriter(PipelineWriter inner, PSRuleOption option, ShouldProcess shouldProcess)
         : base(inner, option, shouldProcess) { }
 
@@ -20,6 +24,9 @@ internal sealed class JsonOutputWriter : SerializationOutputWriter<object>
 
     internal static string ToJson(object[] o, int? jsonIndent)
     {
+        if (o == null || o.Length == 0)
+            return EMPTY_ARRAY;
+
         using var stringWriter = new StringWriter();
         using var jsonTextWriter = new JsonCommentWriter(stringWriter);
 
@@ -56,3 +63,5 @@ internal sealed class JsonOutputWriter : SerializationOutputWriter<object>
         return stringWriter.ToString();
     }
 }
+
+#nullable restore

--- a/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
+++ b/src/PSRule/Pipeline/Output/YamlOutputWriter.cs
@@ -11,6 +11,8 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace PSRule.Pipeline.Output;
 
+#nullable enable
+
 internal sealed class YamlOutputWriter : SerializationOutputWriter<object>
 {
     internal YamlOutputWriter(PipelineWriter inner, PSRuleOption option, ShouldProcess shouldProcess)
@@ -18,6 +20,9 @@ internal sealed class YamlOutputWriter : SerializationOutputWriter<object>
 
     protected override string Serialize(object[] o)
     {
+        if (o == null || o.Length == 0)
+            return string.Empty;
+
         return o[0] is IEnumerable<Baseline> baselines ? ToBaselineYaml(baselines) : ToYaml(o);
     }
 
@@ -57,3 +62,5 @@ internal sealed class YamlOutputWriter : SerializationOutputWriter<object>
         return output.ToString();
     }
 }
+
+#nullable restore

--- a/tests/PSRule.Tests/Pipeline/Output/JsonOutputWriterTests.cs
+++ b/tests/PSRule.Tests/Pipeline/Output/JsonOutputWriterTests.cs
@@ -12,17 +12,17 @@ namespace PSRule.Pipeline.Output;
 public sealed class JsonOutputWriterTests : OutputWriterBaseTests
 {
     [Fact]
-    public void Json()
+    public void Output_WithIndent_ShouldReturnIndentedResults()
     {
         var option = GetOption();
         option.Output.JsonIndent = 2;
-        option.Repository.Url = "https://github.com/microsoft/PSRule.UnitTest";
         var output = new TestWriter(option);
         var result = new InvokeResult(GetRun());
         result.Add(GetPass());
         result.Add(GetFail());
         result.Add(GetFail("rid-003", SeverityLevel.Warning));
         result.Add(GetFail("rid-004", SeverityLevel.Information));
+
         var writer = new JsonOutputWriter(output, option, null);
         writer.Begin();
         writer.WriteObject(result, false);
@@ -131,5 +131,21 @@ public sealed class JsonOutputWriterTests : OutputWriterBaseTests
     ""time"": 1000
   }
 ]", output.Output.OfType<string>().FirstOrDefault());
+    }
+
+    [Fact]
+    public void Output_WithNoRecords_ShouldReturnEmptyArray()
+    {
+        var option = GetOption();
+        option.Output.JsonIndent = 2;
+        var output = new TestWriter(option);
+        var result = new InvokeResult(GetRun());
+        var writer = new JsonOutputWriter(output, option, null);
+
+        writer.Begin();
+        writer.WriteObject(result, false);
+        writer.End(new DefaultPipelineResult(null, Options.BreakLevel.None));
+
+        Assert.Equal("[]", output.Output.OfType<string>().FirstOrDefault());
     }
 }

--- a/tests/PSRule.Tests/Pipeline/Output/YamlOutputWriterTests.cs
+++ b/tests/PSRule.Tests/Pipeline/Output/YamlOutputWriterTests.cs
@@ -11,12 +11,10 @@ namespace PSRule.Pipeline.Output;
 /// </summary>
 public sealed class YamlOutputWriterTests : OutputWriterBaseTests
 {
-
     [Fact]
-    public void Yaml()
+    public void Output_WithIndent_ShouldReturnResults()
     {
         var option = GetOption();
-        option.Repository.Url = "https://github.com/microsoft/PSRule.UnitTest";
         var output = new TestWriter(option);
         var result = new InvokeResult(GetRun());
         result.Add(GetPass());
@@ -109,4 +107,18 @@ public sealed class YamlOutputWriterTests : OutputWriterBaseTests
 ", output.Output.OfType<string>().FirstOrDefault());
     }
 
+    [Fact]
+    public void Output_WithNoRecords_ShouldReturnSuccessfully()
+    {
+        var option = GetOption();
+        var output = new TestWriter(option);
+        var result = new InvokeResult(GetRun());
+        var writer = new YamlOutputWriter(output, option, null);
+
+        writer.Begin();
+        writer.WriteObject(result, false);
+        writer.End(new DefaultPipelineResult(null, Options.BreakLevel.None));
+
+        Assert.Empty(output.Output.OfType<string>().FirstOrDefault());
+    }
 }


### PR DESCRIPTION
## PR Summary

 - Fixed JSON output format returns exception when no results are produced.

Fixes #1832

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v3.md) has been updated with change under unreleased section
