### PR TITLE
Also fail on Pester block/container failures (not just failed tests)

### DIFF
--- a/pipeline.build.ps1
+++ b/pipeline.build.ps1
@@ -323,8 +323,8 @@ task TestModule Dependencies, {
     if ($Null -eq $results) {
         throw 'Failed to get Pester test results.';
     }
-    elseif ($results.FailedCount -gt 0) {
-        throw "$($results.FailedCount) tests failed.";
+    elseif (($results.FailedCount + $results.FailedBlocksCount + $results.FailedContainersCount) -gt 0) {
+        throw "Pester run failed: $($results.FailedCount) failed test(s), $($results.FailedBlocksCount) failed block(s), $($results.FailedContainersCount) failed container(s), of $($results.TotalCount) total tests";
     }
 }
 


### PR DESCRIPTION
> ⚠️ This PR was generated by an AI agent (GitHub Copilot CLI). Please review accordingly.

I've been seeing this commonly across Pester 5 build scripts and I'm fixing it where it looks like it could hide real failures.

In Pester 5 a run reports three independent failure counts:

- `FailedCount` — failed tests (`It`)
- `FailedBlocksCount` — failed `BeforeAll` / `AfterAll`
- `FailedContainersCount` — files that error during discovery / fail to load

Gating on only `FailedCount` means a `BeforeAll` that throws, or a test file that fails to load, leaves `FailedCount = 0` and the build passes green despite real failures. Pester itself derives the overall pass/fail from the sum of all three.

This includes all three counts in the gate, and surfaces each count (failed tests, blocks, containers) in the reported output instead of only the failed test count.
