### PR TITLE
Added support for target scanning in VSCode #2641

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,6 +26,11 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 What's changed since pre-release v3.0.0-B0453:
 
+- New features:
+  - **Experimental**: Added support for target scanning in Visual Studio Code by @BernieWhite.
+    [#2641](https://github.com/microsoft/PSRule/issues/2641)
+    - To scan a single file, right-click on the file in explorer or an open editor tab and select `Run scan on path`.
+    - To scan a folder, right-click on the folder in explorer and select `Run scan on path`.
 - Engineering:
   - Added GitHub Actions support to CLI by @BernieWhite.
     [#2824](https://github.com/microsoft/PSRule/issues/2824)

--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
         "category": "PSRule"
       },
       {
+        "command": "PSRule.runAnalysisForPath",
+        "title": "Run scan on path",
+        "category": "PSRule",
+        "enablement": "config.PSRule.experimental.enabled"
+      },
+      {
         "command": "PSRule.showTasks",
         "title": "Show tasks",
         "enablement": "false",
@@ -113,6 +119,22 @@
         "category": "PSRule"
       }
     ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "PSRule.runAnalysisForPath",
+          "group": "2_psrule_run",
+          "when": "config.PSRule.experimental.enabled"
+        }
+      ],
+      "editor/title/context": [
+        {
+          "command": "PSRule.runAnalysisForPath",
+          "group": "2_psrule_run",
+          "when": "config.PSRule.experimental.enabled"
+        }
+      ]
+    },
     "configuration": [
       {
         "title": "PSRule",
@@ -262,10 +284,21 @@
           "PSRule.trace.task": {
             "type": "string",
             "default": "Off",
-            "markdownDescription": "Determines if verbose logging is enabled for task output.",
+            "markdownDescription": "Determines if diagnostic logging is enabled for task output.",
             "enum": [
               "Off",
               "Verbose"
+            ],
+            "scope": "application"
+          },
+          "PSRule.trace.server": {
+            "type": "string",
+            "default": "Off",
+            "markdownDescription": "Determines if diagnostic logging is enabled for language server.",
+            "enum": [
+              "Off",
+              "Verbose",
+              "Debug"
             ],
             "scope": "application"
           }

--- a/src/PSRule.CommandLine/Models/RunCommandOutput.cs
+++ b/src/PSRule.CommandLine/Models/RunCommandOutput.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+namespace PSRule.CommandLine.Models;
+
+/// <summary>
+/// Output from the <c>run</c> command.
+/// </summary>
+public sealed class RunCommandOutput(int exitCode)
+{
+    /// <summary>
+    /// The exit code from the command.
+    /// </summary>
+    public int ExitCode { get; } = exitCode;
+}

--- a/src/PSRule.CommandLine/Models/RunOptions.cs
+++ b/src/PSRule.CommandLine/Models/RunOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using PSRule.Configuration;
+using PSRule.Options;
 using PSRule.Rules;
 
 namespace PSRule.CommandLine.Models;
@@ -11,6 +12,11 @@ namespace PSRule.CommandLine.Models;
 /// </summary>
 public sealed class RunOptions
 {
+    /// <summary>
+    /// An optional workspace path to use with this command.
+    /// </summary>
+    public string? WorkspacePath { get; set; }
+
     /// <summary>
     /// The path to search for rules.
     /// </summary>
@@ -60,4 +66,9 @@ public sealed class RunOptions
     /// The path to write the job summary file.
     /// </summary>
     public string? JobSummaryPath { get; set; }
+
+    /// <summary>
+    /// Determine the rule severity level at which to break the pipeline.
+    /// </summary>
+    public BreakLevel? BreakLevel { get; set; }
 }

--- a/src/PSRule.CommandLine/Models/SessionContext.cs
+++ b/src/PSRule.CommandLine/Models/SessionContext.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Management.Automation;
+using PSRule.Pipeline;
+
+namespace PSRule.CommandLine.Models;
+
+/// <summary>
+/// A context for a single invocation of a command.
+/// </summary>
+internal sealed class SessionContext(IHostContext parent) : IHostContext
+{
+    private readonly IHostContext _Parent = parent;
+
+    public bool InSession => _Parent.InSession;
+
+    public bool HadErrors => _Parent.HadErrors;
+
+    public string? CachePath => _Parent.CachePath;
+
+    public string? WorkingPath { get; set; }
+
+    public Action<object>? GetResultOutput { get; set; }
+
+    public void Debug(string text)
+    {
+        _Parent.Debug(text);
+    }
+
+    public void Error(ErrorRecord errorRecord)
+    {
+        _Parent.Error(errorRecord);
+    }
+
+    public ActionPreference GetPreferenceVariable(string variableName)
+    {
+        return _Parent.GetPreferenceVariable(variableName);
+    }
+
+    public T? GetVariable<T>(string variableName)
+    {
+        return _Parent.GetVariable<T>(variableName);
+    }
+
+    public string GetWorkingPath()
+    {
+        return WorkingPath ?? _Parent.GetWorkingPath();
+    }
+
+    public void Information(InformationRecord informationRecord)
+    {
+        _Parent.Information(informationRecord);
+    }
+
+    public void Object(object sendToPipeline, bool enumerateCollection)
+    {
+        GetResultOutput?.Invoke(sendToPipeline);
+        _Parent.Object(sendToPipeline, enumerateCollection);
+    }
+
+    public void SetVariable<T>(string variableName, T value)
+    {
+        _Parent.SetVariable(variableName, value);
+    }
+
+    public bool ShouldProcess(string target, string action)
+    {
+        return _Parent.ShouldProcess(target, action);
+    }
+
+    public void Verbose(string text)
+    {
+        _Parent.Verbose(text);
+    }
+
+    public void Warning(string text)
+    {
+        _Parent.Warning(text);
+    }
+}

--- a/src/PSRule.EditorServices/ClientBuilder.cs
+++ b/src/PSRule.EditorServices/ClientBuilder.cs
@@ -199,7 +199,8 @@ internal sealed class ClientBuilder
                 invocation.Console.WriteLine($"VERBOSE: Using cache path: {client.CachePath}");
             }
 
-            invocation.ExitCode = await RunCommand.RunAsync(option, client);
+            var result = await RunCommand.RunAsync(option, client);
+            invocation.ExitCode = result.ExitCode;
         });
         Command.AddCommand(cmd);
     }

--- a/src/PSRule.EditorServices/Handlers/RunAnalysisCommandHandler.cs
+++ b/src/PSRule.EditorServices/Handlers/RunAnalysisCommandHandler.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using OmniSharp.Extensions.JsonRpc;
+using OmniSharp.Extensions.LanguageServer.Protocol.Window;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+using PSRule.CommandLine;
+using PSRule.CommandLine.Commands;
+using PSRule.CommandLine.Models;
+using PSRule.Runtime;
+
+namespace PSRule.EditorServices.Handlers;
+
+/// <summary>
+/// Handler for running analysis.
+/// </summary>
+public sealed class RunAnalysisCommandHandler(ClientContext context, ISerializer serializer, ILogger logger)
+    : ExecuteTypedResponseCommandHandlerBase<RunAnalysisCommandHandlerInput, RunAnalysisCommandHandlerOutput>(COMMAND_NAME, serializer)
+{
+    private const string COMMAND_NAME = "runAnalysis";
+
+    private readonly ClientContext _Context = context;
+    private readonly ILogger _Logger = logger;
+
+    /// <summary>
+    /// Handle the <c>runAnalysis</c> command.
+    /// </summary>
+    public override async Task<RunAnalysisCommandHandlerOutput> Handle(RunAnalysisCommandHandlerInput input, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(input, nameof(input));
+        ArgumentException.ThrowIfNullOrWhiteSpace(input.WorkspacePath, nameof(input.WorkspacePath));
+
+        var options = new RunOptions
+        {
+            InputPath = input.InputPath,
+            WorkspacePath = input.WorkspacePath,
+            BreakLevel = Options.BreakLevel.Never,
+        };
+
+        _Logger.LogInformation(new EventId(0), "Running tests in: {0}", input.WorkspacePath);
+        _Logger.LogInformation(new EventId(0), "Input path: {0}", string.Join(", ", input.InputPath ?? []));
+
+        try
+        {
+            var output = await RunCommand.RunAsync(options, _Context, cancellationToken);
+            return new RunAnalysisCommandHandlerOutput(output.ExitCode);
+        }
+        catch (Exception ex)
+        {
+            _Logger.LogError(new EventId(0), ex, ex.Message);
+        }
+
+        return new RunAnalysisCommandHandlerOutput(1);
+    }
+}

--- a/src/PSRule.EditorServices/Handlers/RunAnalysisCommandHandlerInput.cs
+++ b/src/PSRule.EditorServices/Handlers/RunAnalysisCommandHandlerInput.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.EditorServices.Handlers;
+
+/// <summary>
+/// Input to the <c>runAnalysis</c> command handler.
+/// </summary>
+public sealed class RunAnalysisCommandHandlerInput
+{
+    /// <summary>
+    /// The workspace path that the command is running in.
+    /// </summary>
+    public string? WorkspacePath { get; set; }
+
+    /// <summary>
+    /// The path for the input files to analyze.
+    /// </summary>
+    public string[]? InputPath { get; set; }
+}

--- a/src/PSRule.EditorServices/Handlers/RunAnalysisCommandHandlerOutput.cs
+++ b/src/PSRule.EditorServices/Handlers/RunAnalysisCommandHandlerOutput.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace PSRule.EditorServices.Handlers;
+
+/// <summary>
+/// Output from the <c>runAnalysis</c> command handler.
+/// </summary>
+public sealed class RunAnalysisCommandHandlerOutput(int exitCode)
+{
+    /// <summary>
+    /// The exit code from the command.
+    /// </summary>
+    public int ExitCode { get; } = exitCode;
+}

--- a/src/PSRule.EditorServices/Handlers/UpgradeDependencyCommandHandler.cs
+++ b/src/PSRule.EditorServices/Handlers/UpgradeDependencyCommandHandler.cs
@@ -25,7 +25,7 @@ public sealed class UpgradeDependencyCommandHandler(ClientContext context, ISeri
     private readonly ILogger _Logger = logger;
 
     /// <summary>
-    /// Handle the upgradeDependency command.
+    /// Handle the <c>upgradeDependency</c> command.
     /// </summary>
     public override async Task<UpgradeDependencyCommandHandlerOutput> Handle(UpgradeDependencyCommandHandlerInput input, CancellationToken cancellationToken)
     {

--- a/src/PSRule.EditorServices/Hosting/LspServer.cs
+++ b/src/PSRule.EditorServices/Hosting/LspServer.cs
@@ -23,9 +23,9 @@ internal sealed class LspServer : IDisposable
     {
         _Server = LanguageServer.PreInit(options =>
         {
+            WithServices(options);
             WithHandlers(options);
             WithEvents(options);
-            WithServices(options);
 
             configure(options);
         });
@@ -72,6 +72,7 @@ internal sealed class LspServer : IDisposable
     private static void WithHandlers(LanguageServerOptions options)
     {
         options.WithHandler<UpgradeDependencyCommandHandler>();
+        options.WithHandler<RunAnalysisCommandHandler>();
     }
 
     /// <summary>

--- a/src/PSRule.Tool/ClientBuilder.cs
+++ b/src/PSRule.Tool/ClientBuilder.cs
@@ -199,7 +199,8 @@ internal sealed class ClientBuilder
             };
 
             var client = GetClientContext(invocation);
-            invocation.ExitCode = await RunCommand.RunAsync(option, client);
+            var output = await RunCommand.RunAsync(option, client);
+            invocation.ExitCode = output.ExitCode;
         });
         Command.AddCommand(cmd);
     }

--- a/src/vscode-ps-rule/README.md
+++ b/src/vscode-ps-rule/README.md
@@ -69,9 +69,9 @@ Name                                            | Description
 ----                                            | -----------
 `PSRule.codeLens.dependencyManagement`          | Enables Code Lens that displays links to manage dependencies.
 `PSRule.codeLens.ruleDocumentationLinks`        | Enables Code Lens that displays links to rule documentation.
-`PSRule.documentation.path`                     | The path to look for rule documentation. When not set, the path containing rules will be used.
-`PSRule.documentation.localePath`               | The locale path to use for locating rule documentation. The VS Code locale will be used by default.
 `PSRule.documentation.customSnippetPath`        | The path to a file containing a rule documentation snippet. When not set, built-in PSRule snippets will be used.
+`PSRule.documentation.localePath`               | The locale path to use for locating rule documentation. The VS Code locale will be used by default.
+`PSRule.documentation.path`                     | The path to look for rule documentation. When not set, the path containing rules will be used.
 `PSRule.documentation.snippet`                  | The name of a snippet to use when creating new rule documentation. By default, the built-in `Rule Doc` snippet will be used.
 `PSRule.execution.ruleExcluded`                 | Determines how to handle excluded rules. When set to `None`, PSRule will use the default (`Ignore`), unless set by PSRule options.
 `PSRule.execution.ruleSuppressed`               | Determines how to handle suppressed rules. When set to `None`, PSRule will use the default (`Warn`), unless set by PSRule options.
@@ -84,6 +84,7 @@ Name                                            | Description
 `PSRule.options.path`                           | The path specifying a PSRule option file. When not set, the default `ps-rule.yaml` will be used from the current workspace.
 `PSRule.output.as`                              | Configures the output of analysis tasks, either summary or detailed.
 `PSRule.rule.baseline`                          | The name of the default baseline to use for executing rules. This setting can be overridden on individual PSRule tasks.
-`PSRule.trace.task`                             | Determines the level of trace information to output for PSRule tasks.
+`PSRule.trace.task`                             | Determines if diagnostic logging is enabled for task output.
+`PSRule.trace.server`                            | Determines if diagnostic logging is enabled for language server.
 
 [ps-rule.yaml]: https://aka.ms/ps-rule/options

--- a/src/vscode-ps-rule/client.ts
+++ b/src/vscode-ps-rule/client.ts
@@ -8,6 +8,7 @@ import * as lsp from 'vscode-languageclient/node';
 import { logger } from './logger';
 import { ext } from './extension';
 import { getActiveOrFirstWorkspace } from './utils';
+import { configuration, TraceLevelPreference } from './configuration';
 
 export const StartProgressNotificationType = new lsp.ProgressType<string>();
 
@@ -103,10 +104,19 @@ export class PSRuleClient implements vscode.Disposable {
             return undefined;
         }
 
+        // Start the language server with additional arguments based on the configuration.
+        let additionalArgs: string[] = [];
+        if (configuration.get().traceServer === TraceLevelPreference.Verbose) {
+            additionalArgs = ['--verbose'];
+        }
+        else if (configuration.get().traceServer === TraceLevelPreference.Debug) {
+            additionalArgs = ['--verbose', '--debug'];
+        }
+
         const cwd = getActiveOrFirstWorkspace()?.uri.fsPath;
         const serverExecutable: lsp.Executable = {
             command: binPath,
-            args: [languageServerPath, 'listen'],
+            args: [languageServerPath, 'listen', ...additionalArgs],
             options: { cwd },
             transport: lsp.TransportKind.pipe,
         };

--- a/src/vscode-ps-rule/commands/runAnalysisForPath.ts
+++ b/src/vscode-ps-rule/commands/runAnalysisForPath.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { ProgressLocation, window } from 'vscode';
+import { ExecuteCommandRequest, integer } from 'vscode-languageclient';
+import { getActiveOrFirstWorkspace } from '../utils';
+import { ext } from '../extension';
+import { logger } from '../logger';
+import { scanQuickPicker } from '../features/scanQuickpick/scanQuickpick';
+
+interface RunCommandOutput {
+    exitCode: integer;
+}
+
+/**
+ * Runs the PSRule run analysis for a file or folder.
+ * @param path The path to the file or folder to run analysis on.
+ * @returns A promise for the task.
+ */
+export async function runAnalysisForPath(path: string | undefined): Promise<void> {
+    const workspace = getActiveOrFirstWorkspace();
+    if (!workspace) return;
+
+    if (!path) {
+        await scanQuickPicker();
+    }
+
+
+    await window.withProgress({
+        location: ProgressLocation.Notification,
+        title: 'PSRule',
+        cancellable: false,
+    }, async (progress) => {
+
+        progress.report({ message: 'Running scan on path...' });
+
+        logger.channel.show(true);
+
+        const result: RunCommandOutput = await ext.client.sendRequest(ExecuteCommandRequest.type, {
+            command: 'runAnalysis',
+            arguments: [
+                {
+                    inputPath: [path],
+                    workspacePath: workspace.uri.fsPath,
+                }
+            ]
+        });
+
+        progress.report({ message: 'Completed test', increment: 100 });
+    });
+}

--- a/src/vscode-ps-rule/configuration.ts
+++ b/src/vscode-ps-rule/configuration.ts
@@ -46,6 +46,11 @@ export enum TraceLevelPreference {
      * Output verbose information.
      */
     Verbose = 'Verbose',
+
+    /**
+     * Output debug information.
+     */
+    Debug = 'Debug',
 }
 
 /**
@@ -129,9 +134,14 @@ export interface ISetting {
     // languageServerPath: string | undefined;
 
     /**
-     * Determines if verbose logging is enabled for task output.
+     * Determines if diagnostic logging is enabled for task output.
      */
     traceTask: TraceLevelPreference;
+
+    /**
+     * Determines if diagnostic logging is enabled for language server.
+     */
+    traceServer: TraceLevelPreference;
 }
 
 /**
@@ -157,6 +167,7 @@ const globalDefaults: ISetting = {
     ruleBaseline: undefined,
     // languageServerPath: undefined,
     traceTask: TraceLevelPreference.Off,
+    traceServer: TraceLevelPreference.Off,
 };
 
 /**
@@ -272,6 +283,11 @@ export class ConfigurationManager {
         this.current.traceTask = config.get<TraceLevelPreference>(
             'trace.task',
             this.default.traceTask
+        );
+
+        this.current.traceServer = config.get<TraceLevelPreference>(
+            'trace.server',
+            this.default.traceServer
         );
 
         // Clear dirty settings flag

--- a/src/vscode-ps-rule/extension.ts
+++ b/src/vscode-ps-rule/extension.ts
@@ -24,6 +24,7 @@ import { client } from './client';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { DependencyLensProvider } from './dependencyLens';
 import { upgradeDependency } from './commands/upgradeDependency';
+import { runAnalysisForPath } from './commands/runAnalysisForPath';
 
 export let taskManager: PSRuleTaskProvider | undefined;
 export let docLensProvider: DocumentationLensProvider | undefined;
@@ -140,6 +141,11 @@ export class ExtensionManager implements vscode.Disposable {
             this._context.subscriptions.push(
                 vscode.commands.registerCommand('PSRule.runAnalysisTask', () => {
                     runAnalysisTask();
+                })
+            );
+            this._context.subscriptions.push(
+                vscode.commands.registerCommand('PSRule.runAnalysisForPath', (path: vscode.Uri | undefined) => {
+                    runAnalysisForPath(path?.fsPath);
                 })
             );
             this._context.subscriptions.push(

--- a/src/vscode-ps-rule/features/scanQuickpick/scanQuickpick.ts
+++ b/src/vscode-ps-rule/features/scanQuickpick/scanQuickpick.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as path from 'path';
+import * as cp from 'child_process';
+import { Uri, window, Disposable } from 'vscode';
+import { QuickPickItem } from 'vscode';
+import { workspace } from 'vscode';
+import * as fs from 'fs';
+import * as fse from 'fs-extra';
+import { logger } from '../../logger';
+
+
+/**
+ * A file opener using window.createQuickPick().
+ * 
+ * It shows how the list of items can be dynamically updated based on
+ * the user's input in the filter field.
+ */
+export async function scanQuickPicker(): Promise<Uri | undefined> {
+    return await pickFile();
+}
+
+class FileItem implements QuickPickItem {
+
+    label: string;
+    description: string;
+
+    constructor(public base: Uri, public uri: Uri) {
+        this.label = path.basename(uri.fsPath);
+        this.description = path.dirname(path.relative(base.fsPath, uri.fsPath));
+    }
+}
+
+class MessageItem implements QuickPickItem {
+
+    label: string;
+    description = '';
+    detail: string;
+
+    constructor(public base: Uri, public message: string) {
+        this.label = message.replace(/\r?\n/g, ' ');
+        this.detail = base.fsPath;
+    }
+}
+
+async function pickFile(): Promise<Uri | undefined> {
+    if (workspace.workspaceFolders == undefined || workspace.workspaceFolders.length == 0) {
+        return undefined;
+    }
+
+    const disposables: Disposable[] = [];
+    const workspacePaths = workspace.workspaceFolders.map(f => f.uri.fsPath);
+
+    try {
+        return await new Promise<Uri | undefined>((resolve) => {
+            const input = window.createQuickPick<FileItem | MessageItem>();
+            input.placeholder = 'Type to search for files';
+            disposables.push(
+                input.onDidChangeValue(value => {
+
+                    const dirName = value.split('/').slice(0, -1).join('/');
+                    const fileName = value.split('/').pop() || '';
+
+                    const re = new RegExp(fileName, 'i');
+
+                    logger.verbose(`Searching for ${fileName} in ${workspacePaths}`);
+
+                    let files = [] as FileItem[];
+
+                    input.busy = true;
+
+                    workspacePaths.map(cwd => {
+
+                        const target = path.join(cwd, `/${dirName}/`)
+
+                        logger.verbose(`Searching in ${target}`);
+                        logger.verbose(`Searching using regex ${re}`);
+
+                        fse.readdirSync(target).forEach(file => {
+                            logger.verbose(`Found ${file}`);
+                            if (file.match(re)) {
+                                files.push(new FileItem(Uri.file(cwd), Uri.file(path.join(target, file))));
+                            }
+                        });
+
+
+
+                    });
+                    input.items = files
+
+                    input.busy = false;
+                }),
+                input.onDidChangeSelection(items => {
+                    const item = items[0];
+                    if (item instanceof FileItem) {
+                        resolve(item.uri);
+                        input.hide();
+                    }
+                }),
+            );
+            input.show();
+        });
+    } finally {
+        disposables.forEach(d => d.dispose());
+    }
+}

--- a/src/vscode-ps-rule/test/suite/configuration.test.ts
+++ b/src/vscode-ps-rule/test/suite/configuration.test.ts
@@ -25,5 +25,6 @@ suite('ConfigurationManager tests', () => {
         assert.equal(config.get().notificationsShowPowerShellExtension, true);
         assert.equal(config.get().ruleBaseline, undefined);
         assert.equal(config.get().traceTask, false);
+        assert.equal(config.get().traceServer, false);
     });
 });

--- a/tests/PSRule.CommandLine.Tests/Commands/RunCommandTests.cs
+++ b/tests/PSRule.CommandLine.Tests/Commands/RunCommandTests.cs
@@ -19,8 +19,8 @@ public sealed class RunCommandTests : BaseTests
             workingPath: GetSourcePath("../../../../../")
         );
 
-        var exitCode = await RunCommand.RunAsync(OperationOptions(), context);
-        Assert.Equal(0, exitCode);
+        var output = await RunCommand.RunAsync(OperationOptions(), context);
+        Assert.Equal(0, output.ExitCode);
     }
 
     #region Helper methods


### PR DESCRIPTION
## PR Summary

- **Experimental**: Added support for target scanning in Visual Studio Code by @BernieWhite.
  - To scan a single file, right-click on the file in explorer or an open editor tab and select `Run scan on path`.
  - To scan a folder, right-click on the folder in explorer and select `Run scan on path`.

Fixes #2641

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/microsoft/PSRule/blob/main/docs/changelog.md) has been updated with change under unreleased section
