### PR TITLE
Skip major versions of Microsoft.Extensions.DependencyInjection

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,13 +95,7 @@ updates:
     labels:
       - dependencies
 
-  # Maintain dependencies for Docker
-  - package-ecosystem: docker
-    directory: '/'
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
+  # Maintain dependencies for .NET SDK
   - package-ecosystem: dotnet-sdk
     directory: /
     schedule:


### PR DESCRIPTION
## PR Summary

Skip major versions of Microsoft.Extensions.DependencyInjection which are not compatible with .NET Standard 2.0 and PowerShell support.

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**