### PR TITLE
Fix #2885

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,6 +39,9 @@ What's changed since pre-release v3.0.0-B0453:
     [#2824](https://github.com/microsoft/PSRule/issues/2824)
   - Bump vscode engine to v1.99.1.
     [#2858](https://github.com/microsoft/PSRule/pull/2858)
+- Bug fixes:
+  - Fixed path handling issue string is missing the terminator with single quote in source paths by @juan-carlos-diaz.
+    [#2885](https://github.com/microsoft/PSRule/issues/2885)
 
 ## v3.0.0-B0453 (pre-release)
 

--- a/src/PSRule/Host/HostHelper.cs
+++ b/src/PSRule/Host/HostHelper.cs
@@ -193,7 +193,7 @@ internal static class HostHelper
                         }
 
                         // Invoke script
-                        ps.AddScript(string.Concat("& '", file.Path, "'"), true);
+                        ps.AddScript(string.Concat("& '", file.Path.EscapeSingleQuote(), "'"), true);
                         var invokeResults = ps.Invoke();
 
                         // Discovery has errors so skip this file
@@ -222,6 +222,9 @@ internal static class HostHelper
         }
         return [.. results];
     }
+
+    private static string EscapeSingleQuote(this string input)
+        => input.Replace(@"'", @"''");
 
     /// <summary>
     /// Get language blocks from YAML source files.

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -185,12 +185,10 @@
   </ItemGroup>
   
   <Target Name="CopyFile_ForTest_Issue2885" AfterTargets="Build">
-    <Message Importance="high" Text="Copy File = $(ProjectDir)FromFileBaseline.Rule.ps1 to = $(TargetDir)John's Documents" />
     <Copy
         SourceFiles="$(ProjectDir)FromFileBaseline.Rule.ps1"
         DestinationFolder="$(TargetDir)John's Documents"
     />
-    <Message Importance="high" Text="Test file for issue #2885 copied!!!" />
   </Target>
   
 </Project>

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -183,12 +183,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
+  
   <Target Name="CopyFile_ForTest_Issue2885" AfterTargets="Build">
+    <Message Importance="high" Text="Copy File = $(ProjectDir)FromFileBaseline.Rule.ps1 to = $(TargetDir)John's Documents" />
     <Copy
         SourceFiles="$(ProjectDir)FromFileBaseline.Rule.ps1"
         DestinationFolder="$(TargetDir)John's Documents"
     />
+    <Message Importance="high" Text="Test file for issue #2885 copied!!!" />
   </Target>
   
 </Project>

--- a/tests/PSRule.Tests/PSRule.Tests.csproj
+++ b/tests/PSRule.Tests/PSRule.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -184,4 +184,11 @@
     </None>
   </ItemGroup>
 
+  <Target Name="CopyFile_ForTest_Issue2885" AfterTargets="Build">
+    <Copy
+        SourceFiles="$(ProjectDir)FromFileBaseline.Rule.ps1"
+        DestinationFolder="$(TargetDir)John's Documents"
+    />
+  </Target>
+  
 </Project>

--- a/tests/PSRule.Tests/Pipeline/PipelineTests.cs
+++ b/tests/PSRule.Tests/Pipeline/PipelineTests.cs
@@ -315,6 +315,22 @@ public sealed partial class PipelineTests : ContextBaseTests
         Assert.NotNull(pipeline);
     }
 
+    /// <summary>
+    /// Test for issue #2885, the error happen when any script source directory contains a quote in the name
+    /// </summary>
+    [Fact]
+    public void PipelineWithInQuoteSourceDirectory()
+    {
+        var option = GetOption();
+        var builder = PipelineBuilder.Invoke(GetSource(
+        [
+            "John's Documents"
+        ]), option, null);
+        var pipeline = builder.Build();
+
+        Assert.NotNull(pipeline);
+    }
+
     ///// <summary>
     ///// An Invoke pipeline reading from an input file with File format.
     ///// </summary>

--- a/tests/PSRule.Tests/Pipeline/PipelineTests.cs
+++ b/tests/PSRule.Tests/Pipeline/PipelineTests.cs
@@ -299,6 +299,22 @@ public sealed partial class PipelineTests : ContextBaseTests
         //Assert.True(items[2].HasSource());
     }
 
+    /// <summary>
+    /// Test for issue #2885, the error happen when any script source directory contains a quote in the name
+    /// </summary>
+    [Fact]
+    public void PipelineWithInQuoteSource()
+    {
+        var option = GetOption();
+        var builder = PipelineBuilder.Invoke(GetSource(
+        [
+            @"John's Documents\FromFileBaseline.Rule.ps1"
+        ]), option, null);
+        var pipeline = builder.Build();
+
+        Assert.NotNull(pipeline);
+    }
+
     ///// <summary>
     ///// An Invoke pipeline reading from an input file with File format.
     ///// </summary>

--- a/tests/PSRule.Tests/Pipeline/PipelineTests.cs
+++ b/tests/PSRule.Tests/Pipeline/PipelineTests.cs
@@ -308,7 +308,7 @@ public sealed partial class PipelineTests : ContextBaseTests
         var option = GetOption();
         var builder = PipelineBuilder.Invoke(GetSource(
         [
-            @"John's Documents\FromFileBaseline.Rule.ps1"
+            Path.Combine(@"John's Documents", "FromFileBaseline.Rule.ps1")
         ]), option, null);
         var pipeline = builder.Build();
 

--- a/tests/PSRule.Tests/SourcePipelineBuilderTests.cs
+++ b/tests/PSRule.Tests/SourcePipelineBuilderTests.cs
@@ -30,7 +30,7 @@ public sealed class SourcePipelineBuilderTests : BaseTests
         var sources = builder.Build();
 
         Assert.Single(sources);
-        Assert.Equal(25, sources[0].File.Length);
+        Assert.Equal(26, sources[0].File.Length);
     }
 
     [Fact]


### PR DESCRIPTION
This PR fix the issue #2885 

The issue was, when PS files are located in a folder with single quote in the name, the InvokePipelineBuilder generate an exception at build time