### PR TITLE
Pre-release v3.0.0-B0755

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,8 @@ See [upgrade notes][1] for helpful information when upgrading from previous vers
 
 ## Unreleased
 
+## v3.0.0-B0755 (pre-release)
+
 What's changed since pre-release v3.0.0-B0453:
 
 - New features:
@@ -51,12 +53,14 @@ What's changed since pre-release v3.0.0-B0453:
     [#2824](https://github.com/microsoft/PSRule/issues/2824)
   - Added Azure Pipelines support to CLI by @BernieWhite.
     [#2825](https://github.com/microsoft/PSRule/issues/2825)
-  - Bump vscode engine to v1.108.0.
-    [#3183](https://github.com/microsoft/PSRule/pull/3183)
+  - Bump vscode engine to v1.108.1.
+    [#3188](https://github.com/microsoft/PSRule/pull/3188)
   - Bump Newtonsoft.Json to 13.0.4.
     [#3161](https://github.com/microsoft/PSRule/pull/3161)
-  - Bump System.CommandLine to 2.0.1.
-    [#3166](https://github.com/microsoft/PSRule/pull/3166)
+  - Bump System.CommandLine to 2.0.5.
+    [#3267](https://github.com/microsoft/PSRule/pull/3267)
+  - Bump NuGet.Protocol to 7.0.1.
+    [#3162](https://github.com/microsoft/PSRule/pull/3162)
 - Bug fixes:
   - Fixed path handling issue string is missing the terminator with single quote in source paths by @juan-carlos-diaz.
     [#2885](https://github.com/microsoft/PSRule/issues/2885)

--- a/src/PSRule.EditorServices/packages.lock.json
+++ b/src/PSRule.EditorServices/packages.lock.json
@@ -979,8 +979,8 @@
       },
       "System.CommandLine": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "zqn6I1IULEJaLEFKejeSFlZrf8HzIUU4qEjuYtEVRx5AsxKMLqLP+t0dQ4fk51A5CzT9Uv8wBLdMHSIYIrCKBw=="
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
@@ -1787,7 +1787,7 @@
           "Microsoft.PSRule.SDK": "[0.0.1, )",
           "Microsoft.PowerShell.SDK": "[7.4.13, )",
           "NuGet.Protocol": "[7.0.1, )",
-          "System.CommandLine": "[2.0.2, )"
+          "System.CommandLine": "[2.0.5, )"
         }
       },
       "Microsoft.PSRule.Core": {

--- a/src/PSRule.Tool/packages.lock.json
+++ b/src/PSRule.Tool/packages.lock.json
@@ -872,8 +872,8 @@
       },
       "System.CommandLine": {
         "type": "Transitive",
-        "resolved": "2.0.2",
-        "contentHash": "zqn6I1IULEJaLEFKejeSFlZrf8HzIUU4qEjuYtEVRx5AsxKMLqLP+t0dQ4fk51A5CzT9Uv8wBLdMHSIYIrCKBw=="
+        "resolved": "2.0.5",
+        "contentHash": "2XtWAPk1G6arpe3OCFNrYYuf6iIboznxs2elJSGgd8e0euou7LfGYFon6hBEfDWNtOLr0M3+oUVgy1a5EGa41A=="
       },
       "System.ComponentModel.Annotations": {
         "type": "Transitive",
@@ -1665,7 +1665,7 @@
           "Microsoft.PSRule.SDK": "[0.0.1, )",
           "Microsoft.PowerShell.SDK": "[7.4.13, )",
           "NuGet.Protocol": "[7.0.1, )",
-          "System.CommandLine": "[2.0.2, )"
+          "System.CommandLine": "[2.0.5, )"
         }
       },
       "Microsoft.PSRule.Core": {


### PR DESCRIPTION
## PR Summary

What's changed since pre-release v3.0.0-B0453:

- New features:
  - **Experimental**: Added support for target scanning in Visual Studio Code by @BernieWhite.
    [#2641](https://github.com/microsoft/PSRule/issues/2641)
    - To scan a single file, right-click on the file in explorer or an open editor tab and select `Run scan on path`.
    - To scan a folder, right-click on the folder in explorer and select `Run scan on path`.
  - Added support and by default error if rules or input is not found during a run by @BernieWhite.
    [#1778](https://github.com/microsoft/PSRule/issues/1778)
    - Added options for `Execution.NoMatchingRules`, `Execution.NoValidInput`, and `Execution.NoValidSources`.
  - Added support for customizing CSV output columns by @BernieWhite.
    [#1165](https://github.com/microsoft/PSRule/issues/1165)
    - The `Output.CsvDetailedColumns` option can be used to customize the columns included in the CSV output format.
- General improvements:
  - Reload language server when options change by @BernieWhite.
    [#2842](https://github.com/microsoft/PSRule/issues/2842)
- Engineering:
  - **Important change**: Remove legacy log scopes by @BernieWhite.
    [#2891](https://github.com/microsoft/PSRule/issues/2891)
  - **Important change**: Remove pass fail streams by @BernieWhite.
    [#2892](https://github.com/microsoft/PSRule/issues/2892)
  - **Important change**: Cleanup PreferTargetInfo option by @BernieWhite.
    [#2994](https://github.com/microsoft/PSRule/issues/2994)
  - Added GitHub Actions support to CLI by @BernieWhite.
    [#2824](https://github.com/microsoft/PSRule/issues/2824)
  - Added Azure Pipelines support to CLI by @BernieWhite.
    [#2825](https://github.com/microsoft/PSRule/issues/2825)
  - Bump vscode engine to v1.108.1.
    [#3188](https://github.com/microsoft/PSRule/pull/3188)
  - Bump Newtonsoft.Json to 13.0.4.
    [#3161](https://github.com/microsoft/PSRule/pull/3161)
  - Bump System.CommandLine to 2.0.5.
    [#3267](https://github.com/microsoft/PSRule/pull/3267)
  - Bump NuGet.Protocol to 7.0.1.
    [#3162](https://github.com/microsoft/PSRule/pull/3162)
- Bug fixes:
  - Fixed path handling issue string is missing the terminator with single quote in source paths by @juan-carlos-diaz.
    [#2885](https://github.com/microsoft/PSRule/issues/2885)
  - Fixed module path not found with pre-release by @BernieWhite.
    [#2889](https://github.com/microsoft/PSRule/issues/2889)
  - Fixed empty SARIF run metadata by @BernieWhite.
    [#2901](https://github.com/microsoft/PSRule/issues/2901)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**

