### PR TITLE
Add Dependabot configuration for .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
           - Microsoft.PowerShell.SDK
     ignore:
       - dependency-name: gitversion.tool
-
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: github-actions
     directory: '/'
@@ -30,7 +29,6 @@ updates:
       interval: daily
     labels:
       - dependencies
-
   # Maintain dependencies for Python
   - package-ecosystem: pip
     directory: '/'
@@ -38,7 +36,6 @@ updates:
       interval: daily
     labels:
       - dependencies
-
   # Maintain dependencies for npm.
   - package-ecosystem: npm
     directory: '/'
@@ -58,7 +55,6 @@ updates:
           - '@types/*'
         exclude-patterns:
           - '@types/vscode'
-
   # Maintain dependencies for Dev Containers
   - package-ecosystem: devcontainers
     directory: '/'
@@ -66,7 +62,6 @@ updates:
       interval: weekly
     labels:
       - dependencies
-
   # Maintain dependencies for Docker
   - package-ecosystem: docker
     directory: '/'
@@ -74,3 +69,13 @@ updates:
       interval: weekly
     labels:
       - dependencies
+  - package-ecosystem: dotnet-sdk
+    directory: /
+    schedule:
+      interval: weekly
+      day: wednesday
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor


### PR DESCRIPTION
This PR adds Dependabot configuration to automatically manage .NET SDK version updates in global.json.

This configuration will:
- Monitor the global.json file for .NET SDK version updates
- Create pull requests when new SDK versions are available
- Help keep the project secure with the latest SDK patches

For more information, see: https://devblogs.microsoft.com/dotnet/using-dependabot-to-manage-dotnet-sdk-updates/